### PR TITLE
Small fixes for the openapi specification

### DIFF
--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -890,7 +890,7 @@ paths:
         '403':
           $ref: '#/components/responses/Forbidden'
 
-  /bulk/cas/sync/parents:
+  /bulk/cas/sync/parent:
     post:
       operationId: refresh_all_cas
       tags:
@@ -1117,7 +1117,7 @@ components:
       type: object
       properties:
         asn:
-          type: string
+          type: integer
         prefix:
           type: string
         max_length:


### PR DESCRIPTION
These couple of issues in the openapi specification were found when we used the [openapi-generator](https://github.com/openapitools/openapi-generator/) to generate client code to interact with the Krill REST API.

The `/bulk/cas/sync/parent` path on the server side is defined in [src/daemon/http/server.rs](https://github.com/NLnetLabs/krill/blob/ef7274bd73a8e24bf8c1732f06905fbca273bd06/src/daemon/http/server.rs#L546).

The issue with the ASN was found when we tried to make modifications to authorizations through the API. Krill won't accept ASNs provided as JSON strings, most likely due to the [AsNumber](https://github.com/NLnetLabs/krill/blob/ef7274bd73a8e24bf8c1732f06905fbca273bd06/src/commons/api/roas.rs#L613) type define in (RoaDefinition)[https://github.com/NLnetLabs/krill/blob/ef7274bd73a8e24bf8c1732f06905fbca273bd06/src/commons/api/roas.rs#L116).