### PR TITLE
Expose Krill server major.minor.patch version as gauge metrics

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,7 @@
-pub const KRILL_VERSION: &str = "0.8.0-RC-dev";
+pub const KRILL_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const KRILL_VERSION_MAJOR: &str = env!("CARGO_PKG_VERSION_MAJOR");
+pub const KRILL_VERSION_MINOR: &str = env!("CARGO_PKG_VERSION_MINOR");
+pub const KRILL_VERSION_PATCH: &str = env!("CARGO_PKG_VERSION_PATCH");
 pub const KRILL_SERVER_APP: &str = "Krill";
 pub const KRILL_CLIENT_APP: &str = "Krill Client";
 

--- a/src/daemon/http/server.rs
+++ b/src/daemon/http/server.rs
@@ -28,6 +28,7 @@ use crate::commons::error::Error;
 use crate::commons::remote::rfc8183;
 use crate::commons::util::file;
 use crate::constants::KRILL_ENV_UPGRADE_ONLY;
+use crate::constants::{KRILL_VERSION_MAJOR, KRILL_VERSION_MINOR, KRILL_VERSION_PATCH};
 use crate::daemon::config::CONFIG;
 use crate::daemon::http::statics::statics;
 use crate::daemon::http::{tls, tls_keys, HttpResponse, Request, RequestPath, RoutingResult};
@@ -218,6 +219,21 @@ pub async fn metrics(req: Request) -> RoutingResult {
         res.push_str("# HELP krill_server_start timestamp of last krill server start\n");
         res.push_str("# TYPE krill_server_start gauge\n");
         res.push_str(&format!("krill_server_start {}\n", info.started()));
+        res.push_str("\n");
+
+        res.push_str("# HELP krill_version_major krill server major version number\n");
+        res.push_str("# TYPE krill_version_major gauge\n");
+        res.push_str(&format!("krill_version_major {}\n", KRILL_VERSION_MAJOR));
+        res.push_str("\n");
+
+        res.push_str("# HELP krill_version_minor krill server minor version number\n");
+        res.push_str("# TYPE krill_version_minor gauge\n");
+        res.push_str(&format!("krill_version_minor {}\n", KRILL_VERSION_MINOR));
+        res.push_str("\n");
+
+        res.push_str("# HELP krill_version_patch krill server patch version number\n");
+        res.push_str("# TYPE krill_version_patch gauge\n");
+        res.push_str(&format!("krill_version_patch {}\n", KRILL_VERSION_PATCH));
         res.push_str("\n");
 
         if let Ok(stats) = server.repo_stats() {


### PR DESCRIPTION
Note: also changes the initialisation of the `KRILL_VERSION` constant to use Cargo compile-time environment variable [`CARGO_PKG_VERSION`](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates) because then using the similar `_MAJOR`, `_MINOR` and `_PATCH` compile-time env vars is easy.

The alternative is to use something like [`std::sync::Once` ](https://doc.rust-lang.org/std/sync/struct.Once.html) and [`semver_parser::version::parse()`](https://docs.rs/semver-parser/0.9.0/semver_parser/version/fn.parse.html) which is overkill when the values are available during compilation as Cargo env vars AND that removes the need to manually keep the constant in sync with the Cargo.toml version key value.

With this PR the following metric output is added:

```
# HELP krill_version_major krill server major version number
# TYPE krill_version_major gauge
krill_version_major 0

# HELP krill_version_minor krill server minor version number
# TYPE krill_version_minor gauge
krill_version_minor 8

# HELP krill_version_patch krill server patch version number
# TYPE krill_version_patch gauge
krill_version_patch 0
```