### PR TITLE
Support 'pre-release' build labels in .deb packages

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -60,6 +60,9 @@ jobs:
         ]
     env:
       CARGO_DEB_VER: 1.23.1
+      # A Krill version of the form 'x.y.z-plus' denotes a dev build that is
+      # newer than the released x.y.z version but is not yet a new release.
+      NEXT_VER_LABEL: plus
     name: deb-pkg
     runs-on: ubuntu-latest
     # Build on the oldest platform we are targeting in order to avoid
@@ -142,6 +145,7 @@ jobs:
         # See:
         #   - https://unix.stackexchange.com/a/190899
         #   - https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
+        #   - https://readme.phys.ethz.ch/documentation/debian_version_numbers/
         # Therefore we generate the version ourselves.
         #
         # In addition, Semantic Versioning and Debian version policy cannot
@@ -150,7 +154,13 @@ jobs:
         # Debian package version 0.8.0-rc.1 would be considered _NEWER_ than
         # the final 0.8.0 release. To express this in a Debian compatible way we
         # must replace the dash '-' with a tilda '~'.
+        #
+        # Finally, sometimes we want a version to be NEWER than the latest
+        # release but without having to decide what higher semver number to bump
+        # to. In this case we do NOT want dash '-' to become '~' because `-`
+        # is treated as higher and tilda is treated as lower.
         KRILL_VER=$(cargo read-manifest | jq -r '.version' | tr '-' '~')
+        KRILL_VER=$(echo $KRILL_VER | sed -e "s/~$NEXT_VER_LABEL/-$NEXT_VER_LABEL/")
         case ${MATRIX_IMAGE} in
           ubuntu:16.04) OS_REL=xenial ;;
           ubuntu:18.04) OS_REL=bionic ;;

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -356,21 +356,8 @@ jobs:
         echo -e "\nKRILL DATA DIR:"
         sg lxd -c "lxc exec testcon -- ls -la /var/lib/krill"
 
-        echo -e "\nKRILL SERVICE STATUS BEFORE ENABLE:"
+        echo -e "\nKRILL SERVICE STATUS:"
         sg lxd -c "lxc exec testcon -- systemctl status krill || true"
-
-        echo -e "\nENABLE KRILL SERVICE:"
-        sg lxd -c "lxc exec testcon -- systemctl enable krill"
-
-        echo -e "\nKRILL SERVICE STATUS AFTER ENABLE:"
-        sg lxd -c "lxc exec testcon -- systemctl status krill || true"
-
-        echo -e "\nSTART KRILL SERVICE:"
-        sg lxd -c "lxc exec testcon -- systemctl start krill"
-        
-        echo -e "\nKRILL SERVICE STATUS AFTER START:"
-        sleep 1s
-        sg lxd -c "lxc exec testcon -- systemctl status krill"
 
         echo -e "\nKRILL MAN PAGE:"
         sg lxd -c "lxc exec testcon -- man -P cat krill"

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -240,9 +240,9 @@ jobs:
         # namespacing: Permission denied" in a Debian 10 container.
         sg lxd -c "lxc launch $LXC_IMAGE -c security.nesting=true testcon"
 
-    # Run apt-get update and install man support (missing in some LXC/LXD O/S
-    # images) but first wait for cloud-init to finish otherwise the network
-    # isn't yet ready.
+    # Run apt-get update and install packages missing in some O/S images that
+    # are needed by later steps, but first wait for cloud-init to finish
+    # otherwise the network isn't yet ready.
     - name: Prepare container
       shell: bash
       run: |
@@ -270,7 +270,7 @@ jobs:
           sleep 1s
         done
         sg lxd -c "lxc exec testcon -- apt-get update"
-        sg lxd -c "lxc exec testcon -- apt-get install -y man"
+        sg lxd -c "lxc exec testcon -- apt-get install -y apt-transport-https gnupg2 man wget"
 
     - name: Copy DEB into LXC container
       run: |

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -195,6 +195,9 @@ jobs:
           - 'ubuntu:20.04'
           - 'debian:9'
           - 'debian:10'
+        mode:
+          - 'fresh-install'
+          - 'upgrade-from-published'
     steps:
     # Set some environment variables that will be available to "run" steps below
     # in this job, and some output variables that will be available in GH Action
@@ -275,11 +278,70 @@ jobs:
         echo ::set-env name=DEB_FILE::$DEB_FILE
         sg lxd -c "lxc file push ${DEB_FILE} testcon/tmp/"
 
