### PR TITLE
Create a Krill DEB package via GH actions (#19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     paths-ignore:
       - '.dockerignore'
       - '.github/workflow/e2e.yml'
+      - '.github/workflow/pkg.yml'
+      - '.github/workflow/e2e test cache rebuild.yml'
       - 'Changelog.md'
       - 'Dockerfile'
       - 'doc/**'
@@ -16,6 +18,8 @@ on:
     paths-ignore:
       - '.dockerignore'
       - '.github/workflow/e2e.yml'
+      - '.github/workflow/pkg.yml'
+      - '.github/workflow/e2e test cache rebuild.yml'
       - 'Changelog.md'
       - 'Dockerfile'
       - 'doc/**'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,6 +24,8 @@ on:
     paths:
       - '**'
       - '!.github/workflows/ci.yml'
+      - '!.github/workflows/e2e test cache rebuild.yml'
+      - '!.github/workflows/pkg.yml'
       - '!Changelog.md'
       - '!doc/**'
       - '!LICENSE'

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -36,18 +36,49 @@ jobs:
   # Use the cargo-deb Rust create to build a Debian package for installing
   # Krill. See: https://github.com/mmstick/cargo-deb
   deb-pkg:
+    strategy:
+      matrix:
+        image: [
+          "ubuntu:16.04",
+          "ubuntu:18.04",
+          "ubuntu:20.04",
+          "debian:9",
+          "debian:10",
+        ]
     env:
       CARGO_DEB_VER: 1.23.1
     name: deb-pkg
-    runs-on: [ubuntu-16.04]
+    runs-on: ubuntu-latest
+    # Build on the oldest platform we are targeting in order to avoid
+    # https://github.com/rust-lang/rust/issues/57497.
+    container: ${{ matrix.image }}
     steps:
+    - name: Set vars
+      id: setvars
+      shell: bash
+      run: |
+        echo ::set-env name=DEB_NAME::$(echo $MATRIX_IMAGE | tr -d ':.')
+        echo ::set-output name=pkgname::$(echo $MATRIX_IMAGE | tr -d ':.')
+      env:
+        MATRIX_IMAGE: ${{ matrix.image }}
+        
     - name: Checkout repository
       uses: actions/checkout@v1
 
     - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: stable
+      run: |
+        apt-get update
+        apt-get install -y curl
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
+        echo "::add-path::$HOME/.cargo/bin"
+      env:
+        DEBIAN_FRONTEND: noninteractive
+  
+    - name: Install compilation dependencies
+      run: |
+          apt-get install -y build-essential libssl-dev pkg-config
+      env:
+        DEBIAN_FRONTEND: noninteractive
 
     # Speed up Krill Rust builds by caching unchanged built dependencies.
     # See: https://github.com/actions/cache/blob/master/examples.md#rust---cargo
@@ -58,7 +89,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ job.container.image }}-${{ matrix.image }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     # Speed up cargo-deb installation by only re-downloading it and
     # re-building its dependent crates if we change the version of
@@ -68,16 +99,16 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cargo/bin/cargo-deb
-        key: ${{ runner.os }}-${{ env.CARGO_DEB_VER }}-cargo-deb
+        key: ${{ job.container.image }}-${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}
 
     - name: Install Cargo Deb
       if: steps.cache-cargo-deb.outputs.cache-hit != 'true'
       run: |
         cargo install cargo-deb --version=$CARGO_DEB_VER
 
-    - name: Create the package
+    - name: Create the DEB package
       run: |
-        cargo deb --verbose
+        cargo deb --variant $DEB_NAME
 
     # Upload the produced DEB package. The artifact will be available
     # via the GH Actions job summary and build log pages, but only to
@@ -85,36 +116,213 @@ jobs:
     # uploaded artifact is also downloaded by the next job (see below)
     # to sanity check that it can be installed and results in a working
     # Krill installation.
-    - name: Upload artifacts
+    - name: Upload DEB package
       uses: actions/upload-artifact@v2
       with:
-        name: debian-package
+        name: ${{ steps.setvars.outputs.pkgname }}
         path: target/debian/*.deb
 
-  # Download and sanity check on target operating systems the packages
-  # created by previous jobs (see above).
-  # TODO: test on actual VMs or Docker containers, not on GH runner
-  # images as GH runners come with lots of software and libraries
-  # pre-installed and are not representative of the actual deployment
-  # targets nor do GH runners support all targets that we want to test.
-  deb-pkg-test:
-    name: test
-    needs: deb-pkg
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+  # Use the cargo-rpm Rust create to build an RPM package for installing
+  # Krill. See: https://github.com/iqlusioninc/cargo-rpm
+  rpm-pkg:
+    env:
+      CARGO_RPM_VER: 0.7.0
+    name: rpm-pkg
+    runs-on: ubuntu-latest
+    # Build on the oldest platform we are targeting in order to avoid
+    # https://github.com/rust-lang/rust/issues/57497.
+    container: "centos:7"
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+
+    - name: Install Rust
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
+        echo "::add-path::$HOME/.cargo/bin"
+
+    - name: Install compilation dependencies
+      run: |
+        yum -y install gcc gcc-c++ make openssl-devel perl rpm-build
+
+    # # Speed up Krill Rust builds by caching unchanged built dependencies.
+    # # See: https://github.com/actions/cache/blob/master/examples.md#rust---cargo
+    # - name: Cache Dot Cargo
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: |
+    #       ~/.cargo/registry
+    #       ~/.cargo/git
+    #       target
+    #     key: ${{ job.container.image }}-cargo-${{ hashFiles('**/Cargo.lock') }}-20200617
+
+    # # Speed up cargo-rpm installation by only re-downloading it and
+    # # re-building its dependent crates if we change the version of
+    # # cargo-rpm that we are using.
+    # - name: Cache Cargo RPM binary
+    #   id: cache-cargo-rpm
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: ~/.cargo/bin/cargo-rpm
+    #     key: ${{ job.container.image }}-cargo-rpm-${{ env.CARGO_RPM_VER }}
+
+    - name: Install Cargo RPM
+      # if: steps.cache-cargo-rpm.outputs.cache-hit != 'true'
+      run: |
+        cargo install cargo-rpm --version=$CARGO_RPM_VER
+
+    - name: Create the RPM package
+      run: |
+        mkdir -p target
+        cargo rpm build --verbose
+
+    # Upload the produced DEB package. The artifact will be available
+    - name: Upload RPM package
+      uses: actions/upload-artifact@v2
+      with:
+        name: rpm-package
+        path: target/release/rpmbuild/RPMS/x86_64/*.rpm
+
+  # Download and sanity check on target operating systems the packages
+  # created by previous jobs (see above). Don't test on GH runners as
+  # they come with lots of software and libraries pre-installed and thus
+  # are not representative of the actual deployment targets, nor do GH
+  # runners support all targets that we want to test.
+  deb-pkg-test:
+    name: deb-pkg-test
+    needs: deb-pkg
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - 'ubuntu:16.04'
+          - 'ubuntu:18.04'
+          - 'ubuntu:20.04'
+          - 'debian:9'
+          - 'debian:10'
+    steps:
+    - name: Set vars
+      id: setvars
+      shell: bash
+      run: |
+        if [[ $MATRIX_IMAGE == *debian* ]]; then
+          SLASHED=$(echo $MATRIX_IMAGE | tr ':' '/')
+          echo ::set-env name=LXC_IMAGE::$(echo "images:${SLASHED}/cloud")
+        else
+          echo ::set-env name=LXC_IMAGE::$(echo $MATRIX_IMAGE)
+        fi
+        echo ::set-env name=DEB_NAME::$(echo $MATRIX_IMAGE | tr -d ':.')
+        echo ::set-output name=pkgname::$(echo $MATRIX_IMAGE | tr -d ':.')
+      env:
+        MATRIX_IMAGE: ${{ matrix.image }}
+
     - name: Download DEB package
       uses: actions/download-artifact@v2
+      with:
+        name: ${{ steps.setvars.outputs.pkgname }}
+
+    - name: Add current user to LXD group
+      run: |
+        sudo usermod --append --groups lxd $(whoami)
+
+    - name: Initialize LXD
+      run: |
+        sudo lxd init --auto
+
+    - name: Check LXD configuration
+      run: |
+        sg lxd -c "lxc info"
+
+    - name: Launch LXC container
+      run: |
+        sg lxd -c "lxc launch $LXC_IMAGE testcon"
+
+    # ubuntu 16.04 cloud-init doesn't support the status --wait argument
+    # so loop instead.
+    - name: Prepare container
+      shell: bash
+      run: |
+        while true; do
+          OUTPUT=$(sg lxd -c "lxc exec testcon -- sh -c 'cloud-init status || true'")
+          [[ "$OUTPUT" == "status: done" ]] && break
+          [ -f /run/cloud-init/result.json ] && break
+          echo "Waiting for cloud-init.."
+          sleep 1s
+        done
+        sg lxd -c "lxc exec testcon -- apt-get update"
+        sg lxd -c "lxc exec testcon -- apt-get install -y man"
+
+    - name: Copy DEB into LXC container
+      run: |
+        DEB_FILE=$(ls -1 *.deb)
+        echo ::set-env name=DEB_FILE::$DEB_FILE
+        sg lxd -c "lxc file push ${DEB_FILE} testcon/tmp/"
 
     - name: Install DEB package
       run: |
-        sudo apt-get -y install ./debian-package/*.deb
-      shell: bash
+        sg lxd -c "lxc exec testcon -- apt-get -y install /tmp/$DEB_FILE"
 
-    - name: Test installed binaries
+    - name: Test installed packages
+      run: |
+        echo -e "\nKRILLC VERSION:"
+        sg lxd -c "lxc exec testcon -- krillc --version"
+
+        echo -e "\nKRILL VERSION:"
+        sg lxd -c "lxc exec testcon -- krill --version"
+
+        echo -e "\nKRILL CONF:"
+        sg lxd -c "lxc exec testcon -- cat /etc/krill.conf"
+
+        echo -e "\nKRILL DATA DIR:"
+        sg lxd -c "lxc exec testcon -- ls -la /var/lib/krill"
+
+        echo -e "\nKRILL SERVICE STATUS BEFORE ENABLE:"
+        sg lxd -c "lxc exec testcon -- systemctl status krill || true"
+
+        echo -e "\nENABLE KRILL SERVICE:"
+        sg lxd -c "lxc exec testcon -- systemctl enable krill"
+
+        echo -e "\nKRILL SERVICE STATUS AFTER ENABLE:"
+        sg lxd -c "lxc exec testcon -- systemctl status krill || true"
+
+        echo -e "\nSTART KRILL SERVICE:"
+        sg lxd -c "lxc exec testcon -- systemctl start krill"
+        
+        echo -e "\nKRILL SERVICE STATUS AFTER START:"
+        sleep 1s
+        sg lxd -c "lxc exec testcon -- systemctl status krill"
+
+        echo -e "\nKRILL MAN PAGE:"
+        sg lxd -c "lxc exec testcon -- man -P cat krill"
+
+  # Download and sanity check on target operating systems the packages
+  # created by previous jobs (see above). Don't test on GH runners as
+  # they come with lots of software and libraries pre-installed and thus
+  # are not representative of the actual deployment targets, nor do GH
+  # runners support all targets that we want to test.
+  rpm-pkg-test:
+    name: rpm-pkg-test
+    needs: rpm-pkg
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - 'centos:7'
+          - 'centos:8'
+    container: ${{ matrix.image }}
+    steps:
+    - name: Download RPM package
+      uses: actions/download-artifact@v2
+      with:
+        name: rpm-package
+
+    - name: Install RPM package
+      run: yum install -y ./*.rpm
+
+    - name: Test installed packages
+      shell: bash
       run: |
         krillc --version
         krill --version
-      shell: bash

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -52,7 +52,7 @@ jobs:
           "ubuntu:18.04",
           "ubuntu:20.04",
           "debian:9",
-          # "debian:10",
+          "debian:10",
         ]
     env:
       CARGO_DEB_VER: 1.23.1
@@ -158,7 +158,7 @@ jobs:
           - 'ubuntu:18.04'
           - 'ubuntu:20.04'
           - 'debian:9'
-          # - 'debian:10'
+          - 'debian:10'
     steps:
     # Set some environment variables that will be available to "run" steps below
     # in this job, and some output variables that will be available in GH Action
@@ -197,7 +197,9 @@ jobs:
 
     - name: Launch LXC container
       run: |
-        sg lxd -c "lxc launch $LXC_IMAGE testcon"
+        # security.nesting=true is needed to avoid error "Failed to set up mount
+        # namespacing: Permission denied" in a Debian 10 container.
+        sg lxd -c "lxc launch $LXC_IMAGE -c security.nesting=true testcon"
 
     # Run apt-get update and install man support (missing in some LXC/LXD O/S
     # images) but first wait for cloud-init to finish otherwise the network

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -1,3 +1,11 @@
+# GitHub Actions workflow for building and testing Krill O/S packages.
+# Uses GitHub Actions caching to avoid rebuilding Rust cargo-deb and
+# Krill dependencies on every run.
+#
+# Note: at the time of writing the GH cache contents expire after a
+# week if not used so the next build may be much slower as it will
+# have to re-download/build/install lots of Rust crates.
+
 name: Packaging
 on:
   push:
@@ -25,6 +33,8 @@ on:
       - 'tests/e2e/**'
 
 jobs:
+  # Use the cargo-deb Rust create to build a Debian package for installing
+  # Krill. See: https://github.com/mmstick/cargo-deb
   deb-pkg:
     env:
       CARGO_DEB_VER: 1.23.1
@@ -39,6 +49,8 @@ jobs:
       with:
         rust-version: stable
 
+    # Speed up Krill Rust builds by caching unchanged built dependencies.
+    # See: https://github.com/actions/cache/blob/master/examples.md#rust---cargo
     - name: Cache Dot Cargo
       uses: actions/cache@v2
       with:
@@ -48,6 +60,9 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+    # Speed up cargo-deb installation by only re-downloading it and
+    # re-building its dependent crates if we change the version of
+    # cargo-deb that we are using.
     - name: Cache Cargo Deb binary
       id: cache-cargo-deb
       uses: actions/cache@v2
@@ -64,12 +79,24 @@ jobs:
       run: |
         cargo deb --verbose
 
+    # Upload the produced DEB package. The artifact will be available
+    # via the GH Actions job summary and build log pages, but only to
+    # users logged in to GH with sufficient rights in this project. The
+    # uploaded artifact is also downloaded by the next job (see below)
+    # to sanity check that it can be installed and results in a working
+    # Krill installation.
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
         name: debian-package
         path: target/debian/*.deb
 
+  # Download and sanity check on target operating systems the packages
+  # created by previous jobs (see above).
+  # TODO: test on actual VMs or Docker containers, not on GH runner
+  # images as GH runners come with lots of software and libraries
+  # pre-installed and are not representative of the actual deployment
+  # targets nor do GH runners support all targets that we want to test.
   deb-pkg-test:
     name: test
     needs: deb-pkg

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -199,17 +199,27 @@ jobs:
       run: |
         sg lxd -c "lxc launch $LXC_IMAGE testcon"
 
+    # Run apt-get update and install man support (missing in some LXC/LXD O/S
+    # images) but first wait for cloud-init to finish otherwise the network
+    # isn't yet ready.
     - name: Prepare container
       shell: bash
       run: |
         while true; do
           case ${LXC_IMAGE} in
-            ubuntu:16.04|ubuntu:18.04|ubuntu:20.04|images:debian/10/cloud)
-              OUTPUT=$(sg lxd -c "lxc exec testcon -- cloud-init status")
+            # ubuntu:16.04|ubuntu:18.04|ubuntu:20.04|images:debian/10/cloud)
+            ubuntu:16.04|ubuntu:18.04|ubuntu:20.04|images)
+            OUTPUT=$(sg lxd -c "lxc exec testcon -- cloud-init status")
               [[ "$OUTPUT" == "status: done" ]] && break
               ;;
-            images:debian/9/cloud)
-              [ -f /run/cloud-init/result.json ] && echo "Debian 9 extra pause" && sleep 2s && break
+            # images:debian/9/cloud)
+            #   [ -f /run/cloud-init/result.json ] && echo "Debian 9 extra pause" && sleep 2s && break
+            
+            images:debian/9/cloud|images:debian/10/cloud)
+              # Not sure why the above don't work for Debian 9 and 10. Just
+              # sleep for now instead to avoid the name resolution failures that
+              # otherwise happen during apt-get update below.
+              sleep 60s && break
               ;;
             *)
               echo >&2 "ERROR: Unknown LXC image $LXC_IMAGE"

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -122,67 +122,6 @@ jobs:
         name: ${{ steps.setvars.outputs.pkgname }}
         path: target/debian/*.deb
 
-  # Use the cargo-rpm Rust create to build an RPM package for installing
-  # Krill. See: https://github.com/iqlusioninc/cargo-rpm
-  rpm-pkg:
-    env:
-      CARGO_RPM_VER: 0.7.0
-    name: rpm-pkg
-    runs-on: ubuntu-latest
-    # Build on the oldest platform we are targeting in order to avoid
-    # https://github.com/rust-lang/rust/issues/57497.
-    container: "centos:7"
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v1
-
-    - name: Install Rust
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile minimal -y
-        echo "::add-path::$HOME/.cargo/bin"
-
-    - name: Install compilation dependencies
-      run: |
-        yum -y install gcc gcc-c++ make openssl-devel perl rpm-build
-
-    # # Speed up Krill Rust builds by caching unchanged built dependencies.
-    # # See: https://github.com/actions/cache/blob/master/examples.md#rust---cargo
-    # - name: Cache Dot Cargo
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: |
-    #       ~/.cargo/registry
-    #       ~/.cargo/git
-    #       target
-    #     key: ${{ job.container.image }}-cargo-${{ hashFiles('**/Cargo.lock') }}-20200617
-
-    # # Speed up cargo-rpm installation by only re-downloading it and
-    # # re-building its dependent crates if we change the version of
-    # # cargo-rpm that we are using.
-    # - name: Cache Cargo RPM binary
-    #   id: cache-cargo-rpm
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: ~/.cargo/bin/cargo-rpm
-    #     key: ${{ job.container.image }}-cargo-rpm-${{ env.CARGO_RPM_VER }}
-
-    - name: Install Cargo RPM
-      # if: steps.cache-cargo-rpm.outputs.cache-hit != 'true'
-      run: |
-        cargo install cargo-rpm --version=$CARGO_RPM_VER
-
-    - name: Create the RPM package
-      run: |
-        mkdir -p target
-        cargo rpm build --verbose
-
-    # Upload the produced DEB package. The artifact will be available
-    - name: Upload RPM package
-      uses: actions/upload-artifact@v2
-      with:
-        name: rpm-package
-        path: target/release/rpmbuild/RPMS/x86_64/*.rpm
-
   # Download and sanity check on target operating systems the packages
   # created by previous jobs (see above). Don't test on GH runners as
   # they come with lots of software and libraries pre-installed and thus
@@ -295,34 +234,3 @@ jobs:
 
         echo -e "\nKRILL MAN PAGE:"
         sg lxd -c "lxc exec testcon -- man -P cat krill"
-
-  # Download and sanity check on target operating systems the packages
-  # created by previous jobs (see above). Don't test on GH runners as
-  # they come with lots of software and libraries pre-installed and thus
-  # are not representative of the actual deployment targets, nor do GH
-  # runners support all targets that we want to test.
-  rpm-pkg-test:
-    name: rpm-pkg-test
-    needs: rpm-pkg
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - 'centos:7'
-          - 'centos:8'
-    container: ${{ matrix.image }}
-    steps:
-    - name: Download RPM package
-      uses: actions/download-artifact@v2
-      with:
-        name: rpm-package
-
-    - name: Install RPM package
-      run: yum install -y ./*.rpm
-
-    - name: Test installed packages
-      shell: bash
-      run: |
-        krillc --version
-        krill --version

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -5,6 +5,15 @@
 # Note: at the time of writing the GH cache contents expire after a
 # week if not used so the next build may be much slower as it will
 # have to re-download/build/install lots of Rust crates.
+#
+# Packages are built inside Docker containers as GH Runners have extra libraries
+# and packages installed which can cause package building to succeed but package
+# installation on a real target O/S to fail, due to being built against too
+# recent version of a package such as libssl or glibc.
+#
+# Packages are tested inside LXC/LXD containers because Docker containers don't
+# by default support init managers such as systemd but we want to test systemd
+# service unit installation and activation.
 
 name: Packaging
 on:
@@ -50,9 +59,13 @@ jobs:
     name: deb-pkg
     runs-on: ubuntu-latest
     # Build on the oldest platform we are targeting in order to avoid
-    # https://github.com/rust-lang/rust/issues/57497.
+    # https://github.com/rust-lang/rust/issues/57497. Specifying container
+    # causes all of the steps in this job to run inside a Docker container.
     container: ${{ matrix.image }}
     steps:
+    # Set an environment variable that will be available to later steps in
+    # run commands, and a GH Actions output variable that can be used in later
+    # step definitions.
     - name: Set vars
       id: setvars
       shell: bash
@@ -61,10 +74,13 @@ jobs:
         echo ::set-output name=pkgname::$(echo $MATRIX_IMAGE | tr -d ':.')
       env:
         MATRIX_IMAGE: ${{ matrix.image }}
-        
+
+    # Git clone the Krill code in the branch we were invoked on.
     - name: Checkout repository
       uses: actions/checkout@v1
 
+    # Install Rust the hard way rather than using a GH Action because the action
+    # doesn't work inside a Docker container.
     - name: Install Rust
       run: |
         apt-get update
@@ -73,7 +89,7 @@ jobs:
         echo "::add-path::$HOME/.cargo/bin"
       env:
         DEBIAN_FRONTEND: noninteractive
-  
+
     - name: Install compilation dependencies
       run: |
           apt-get install -y build-essential libssl-dev pkg-config
@@ -91,9 +107,8 @@ jobs:
           target
         key: ${{ job.container.image }}-${{ matrix.image }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-    # Speed up cargo-deb installation by only re-downloading it and
-    # re-building its dependent crates if we change the version of
-    # cargo-deb that we are using.
+    # Speed up cargo-deb installation by only re-downloading and re-building its
+    # dependent crates if we change the version of cargo-deb that we are using.
     - name: Cache Cargo Deb binary
       id: cache-cargo-deb
       uses: actions/cache@v2
@@ -101,11 +116,14 @@ jobs:
         path: ~/.cargo/bin/cargo-deb
         key: ${{ job.container.image }}-${{ matrix.image }}-cargo-deb-${{ env.CARGO_DEB_VER }}
 
+    # Only install cargo-deb if not already fetched from the cache.
     - name: Install Cargo Deb
       if: steps.cache-cargo-deb.outputs.cache-hit != 'true'
       run: |
         cargo install cargo-deb --version=$CARGO_DEB_VER
 
+    # Instruct cargo-deb to build the Debian package using the config section
+    # in Cargo.toml for the specified "variant".
     - name: Create the DEB package
       run: |
         cargo deb --variant $DEB_NAME
@@ -122,11 +140,12 @@ jobs:
         name: ${{ steps.setvars.outputs.pkgname }}
         path: target/debian/*.deb
 
-  # Download and sanity check on target operating systems the packages
-  # created by previous jobs (see above). Don't test on GH runners as
-  # they come with lots of software and libraries pre-installed and thus
-  # are not representative of the actual deployment targets, nor do GH
-  # runners support all targets that we want to test.
+  # Download and sanity check on target operating systems the packages created
+  # by previous jobs (see above). Don't test on GH runners as they come with
+  # lots of software and libraries pre-installed and thus are not representative
+  # of the actual deployment targets, nor do GH runners support all targets that
+  # we want to test. Don't test in Docker containers as they do not support
+  # systemd.
   deb-pkg-test:
     name: deb-pkg-test
     needs: deb-pkg
@@ -141,6 +160,9 @@ jobs:
           - 'debian:9'
           - 'debian:10'
     steps:
+    # Set some environment variables that will be available to "run" steps below
+    # in this job, and some output variables that will be available in GH Action
+    # step definitions below.
     - name: Set vars
       id: setvars
       shell: bash
@@ -177,8 +199,6 @@ jobs:
       run: |
         sg lxd -c "lxc launch $LXC_IMAGE testcon"
 
-    # ubuntu 16.04 cloud-init doesn't support the status --wait argument
-    # so loop instead.
     - name: Prepare container
       shell: bash
       run: |
@@ -189,7 +209,7 @@ jobs:
               [[ "$OUTPUT" == "status: done" ]] && break
               ;;
             images:debian/9/cloud)
-              [ -f /run/cloud-init/result.json ] && break
+              [ -f /run/cloud-init/result.json ] && echo "Debian 9 extra pause" && sleep 2s && break
               ;;
             *)
               echo >&2 "ERROR: Unknown LXC image $LXC_IMAGE"

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -1,0 +1,93 @@
+name: Packaging
+on:
+  push:
+    paths-ignore:
+      - '.dockerignore'
+      - '.github/workflow/pkg.yml'
+      - 'Changelog.md'
+      - 'Dockerfile'
+      - 'doc/**'
+      - 'docker/**'
+      - 'LICENSE'
+      - 'README.md'
+      - 'tests/e2e/**'
+  # Hmm, annoying, do we really have to duplicate this?
+  pull_request:
+    paths-ignore:
+      - '.dockerignore'
+      - '.github/workflow/pkg.yml'
+      - 'Changelog.md'
+      - 'Dockerfile'
+      - 'doc/**'
+      - 'docker/**'
+      - 'LICENSE'
+      - 'README.md'
+      - 'tests/e2e/**'
+
+jobs:
+  deb-pkg:
+    env:
+      CARGO_DEB_VER: 1.23.1
+    name: deb-pkg
+    runs-on: [ubuntu-16.04]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+
+    - name: Cache Dot Cargo
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Cache Cargo Deb binary
+      id: cache-cargo-deb
+      uses: actions/cache@v2
+      with:
+        path: ~/.cargo/bin/cargo-deb
+        key: ${{ runner.os }}-${{ env.CARGO_DEB_VER }}-cargo-deb
+
+    - name: Install Cargo Deb
+      if: steps.cache-cargo-deb.outputs.cache-hit != 'true'
+      run: |
+        cargo install cargo-deb --version=$CARGO_DEB_VER
+
+    - name: Create the package
+      run: |
+        cargo deb --verbose
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: debian-package
+        path: target/debian/*.deb
+
+  deb-pkg-test:
+    name: test
+    needs: deb-pkg
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+    steps:
+    - name: Download DEB package
+      uses: actions/download-artifact@v2
+
+    - name: Install DEB package
+      run: |
+        sudo apt-get -y install ./debian-package/*.deb
+      shell: bash
+
+    - name: Test installed binaries
+      run: |
+        krillc --version
+        krill --version
+      shell: bash

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -183,9 +183,18 @@ jobs:
       shell: bash
       run: |
         while true; do
-          OUTPUT=$(sg lxd -c "lxc exec testcon -- sh -c 'cloud-init status || true'")
-          [[ "$OUTPUT" == "status: done" ]] && break
-          [ -f /run/cloud-init/result.json ] && break
+          case ${LXC_IMAGE} in
+            ubuntu:16.04|ubuntu:18.04|ubuntu:20.04|images:debian/10/cloud)
+              OUTPUT=$(sg lxd -c "lxc exec testcon -- cloud-init status")
+              [[ "$OUTPUT" == "status: done" ]] && break
+              ;;
+            images:debian/9/cloud)
+              [ -f /run/cloud-init/result.json ] && break
+              ;;
+            *)
+              echo >&2 "ERROR: Unknown LXC image $LXC_IMAGE"
+              ;;
+          esac
           echo "Waiting for cloud-init.."
           sleep 1s
         done

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -52,7 +52,7 @@ jobs:
           "ubuntu:18.04",
           "ubuntu:20.04",
           "debian:9",
-          "debian:10",
+          # "debian:10",
         ]
     env:
       CARGO_DEB_VER: 1.23.1
@@ -158,7 +158,7 @@ jobs:
           - 'ubuntu:18.04'
           - 'ubuntu:20.04'
           - 'debian:9'
-          - 'debian:10'
+          # - 'debian:10'
     steps:
     # Set some environment variables that will be available to "run" steps below
     # in this job, and some output variables that will be available in GH Action

--- a/.rpm/krill.spec
+++ b/.rpm/krill.spec
@@ -1,0 +1,32 @@
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+Name: krill
+Summary: Resource Public Key Infrastructure (RPKI) daemon
+Version: @@VERSION@@
+Release: @@RELEASE@@
+License: MPLv2.0
+Group: Applications/System
+Source0: %{name}-%{version}.tar.gz
+URL: https://www.nlnetlabs.nl/projects/rpki/krill/
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.10.0+1.1.1g"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47cd4a96d49c3abf4cac8e8a80cba998a030c75608f158fb1c5f609772f265e6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -905,6 +914,7 @@ dependencies = [
  "autocfg 1.0.0",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,32 +53,100 @@ default = []
 extra-debug = [ "rpki/extra-debug" ]
 static-openssl = [ "openssl/vendored" ]
 
-# Configuration for cargo-deb (https://github.com/mmstick/cargo-deb)
-# Builds a Debian package in target/debian/ when invoked with: cargo deb
-# Configuration valid as of cargo-deb v1.23.1.
+# Configurations for cargo-deb. Builds Debian packages in target/debian/ when
+# invoked with: cargo deb. Configuration valid as of cargo-deb v1.23.1. Use
+# `--variant` to select which section below to use. Variant sections inherit and
+# override the settings in the non-variant section. The postinst script uses the
+# adduser command so we depend on that too. krill.conf is deliberately NOT
+# specified as a "conf-file" because it is generated. See:
+#   - https://github.com/mmstick/cargo-deb
+#   - https://lintian.debian.org/tags/systemd-service-file-outside-lib.html
+#   - https://www.debian.org/doc/debian-policy/ch-files.html#behavior
 [package.metadata.deb]
+name = "krill"
 priority = "optional"
 section = "net"
+extended-description-file = "debian/description.txt"
+maintainer-scripts = "debian/scripts/"
+depends = "$auto, adduser, libssl1.1"
 
-# Sstatically link with OpenSSL when building a Debian package because the
-# newest OpenSSL available on Ubuntu 16.04 at the time of writing is 1.0.2g
-# (see: https://packages.ubuntu.com/xenial/openssl) while Krill requires
-# OpenSSL >= 1.1.0.
+[package.metadata.deb.variants.ubuntu2004]
+assets = [
+    ["target/release/krill", "/usr/bin/krill", "755"],
+    ["target/release/krillc", "/usr/bin/krillc", "755"],
+    ["defaults/krill.conf", "/usr/share/doc/krill/krill.conf", "644"],
+    ["doc/krill.1", "/usr/share/man/man1/krill.1", "644"],
+    ["doc/krillc.1", "/usr/share/man/man1/krillc.1", "644"],
+    ["debian/assets/krill.service.ubuntu2004", "/lib/systemd/system/krill.service", "644"]
+]
+
+# Variant of the Debian packaging configuration that uses a slightly simpler
+# systemd service unit file because Ubuntu 18.04 doesn't support newer features
+# supported by Ubuntu 20.04.
+[package.metadata.deb.variants.ubuntu1804]
+assets = [
+    ["target/release/krill", "/usr/bin/krill", "755"],
+    ["target/release/krillc", "/usr/bin/krillc", "755"],
+    ["defaults/krill.conf", "/usr/share/doc/krill/krill.conf", "644"],
+    ["doc/krill.1", "/usr/share/man/man1/krill.1", "644"],
+    ["doc/krillc.1", "/usr/share/man/man1/krillc.1", "644"],
+    ["debian/assets/krill.service.ubuntu1804", "/lib/systemd/system/krill.service", "644"]
+]
+
+# Variant of the Debian packaging configuration that:
+#   a) statically links with OpenSSL when building a Debian package because the
+#      newest OpenSSL available on Ubuntu 16.04 at the time of writing is 1.0.2g
+#      (see: https://packages.ubuntu.com/xenial/openssl) while Krill requires
+#      OpenSSL >= 1.1.0.
+#   b) uses a simpler systemd service unit file because Ubuntu 16.04 doesn't
+#      support newer features supported by Ubuntu 18.04 and 20.04.
+[package.metadata.deb.variants.ubuntu1604]
 features = [ "static-openssl" ]
+depends = "$auto, adduser"
+assets = [
+    ["target/release/krill", "/usr/bin/krill", "755"],
+    ["target/release/krillc", "/usr/bin/krillc", "755"],
+    ["defaults/krill.conf", "/usr/share/doc/krill/krill.conf", "644"],
+    ["doc/krill.1", "/usr/share/man/man1/krill.1", "644"],
+    ["doc/krillc.1", "/usr/share/man/man1/krillc.1", "644"],
+    ["debian/assets/krill.service.ubuntu1604", "/lib/systemd/system/krill.service", "644"]
+]
 
-# Manually specify depends instead of using "$auto" because when building
-# on a GitHub Actions Ubuntu 16.04 runner cargo-deb detects much newer
-# versions of these libraries than are available when testing apt-get install
-# on stock (Docker/DigitalOcean) Ubuntu 16.04, causing installation to fail
-# if "$auto" is used.
-depends = "libc6 (>= 2.23), libgcc1 (>= 1:6.0.1)"
+# Debian 10 variant, identical to the Ubuntu 1804 variant.
+[package.metadata.deb.variants.debian10]
+assets = [
+    ["target/release/krill", "/usr/bin/krill", "755"],
+    ["target/release/krillc", "/usr/bin/krillc", "755"],
+    ["defaults/krill.conf", "/usr/share/doc/krill/krill.conf", "644"],
+    ["doc/krill.1", "/usr/share/man/man1/krill.1", "644"],
+    ["doc/krillc.1", "/usr/share/man/man1/krillc.1", "644"],
+    ["debian/assets/krill.service.ubuntu1804", "/lib/systemd/system/krill.service", "644"]
+]
 
-extended-description = """\
-Krill is a free, open source RPKI Certificate Authority that lets you run
-delegated RPKI under one or multiple Regional Internet Registries (RIRs).
-Through its built-in publication server, Krill can publish Route Origin
-Authorisations (ROAs) on your own servers or with a third party.
+# Debian 9 variant, identical to the Ubuntu 1604 variant.
+[package.metadata.deb.variants.debian9]
+features = [ "static-openssl" ]
+depends = "$auto, adduser"
+assets = [
+    ["target/release/krill", "/usr/bin/krill", "755"],
+    ["target/release/krillc", "/usr/bin/krillc", "755"],
+    ["defaults/krill.conf", "/usr/share/doc/krill/krill.conf", "644"],
+    ["doc/krill.1", "/usr/share/man/man1/krill.1", "644"],
+    ["doc/krillc.1", "/usr/share/man/man1/krillc.1", "644"],
+    ["debian/assets/krill.service.ubuntu1604", "/lib/systemd/system/krill.service", "644"]
+]
 
-This package contains the krill daemon and krillc CLI binaries.
+# Configuration for cargo-rpm (https://github.com/iqlusioninc/cargo-rpm)
+# Builds an RPM package in target/release/rpmbuild/RPMS/x86_64/ when invoked
+# with: cargo rpm build
+# Configuration valid as of cargo-rpm v0.7.0
+[package.metadata.rpm.cargo]
+# Statically link with OpenSSL when building an RPM package because the
+# newest OpenSSL available on CentOS 7 at the time of writing is 1.0.2k
+# (see: http://mirror.centos.org/centos/7/os/x86_64/Packages/) while Krill
+# requires OpenSSL >= 1.1.0.
+buildflags = ["--release", "--features", "static-openssl"]
 
-For more information visit https://rpki.readthedocs.io/en/latest/krill/."""
+[package.metadata.rpm.targets]
+krill = { path = "/usr/bin/krill" }
+krillc = { path = "/usr/bin/krillc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.6.3"
 edition = "2018"
 authors = [ "The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>" ]
 description = "Resource Public Key Infrastructure (RPKI) daemon"
+homepage = "https://www.nlnetlabs.nl/projects/rpki/krill/"
 repository = "https://github.com/NLnetLabs/krill"
 keywords = ["rpki", "routing-security", "bgp"]
 readme = "README.md"
@@ -45,7 +46,22 @@ syslog		    = "^4.0"
 [build-dependencies]
 ignore          = "^0.4"
 
-
 [features]
 default = []
 extra-debug = [ "rpki/extra-debug" ]
+deb-pkg = [ "openssl/vendored" ]
+
+[package.metadata.deb]
+features = [ "deb-pkg" ]
+priority = "extra"
+section = "net"
+depends = "libc6 (>= 2.23), libgcc1 (>= 1:6.0.1)"
+extended-description = """\
+Krill is a free, open source RPKI Certificate Authority that lets you run
+delegated RPKI under one or multiple Regional Internet Registries (RIRs).
+Through its built-in publication server, Krill can publish Route Origin
+Authorisations (ROAs) on your own servers or with a third party.
+
+This package contains the krill daemon and krillc CLI binaries.
+
+For more information visit https://rpki.readthedocs.io/en/latest/krill/."""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [package]
+# Note: some of these values are also used when building operating
+# system packages. See below.
 name    = "krill"
 version = "0.6.3"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,16 +54,27 @@ static-openssl = [ "openssl/vendored" ]
 
 # ------------------------------------------------------------------------------
 # START DEBIAN PACKAGING
-
-# Configurations for cargo-deb. Builds Debian packages in target/debian/ when
-# invoked with: cargo deb. Configuration valid as of cargo-deb v1.23.1. Use
-# `--variant` to select which section below to use. Variant sections inherit and
-# override the settings in the non-variant section. The postinst script uses the
-# adduser command so we depend on that too. krill.conf is deliberately NOT
-# specified as a "conf-file" because it is generated. See:
+#
+# Configurations for the cargo-deb cargo plugin which builds Debian packages in
+# target/debian/ when invoked with: cargo deb. Tested with cargo-deb v1.23.1.
+# Use `--variant` to select which section below to use. Variant sections inherit
+# and override the settings in the base [package.metadata.deb] section. The
+# configs vary because of differing degrees of OpenSSL and systemd support
+# across operating systems.
+#
+# Note that as the postinst script uses the adduser command we declare a
+# dependency on the adduser package to keep the lintian tool happy.
+# Note: krill.conf is deliberately NOT specified as a "conf-file" because it is
+# generated.
+#
+# The GitHub Actions pkg.yml workflow definition file uses these configurations
+# to build and test Ubuntu/Debian packages for Krill.
+# 
+# See:
 #   - https://github.com/mmstick/cargo-deb
 #   - https://lintian.debian.org/tags/systemd-service-file-outside-lib.html
 #   - https://www.debian.org/doc/debian-policy/ch-files.html#behavior
+#   - .github/workflows/pkg.yml
 [package.metadata.deb]
 name = "krill"
 priority = "optional"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,28 @@ ignore          = "^0.4"
 [features]
 default = []
 extra-debug = [ "rpki/extra-debug" ]
-deb-pkg = [ "openssl/vendored" ]
+static-openssl = [ "openssl/vendored" ]
 
+# Configuration for cargo-deb (https://github.com/mmstick/cargo-deb)
+# Builds a Debian package in target/debian/ when invoked with: cargo deb
+# Configuration valid as of cargo-deb v1.23.1.
 [package.metadata.deb]
-features = [ "deb-pkg" ]
-priority = "extra"
+priority = "optional"
 section = "net"
+
+# Sstatically link with OpenSSL when building a Debian package because the
+# newest OpenSSL available on Ubuntu 16.04 at the time of writing is 1.0.2g
+# (see: https://packages.ubuntu.com/xenial/openssl) while Krill requires
+# OpenSSL >= 1.1.0.
+features = [ "static-openssl" ]
+
+# Manually specify depends instead of using "$auto" because when building
+# on a GitHub Actions Ubuntu 16.04 runner cargo-deb detects much newer
+# versions of these libraries than are available when testing apt-get install
+# on stock (Docker/DigitalOcean) Ubuntu 16.04, causing installation to fail
+# if "$auto" is used.
 depends = "libc6 (>= 2.23), libgcc1 (>= 1:6.0.1)"
+
 extended-description = """\
 Krill is a free, open source RPKI Certificate Authority that lets you run
 delegated RPKI under one or multiple Regional Internet Registries (RIRs).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
-# Note: some of these values are also used when building operating
-# system packages. See below.
+# Note: some of these values are also used when building Debian packages below.
 name    = "krill"
 version = "0.6.3"
 edition = "2018"
@@ -52,6 +51,9 @@ ignore          = "^0.4"
 default = []
 extra-debug = [ "rpki/extra-debug" ]
 static-openssl = [ "openssl/vendored" ]
+
+# ------------------------------------------------------------------------------
+# START DEBIAN PACKAGING
 
 # Configurations for cargo-deb. Builds Debian packages in target/debian/ when
 # invoked with: cargo deb. Configuration valid as of cargo-deb v1.23.1. Use
@@ -136,17 +138,5 @@ assets = [
     ["debian/assets/krill.service.ubuntu1604", "/lib/systemd/system/krill.service", "644"]
 ]
 
-# Configuration for cargo-rpm (https://github.com/iqlusioninc/cargo-rpm)
-# Builds an RPM package in target/release/rpmbuild/RPMS/x86_64/ when invoked
-# with: cargo rpm build
-# Configuration valid as of cargo-rpm v0.7.0
-[package.metadata.rpm.cargo]
-# Statically link with OpenSSL when building an RPM package because the
-# newest OpenSSL available on CentOS 7 at the time of writing is 1.0.2k
-# (see: http://mirror.centos.org/centos/7/os/x86_64/Packages/) while Krill
-# requires OpenSSL >= 1.1.0.
-buildflags = ["--release", "--features", "static-openssl"]
-
-[package.metadata.rpm.targets]
-krill = { path = "/usr/bin/krill" }
-krillc = { path = "/usr/bin/krillc" }
+# END DEBIAN PACKAGING
+# ------------------------------------------------------------------------------

--- a/debian/assets/krill.service.ubuntu1604
+++ b/debian/assets/krill.service.ubuntu1604
@@ -1,0 +1,25 @@
+[Unit]
+Description=Krill
+Documentation=man:krill(1)
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/krill --config=/etc/krill.conf
+Type=simple
+Restart=on-failure
+User=krill
+#AmbientCapabilities=CAP_NET_BIND_SERVICE
+#CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+#PrivateDevices=yes
+#PrivateTmp=yes
+#ProtectHome=yes
+#RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+#SystemCallArchitectures=native
+#SystemCallErrorNumber=EPERM
+RestartSec=10
+StartLimitInterval=10m
+StartLimitBurst=5
+WorkingDirectory=/var/lib/krill
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/assets/krill.service.ubuntu1604
+++ b/debian/assets/krill.service.ubuntu1604
@@ -8,14 +8,6 @@ ExecStart=/usr/bin/krill --config=/etc/krill.conf
 Type=simple
 Restart=on-failure
 User=krill
-#AmbientCapabilities=CAP_NET_BIND_SERVICE
-#CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-#PrivateDevices=yes
-#PrivateTmp=yes
-#ProtectHome=yes
-#RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
-#SystemCallArchitectures=native
-#SystemCallErrorNumber=EPERM
 RestartSec=10
 StartLimitInterval=10m
 StartLimitBurst=5

--- a/debian/assets/krill.service.ubuntu1804
+++ b/debian/assets/krill.service.ubuntu1804
@@ -1,0 +1,35 @@
+[Unit]
+Description=Krill
+Documentation=man:krill(1)
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/krill --config=/etc/krill.conf
+Type=simple
+Restart=on-failure
+User=krill
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadWritePaths=/var/lib/krill/
+ConfigurationDirectory=krill
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+StateDirectory=krill
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+RestartSec=10
+StartLimitInterval=10m
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/assets/krill.service.ubuntu2004
+++ b/debian/assets/krill.service.ubuntu2004
@@ -1,0 +1,36 @@
+[Unit]
+Description=Krill
+Documentation=man:krill(1)
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/krill --config=/etc/krill.conf
+Type=exec
+Restart=on-failure
+User=krill
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadWritePaths=/var/lib/krill/
+ConfigurationDirectory=krill
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+StateDirectory=krill
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service
+RestartSec=10
+StartLimitInterval=10m
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/description.txt
+++ b/debian/description.txt
@@ -1,0 +1,8 @@
+Krill is a free, open source RPKI Certificate Authority that lets you run
+delegated RPKI under one or multiple Regional Internet Registries (RIRs).
+Through its built-in publication server, Krill can publish Route Origin
+Authorisations (ROAs) on your own servers or with a third party.
+
+This package contains the krill daemon and krillc CLI binaries.
+
+For more information visit https://rpki.readthedocs.io/en/latest/krill/.

--- a/debian/scripts/postinst
+++ b/debian/scripts/postinst
@@ -1,0 +1,44 @@
+#!/bin/sh -e
+
+KRILL_CONF="/etc/krill.conf"
+KRILL_HOME="/var/lib/krill/"
+KRILL_DATA="${KRILL_HOME}data/"
+KRILL_USER="krill"
+
+create_user() {
+    if id ${KRILL_USER} > /dev/null 2>&1; then return; fi
+    adduser --system --home "${KRILL_HOME}" --group ${KRILL_USER}
+}
+
+generate_password() {
+    # Tries not to depend on too many other commmands
+    # being installed.
+    date | md5sum | awk '{print $1}'
+}
+
+create_first_time_configuration() {
+    if [ ! -f "${KRILL_CONF}" ]; then
+        # generate a token for authenticating with Krill
+        GENERATED_TOKEN="$(generate_password)"
+
+        # generate a config file using our preferred filesystem locations
+        # and generated token
+        # note: we don't configure Krill to store its PID file under /var/run/
+        # because that requires root privileges potentially at least once per
+        # boot, and Krill doesn't drop privileges yet so when run as a non-root
+        # user has no right to create the file or missing /var/run/subdir.
+        # See: https://stackoverflow.com/a/28312577
+        krillc config simple \
+            --data "${KRILL_DATA}" \
+            --token "${GENERATED_TOKEN}" |
+            sed -e "s|^\(### log_type.\+\)|\1\nlog_type = \"syslog\"|" \
+                > "${KRILL_CONF}"
+    fi
+}
+
+case "$1" in
+configure)
+    create_user
+    create_first_time_configuration
+    ;;
+esac

--- a/debian/scripts/postrm
+++ b/debian/scripts/postrm
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+KRILL_CONF="/etc/krill.conf"
+
+case "$1" in
+purge)
+    # Per https://www.debian.org/doc/debian-policy/ch-files.html#behavior
+    # "configuration files must be preserved when the package is removed, and
+    #  only deleted when the package is purged."
+    if [ -f ${KRILL_CONF} ]; then
+        rm ${KRILL_CONF}
+    fi
+    ;;
+esac

--- a/debian/scripts/prerm
+++ b/debian/scripts/prerm
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+# lintian warns maintainer-script-calls-systemctl.
+# at https://lintian.debian.org/tags/maintainer-script-calls-systemctl.html it
+# explains that deb-systemd-helper should be used instead, but we are not using 
+# debhelper, we are using cargo-deb, so we have to manage systemd ourselves.
+uninstall_service_unit() {
+    if systemctl is-enabled krill.service >/dev/null; then
+        systemctl disable --now krill.service
+    fi
+}
+
+case "$1" in
+remove|purge)
+  uninstall_service_unit
+  ;;
+esac

--- a/doc/krill.1
+++ b/doc/krill.1
@@ -1,0 +1,41 @@
+.TH "krill" "1" "June 23, 2020" "NLnet Labs" "krill 0.6.3"
+.SH NAME
+krill - Resource Public Key Infrastructure (RPKI) daemon
+.SH SYNOPSIS
+krill -c, --config <FILE>
+
+krill -h, --help
+
+krill -V, --version
+.SH DESCRIPTION
+Krill is a free, open source RPKI Certificate Authority that lets you run
+delegated RPKI under one or multiple Regional Internet Registries (RIRs). 
+Through its built-in publication server, Krill can publish Route Origin
+Authorisations (ROAs) on your own servers or with a third party.
+
+This manual page documents the krill daemon.
+
+For more information please consult the online documentation at:
+    https://rpki.readthedocs.io/en/latest/krill/
+
+.SH OPTIONS
+The available options are:
+
+.TP
+.BI -c,\ --config\ <FILE>
+Specify the path to the config file to load. If no file is specified, default
+values will be used for all settings.
+
+.TP
+.BI -h,\ --help
+Prints help information.
+
+.TP
+.BI -V,\ --version
+Prints version information.
+.SH CONFIGURATION FILE
+A sample configuration file showing the default values used by Krill can be
+found at:
+  /usr/share/doc/krill/krill.conf
+.SH SEE ALSO
+krillc(1), https://rpki.readthedocs.io/en/latest/krill/

--- a/doc/krillc.1
+++ b/doc/krillc.1
@@ -1,0 +1,29 @@
+.TH "krillc" "1" "June 23, 2020" "NLnet Labs" "krillc 0.6.3"
+.SH NAME
+krillc - Command line client for the Krill RPKI daemon
+.SH SYNOPSIS
+krillc [SUBCOMMAND]
+
+krillc help [SUBCOMMAND]
+
+krill -h, --help
+
+krill -V, --version
+.SH DESCRIPTION
+Krill is a free, open source RPKI Certificate Authority that lets you run
+delegated RPKI under one or multiple Regional Internet Registries (RIRs). 
+Through its built-in publication server, Krill can publish Route Origin
+Authorisations (ROAs) on your own servers or with a third party.
+
+This manual page documents the krillc comand line interface that interacts with
+a krill daemon.
+
+For more information on the extensive set of subcommands
+supported by krillc please consult the online documentation at:
+    https://rpki.readthedocs.io/en/latest/krill/cli.html
+
+The command line client also has built-in help which can be accessed like so:
+    krillc help [SUBCOMMAND]
+
+.SH SEE ALSO
+krill(1)


### PR DESCRIPTION
- Builds for Ubuntu 16.04, 18.04, 20.04 and Debian 9 and 10.
- Includes basic man pages for `krill` and `krillc`.
- Creates a krill user and a systemd (disabled) service with a krill config file generated by `krillc config simple` but with `log_type=syslog` and a generated token.
- Assumes that the target system has ca-certificates installed already.
- Vendor OpenSSL to support Ubuntu 16.04 which only has OpenSSL 1.0.0.
- Use GH caching to avoid repeat compilation of unchanging cargo deb and krill dependencies.
- Build in Docker containers as GH runners have too many non-standard packages and libraries pre-installed.
- Sanity check the created DEB in targeted O/S versions via LXC/LXD containers (for systemd support).