### PR TITLE
Enable support for CTRL-C from outside the container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,7 @@ EXPOSE 3000/tcp
 # Use Tini to ensure that krillc responds to CTRL-C when run in the
 # foreground without the Docker argument "--init" (which is actually another
 # way of activating Tini, but cannot be enabled from inside the Docker image).
-ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /tini
-RUN chmod +x /tini
-
-ENTRYPOINT ["/tini", "--", "/opt/entrypoint.sh"]
+RUN apk add --no-cache tini
+# Tini is now available at /sbin/tini
+ENTRYPOINT ["/sbin/tini", "--", "/opt/entrypoint.sh"]
 CMD ["krill", "-c", "/var/krill/data/krill.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,11 @@ RUN chown ${RUN_USER}: /opt/entrypoint.sh
 
 EXPOSE 3000/tcp
 
-ENTRYPOINT ["/opt/entrypoint.sh"]
+# Use Tini to ensure that krillc responds to CTRL-C when run in the
+# foreground without the Docker argument "--init" (which is actually another
+# way of activating Tini, but cannot be enabled from inside the Docker image).
+ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini /tini
+RUN chmod +x /tini
+
+ENTRYPOINT ["/tini", "--", "/opt/entrypoint.sh"]
 CMD ["krill", "-c", "/var/krill/data/krill.conf"]


### PR DESCRIPTION
Same fix as proposed for Routinator in https://github.com/NLnetLabs/routinator/pull/277.
I'm not sure if `krill` needs this but certainly `krillc` when run via this container needs it.
The "proper" fix is to handle the signal sent to the process, though Tini also handles other "pid 1" responsibilities as well (e.g. reaping finished background processes).