### PR TITLE
Only run the CI build on Krill code changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - '.dockerignore'
       - '.github/workflosw/main.yml'
       - 'Changelog.md'
-        'Dockerfile'
+      - 'Dockerfile'
       - 'doc/**'
       - 'docker/**'
       - 'LICENSE'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,18 @@
 name: CI
 on:
-  [push, pull_request]:
+  push:
+    paths-ignore:
+      - '.dockerignore'
+      - '.github/workflosw/main.yml'
+      - 'Changelog.md'
+      - 'Dockerfile'
+      - 'doc/**'
+      - 'docker/**'
+      - 'LICENSE'
+      - 'README.md'
+      - 'tests/e2e/**'
+  # Hmm, annoying, do we really have to duplicate this?
+  pull_request:
     paths-ignore:
       - '.dockerignore'
       - '.github/workflosw/main.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,16 @@
 name: CI
-on: [push, pull_request]
+on:
+  [push, pull_request]:
+    paths-ignore:
+      - '.dockerignore'
+      - '.github/workflosw/main.yml'
+      - 'Changelog.md'
+        'Dockerfile'
+      - 'doc/**'
+      - 'docker/**'
+      - 'LICENSE'
+      - 'README.md'
+      - 'tests/e2e/**'
 jobs:
   build:
     name: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ name: E2E Test
 on:
   push:
     paths-ignore:
+      - '.github/workflows/ci.yml'
       - 'Changelog.md'
       - 'doc/**'
       - 'LICENSE'


### PR DESCRIPTION
This will prevent wasted executions of the matrix CI builds.