-    - name: Install DEB package
+    - name: Install published DEB package
+      if: ${{ matrix.mode == 'upgrade-from-published' }}
+      run: |
+        case ${MATRIX_IMAGE} in
+          ubuntu:16.04) OS=ubuntu; OS_REL=xenial ;;
+          ubuntu:18.04) OS=ubuntu; OS_REL=bionic ;;
+          ubuntu:20.04) OS=ubuntu; OS_REL=focal ;;
+          debian:9)     OS=debian; OS_REL=stretch ;;
+          debian:10)    OS=debian; OS_REL=buster ;;
+          *)            echo 2>&1 "ERROR: Unexpected matrix image"; exit 1 ;;
+        esac
+        echo "deb [arch=amd64] https://packages.nlnetlabs.nl/linux/${OS}/ ${OS_REL} main" >$HOME/nlnetlabs.list
+        sg lxd -c "lxc file push $HOME/nlnetlabs.list testcon/etc/apt/sources.list.d/"
+        sg lxd -c "lxc exec testcon -- wget -qO- https://packages.nlnetlabs.nl/aptkey.asc | apt-key add -"
+        sg lxd -c "lxc exec testcon -- apt update"
+        sg lxd -c "lxc exec testcon -- apt install -y krill"
+      env:
+        MATRIX_IMAGE: ${{ matrix.image }}
+
+    - name: Install new DEB package
+      if: ${{ matrix.mode == 'fresh-install' }}
       run: |
         sg lxd -c "lxc exec testcon -- apt-get -y install /tmp/$DEB_FILE"
 
     - name: Test installed packages
+      run: |
+        echo -e "\nKRILLC VERSION:"
+        sg lxd -c "lxc exec testcon -- krillc --version"
+
+        echo -e "\nKRILL VERSION:"
+        sg lxd -c "lxc exec testcon -- krill --version"
+
+        echo -e "\nKRILL CONF:"
+        sg lxd -c "lxc exec testcon -- cat /etc/krill.conf"
+
+        echo -e "\nKRILL DATA DIR:"
+        sg lxd -c "lxc exec testcon -- ls -la /var/lib/krill"
+
+        echo -e "\nKRILL SERVICE STATUS BEFORE ENABLE:"
+        sg lxd -c "lxc exec testcon -- systemctl status krill || true"
+
+        echo -e "\nENABLE KRILL SERVICE:"
+        sg lxd -c "lxc exec testcon -- systemctl enable krill"
+
+        echo -e "\nKRILL SERVICE STATUS AFTER ENABLE:"
+        sg lxd -c "lxc exec testcon -- systemctl status krill || true"
+
+        echo -e "\nSTART KRILL SERVICE:"
+        sg lxd -c "lxc exec testcon -- systemctl start krill"
+        
+        echo -e "\nKRILL SERVICE STATUS AFTER START:"
+        sleep 1s
+        sg lxd -c "lxc exec testcon -- systemctl status krill"
+
+        echo -e "\nKRILL MAN PAGE:"
+        sg lxd -c "lxc exec testcon -- man -P cat krill"
+
+    - name: Install new DEB package
+      if: ${{ matrix.mode == 'upgrade-from-published' }}
+      run: |
+        sg lxd -c "lxc exec testcon -- apt-get -y install /tmp/$DEB_FILE"
+
+    - name: Test installed packages
+      if: ${{ matrix.mode == 'upgrade-from-published' }}
       run: |
         echo -e "\nKRILLC VERSION:"
         sg lxd -c "lxc exec testcon -- krillc --version"

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -291,7 +291,8 @@ jobs:
         esac
         echo "deb [arch=amd64] https://packages.nlnetlabs.nl/linux/${OS}/ ${OS_REL} main" >$HOME/nlnetlabs.list
         sg lxd -c "lxc file push $HOME/nlnetlabs.list testcon/etc/apt/sources.list.d/"
-        sg lxd -c "lxc exec testcon -- wget -qO- https://packages.nlnetlabs.nl/aptkey.asc | apt-key add -"
+        sg lxd -c "lxc exec testcon -- wget -q https://packages.nlnetlabs.nl/aptkey.asc"
+        sg lxd -c "lxc exec testcon -- apt-key add ./aptkey.asc"
         sg lxd -c "lxc exec testcon -- apt update"
         sg lxd -c "lxc exec testcon -- apt install -y krill"
       env:

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -143,7 +143,14 @@ jobs:
         #   - https://unix.stackexchange.com/a/190899
         #   - https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
         # Therefore we generate the version ourselves.
