### PR TITLE
Make the .deb copyright file compliant with Debian Policy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ name = "krill"
 priority = "optional"
 section = "net"
 extended-description-file = "debian/description.txt"
+license-file = ["LICENSE", "0"]
 maintainer-scripts = "debian/scripts/"
 depends = "$auto, adduser, libssl1.1"
 


### PR DESCRIPTION
Without license-file the generated copyright file does not contain a "verbatim copy of its copyright information" as per https://www.debian.org/doc/debian-policy/ch-docs.html#copyright-information.