### PR TITLE
Use matching E2E test framework branch if exists

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
         fetch-depth: 1
 
     - name: Checkout the E2E test framework (matching branch if exists)
+      continue-on-error: true
       uses: actions/checkout@v2
       with:
         repository: nlnetlabs/rpki-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     # Only if previous checkout attempt fails. We can't use failure() as
     # continue-on-error: true causes failure() to be false even on failure.
     - name: Checkout the E2E test framework (master)
-      if: not ${{ steps.verify_checkout.outputs.success }}
+      if: not steps.verify_checkout.outputs.success
       uses: actions/checkout@v2
       with:
         repository: nlnetlabs/rpki-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,11 @@ jobs:
         path: rpki-deploy
         fetch-depth: 1
 
+    # Force this step to run by checking for success, otherwise GH Actions refuses
+    # to run this or any subsequent steps when the specific E2E test branch checkout
+    # fails but the master E2E test branch checkout succeeds.
     - name: Checkout RTRLIB (v0.7.0 tag)
+      if: success()
       uses: actions/checkout@v2
       with:
         repository: rtrlib/rtrlib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
         fetch-depth: 1
 
     - name: Checkout the E2E test framework (matching branch if exists)
+      # Don't fail the job if this checkout fails
       continue-on-error: true
       uses: actions/checkout@v2
       with:
@@ -39,21 +40,24 @@ jobs:
         path: rpki-deploy
         fetch-depth: 1
         ref: ${{ steps.extract_branch.outputs.branch }}
-    
-    # Only if previous checkout attempt fails
+      # set an output we can conditionally depend on in the next step
+      run: |
+        if [ -d ${GITHUB_WORKSPACE}/rpki-deploy ]; then
+          echo "::set-output name=success::true"
+        fi
+      id: checkout_specific
+
+    # Only if previous checkout attempt fails. We can't use failure() as
+    # continue-on-error: true causes failure() to be false even on failure.
     - name: Checkout the E2E test framework (master)
-      if: failure()
+      if: not ${{ steps.checkout_specific.outputs.success }}
       uses: actions/checkout@v2
       with:
         repository: nlnetlabs/rpki-deploy
         path: rpki-deploy
         fetch-depth: 1
 
-    # Force this step to run by checking for success, otherwise GH Actions refuses
-    # to run this or any subsequent steps when the specific E2E test branch checkout
-    # fails but the master E2E test branch checkout succeeds.
     - name: Checkout RTRLIB (v0.7.0 tag)
-      if: success()
       uses: actions/checkout@v2
       with:
         repository: rtrlib/rtrlib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     # Only if previous checkout attempt fails. We can't use failure() as
     # continue-on-error: true causes failure() to be false even on failure.
     - name: Checkout the E2E test framework (master)
-      if: !steps.verify_checkout.outputs.success
+      if: ! steps.verify_checkout.outputs.success
       uses: actions/checkout@v2
       with:
         repository: nlnetlabs/rpki-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     # Only if previous checkout attempt fails. We can't use failure() as
     # continue-on-error: true causes failure() to be false even on failure.
     - name: Checkout the E2E test framework (master)
-      if: ! steps.verify_checkout.outputs.success
+      if: steps.verify_checkout.outputs.success != true
       uses: actions/checkout@v2
       with:
         repository: nlnetlabs/rpki-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,17 +40,21 @@ jobs:
         path: rpki-deploy
         fetch-depth: 1
         ref: ${{ steps.extract_branch.outputs.branch }}
-      # set an output we can conditionally depend on in the next step
+
+    # set an output we can conditionally depend on in the next step
+    - name: Verify checkout success
       run: |
         if [ -d ${GITHUB_WORKSPACE}/rpki-deploy ]; then
           echo "::set-output name=success::true"
+        else
+          echo "::set-output name=success::false"
         fi
-      id: checkout_specific
+      id: verify_checkout
 
     # Only if previous checkout attempt fails. We can't use failure() as
     # continue-on-error: true causes failure() to be false even on failure.
     - name: Checkout the E2E test framework (master)
