### PR TITLE
Proper pkg naming

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -148,7 +148,7 @@ jobs:
           debian:10)    OS_REL=buster ;;
           *)            echo 2>&1 "ERROR: Unexpected matrix image"; exit 1 ;;
         esac
-        DEB_VER="krill_${KRILL_VER}-1${OS_REL}_amd64"
+        DEB_VER="${KRILL_VER}-1${OS_REL}"
         cargo deb --variant $DEB_NAME --deb-version $DEB_VER
       env:
         MATRIX_IMAGE: ${{ matrix.image }}

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -126,7 +126,30 @@ jobs:
     # in Cargo.toml for the specified "variant".
     - name: Create the DEB package
       run: |
-        cargo deb --variant $DEB_NAME
+        # Packages for different distributions (e.g. Stretch, Buster) of the same
+        # O/S (e.g. Debian) when served from a single package repository MUST have
+        # unique package_ver_architecture triples. Cargo deb can vary the name based
+        # on the 'variant' config section in use, but doesn't do so according to
+        # Debian policy (as it modifies the package name, not the package version).
+        #   Format: package_ver_architecture
+        #   Where ver has format: [epoch:]upstream_version[-debian_revision]
+        #   And debian_version should be of the form: 1<xxx>
+        #   Where it is common to set <xxx> to the O/S name.
+        # See:
+        #   - https://unix.stackexchange.com/a/190899
+        #   - https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+        # Therefore we generate the version ourselves.
+        KRILL_VER=$(cargo read-manifest | jq -r '.version')
+        case ${MATRIX_IMAGE} in
+          ubuntu:16.04) OS_REL=xenial ;;
+          ubuntu:18.04) OS_REL=bionic ;;
+          ubuntu:20.04) OS_REL=focal ;;
+          debian:9)     OS_REL=stretch ;;
+          debian:10)    OS_REL=buster ;;
+          *)            echo 2>&1 "ERROR: Unexpected matrix image"; exit 1 ;;
+        esac
+        DEB_VER="krill_${KRILL_VER}-1${OS_REL}_amd64"
+        cargo deb --variant $DEB_NAME --deb-version $DEB_VER
 
     # Upload the produced DEB package. The artifact will be available
     # via the GH Actions job summary and build log pages, but only to

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -150,6 +150,8 @@ jobs:
         esac
         DEB_VER="krill_${KRILL_VER}-1${OS_REL}_amd64"
         cargo deb --variant $DEB_NAME --deb-version $DEB_VER
+      env:
+        MATRIX_IMAGE: ${{ matrix.image }}
 
     # Upload the produced DEB package. The artifact will be available
     # via the GH Actions job summary and build log pages, but only to

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -92,7 +92,7 @@ jobs:
 
     - name: Install compilation dependencies
       run: |
-          apt-get install -y build-essential libssl-dev pkg-config
+          apt-get install -y build-essential jq libssl-dev pkg-config
       env:
         DEBIAN_FRONTEND: noninteractive
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ static-openssl = [ "openssl/vendored" ]
 #   - https://www.debian.org/doc/debian-policy/ch-files.html#behavior
 #   - .github/workflows/pkg.yml
 [package.metadata.deb]
+name = "krill"
 priority = "optional"
 section = "net"
 extended-description-file = "debian/description.txt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ static-openssl = [ "openssl/vendored" ]
 #   - https://www.debian.org/doc/debian-policy/ch-files.html#behavior
 #   - .github/workflows/pkg.yml
 [package.metadata.deb]
-name = "krill"
 priority = "optional"
 section = "net"
 extended-description-file = "debian/description.txt"


### PR DESCRIPTION
These GitHub Actions Workflow changes ensure that packages for different releases of the same O/S (e.g. Debian or Ubuntu) are unique in their name/version/arch triple, as required by [Debian policy](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version) and enforced by [Aptly](http://aptly.info/) when managing a conforming repo.

Without these changes we cannot store the different flavours of Krill DEB that we produced on master for Krill v0.7.1 in a policy compliant APT repo server as the triples of the 5 different packages (Ubuntu 16.04/18.04.20.04 and Debian 9/10) are all the same. These physically cannot be stored in a policy compliant repo because the packages are stored by unique triplet in a common 'pool' directory irrespective of which 'distribution' they are served for (e.g. 16.04 or 18.04) and so conflict with or overwrite each other if the triplet is the same for each package.

The packages produced can safely be installed by users who already previously installed the packages created for Krill v0.7.1 from master, doing so will treat the installation as an upgrade and if done using a repo URL the users can then in future do `apt update` to get the newest version (assumes that we publish the created DEBs to a repo server of course).

As a proof-of-concept the packages already produced by this branch have been published to the PoC repo server.