-        KRILL_VER=$(cargo read-manifest | jq -r '.version')
+        #
+        # In addition, Semantic Versioning and Debian version policy cannot
+        # express a pre-release label in the same way. For example 0.8.0-rc.1
+        # is a valid Cargo.toml [package].version value but when used as a
+        # Debian package version 0.8.0-rc.1 would be considered _NEWER_ than
+        # the final 0.8.0 release. To express this in a Debian compatible way we
+        # must replace the dash '-' with a tilda '~'.
+        KRILL_VER=$(cargo read-manifest | jq -r '.version' | tr '-' '~')
         case ${MATRIX_IMAGE} in
           ubuntu:16.04) OS_REL=xenial ;;
           ubuntu:18.04) OS_REL=bionic ;;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "krill"
-version = "0.7.3"
+version = "0.7.3-plus"
 dependencies = [
  "base64 0.10.1",
  "bcder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Note: some of these values are also used when building Debian packages below.
 name    = "krill"
-version = "0.7.3-test.1"
+version = "0.7.4-test.1"
 edition = "2018"
 authors = [ "The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>" ]
 description = "Resource Public Key Infrastructure (RPKI) daemon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Note: some of these values are also used when building Debian packages below.
 name    = "krill"
-version = "0.7.3"
+version = "0.7.3-plus"
 edition = "2018"
 authors = [ "The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>" ]
 description = "Resource Public Key Infrastructure (RPKI) daemon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Note: some of these values are also used when building Debian packages below.
 name    = "krill"
-version = "0.7.3"
+version = "0.7.3-test.1"
 edition = "2018"
 authors = [ "The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>" ]
 description = "Resource Public Key Infrastructure (RPKI) daemon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Note: some of these values are also used when building Debian packages below.
 name    = "krill"
-version = "0.7.4-test.1"
+version = "0.7.3"
 edition = "2018"
 authors = [ "The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>" ]
 description = "Resource Public Key Infrastructure (RPKI) daemon"

--- a/debian/scripts/postinst
+++ b/debian/scripts/postinst
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 KRILL_CONF="/etc/krill.conf"
 KRILL_HOME="/var/lib/krill/"

--- a/debian/scripts/postrm
+++ b/debian/scripts/postrm
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 KRILL_CONF="/etc/krill.conf"
 

--- a/debian/scripts/prerm
+++ b/debian/scripts/prerm
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 # lintian warns maintainer-script-calls-systemctl.
 # at https://lintian.debian.org/tags/maintainer-script-calls-systemctl.html it

--- a/doc/krillc.1
+++ b/doc/krillc.1
@@ -15,7 +15,7 @@ delegated RPKI under one or multiple Regional Internet Registries (RIRs).
 Through its built-in publication server, Krill can publish Route Origin
 Authorisations (ROAs) on your own servers or with a third party.
 
-This manual page documents the krillc comand line interface that interacts with
+This manual page documents the krillc command line interface that interacts with
 a krill daemon.
 
 For more information on the extensive set of subcommands

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,4 @@
-pub const KRILL_VERSION: &str = "0.7.3";
+pub const KRILL_VERSION: &str = "0.7.3-test.1";
 pub const KRILL_SERVER_APP: &str = "Krill";
 pub const KRILL_CLIENT_APP: &str = "Krill Client";
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,4 @@
-pub const KRILL_VERSION: &str = "0.7.3-test.1";
+pub const KRILL_VERSION: &str = "0.7.4-test.1";
 pub const KRILL_SERVER_APP: &str = "Krill";
 pub const KRILL_CLIENT_APP: &str = "Krill Client";
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,4 @@
-pub const KRILL_VERSION: &str = "0.7.4-test.1";
+pub const KRILL_VERSION: &str = "0.7.3";
 pub const KRILL_SERVER_APP: &str = "Krill";
 pub const KRILL_CLIENT_APP: &str = "Krill Client";
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,4 @@
-pub const KRILL_VERSION: &str = "0.7.3";
+pub const KRILL_VERSION: &str = "0.7.3-plus";
 pub const KRILL_SERVER_APP: &str = "Krill";
 pub const KRILL_CLIENT_APP: &str = "Krill Client";
 


### PR DESCRIPTION
Correctly handle dashes in the Krill version number so that 'pre-release' 'tags' appended to the version number do not cause the package to be considered newer than a final untagged version number.