-      if: not ${{ steps.checkout_specific.outputs.success }}
+      if: not ${{ steps.verify_checkout.outputs.success }}
       uses: actions/checkout@v2
       with:
         repository: nlnetlabs/rpki-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       shell: bash
       run: |
         BRANCH=${GITHUB_REF#refs/heads/}
-        if git ls-remote --exit-code --heads git@github.com:nlnetlabs/rpki-deploy; then
+        if git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy; then
           echo "::set-output name=branch::${BRANCH}"
         else
           echo "::set-output name=success::master"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,6 @@ jobs:
     name: deploy_and_test
     runs-on: ubuntu-18.04
     steps:
-    - name: Extract branch name
-      id: extract_branch
-      shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-
     - name: Checkout Krill
       uses: actions/checkout@v2
       with:
@@ -36,7 +31,7 @@ jobs:
       shell: bash
       run: |
         BRANCH=${GITHUB_REF#refs/heads/}
-        if git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy; then
+        if git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy ${BRANCH}; then
           echo "::set-output name=branch::${BRANCH}"
         else
           echo "::set-output name=success::master"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,28 @@ jobs:
     name: deploy_and_test
     runs-on: ubuntu-18.04
     steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+
     - name: Checkout Krill
       uses: actions/checkout@v2
       with:
         path: krill
         fetch-depth: 1
 
-    - name: Checkout the E2E test framework
+    - name: Checkout the E2E test framework (matching branch if exists)
+      uses: actions/checkout@v2
+      with:
+        repository: nlnetlabs/rpki-deploy
+        path: rpki-deploy
+        fetch-depth: 1
+        ref: ${{ steps.extract_branch.outputs.branch }}
+    
+    # Only if previous checkout attempt fails
+    - name: Checkout the E2E test framework (master)
+      if: failure()
       uses: actions/checkout@v2
       with:
         repository: nlnetlabs/rpki-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     # Only if previous checkout attempt fails. We can't use failure() as
     # continue-on-error: true causes failure() to be false even on failure.
     - name: Checkout the E2E test framework (master)
-      if: not steps.verify_checkout.outputs.success
+      if: !steps.verify_checkout.outputs.success
       uses: actions/checkout@v2
       with:
         repository: nlnetlabs/rpki-deploy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Extract branch name
+      id: extract_branch
       shell: bash
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
 
     - name: Checkout Krill
       uses: actions/checkout@v2
@@ -31,35 +31,24 @@ jobs:
         path: krill
         fetch-depth: 1
 
-    - name: Checkout the E2E test framework (matching branch if exists)
-      # Don't fail the job if this checkout fails
-      continue-on-error: true
-      uses: actions/checkout@v2
-      with:
-        repository: nlnetlabs/rpki-deploy
-        path: rpki-deploy
-        fetch-depth: 1
-        ref: ${{ steps.extract_branch.outputs.branch }}
-
-    # set an output we can conditionally depend on in the next step
-    - name: Verify checkout success
+    - name: Determine E2E test framework branch to use
+      id: pick_e2e_branch
+      shell: bash
       run: |
-        if [ -d ${GITHUB_WORKSPACE}/rpki-deploy ]; then
-          echo "::set-output name=success::true"
+        BRANCH=${GITHUB_REF#refs/heads/}
+        if git ls-remote --exit-code --heads git@github.com:nlnetlabs/rpki-deploy; then
+          echo "::set-output name=branch::${BRANCH}"
         else
-          echo "::set-output name=success::false"
+          echo "::set-output name=success::master"
         fi
-      id: verify_checkout
 
-    # Only if previous checkout attempt fails. We can't use failure() as
-    # continue-on-error: true causes failure() to be false even on failure.
-    - name: Checkout the E2E test framework (master)
-      if: steps.verify_checkout.outputs.success != true
+    - name: Checkout the E2E test framework
       uses: actions/checkout@v2
       with:
         repository: nlnetlabs/rpki-deploy
         path: rpki-deploy
         fetch-depth: 1
+        ref: ${{ steps.pick_e2e_branch.outputs.branch }}
 
     - name: Checkout RTRLIB (v0.7.0 tag)
       uses: actions/checkout@v2


### PR DESCRIPTION
Each time a new Krill repo branch is made that changes something that depends on a modification in the E2E test framework in the rpki-deploy repo the Krill `main.yml` file has to be temporarily changed in the PR to reference a corresponding branch in the rpki-deploy repo, and changed back before the PR merges (thus breaking the E2E test in the PR checks report).

This change attempts first to checkout the E2E test framework from a branch by the same name as the current Krill branch, and only if that fails checkout the master E2E test framework branch.