### PR TITLE
Add SessionStatus::NeedsRefresh to status check

### DIFF
--- a/src/daemon/auth/providers/openid_connect/provider.rs
+++ b/src/daemon/auth/providers/openid_connect/provider.rs
@@ -591,9 +591,12 @@ impl AuthProvider for OpenIDConnectAuthProvider {
                 let status = session.status();
 
                 let mut new_auth = None;
+                if log_enabled!(log::Level::Trace) {
+                    trace!("Status: {:?}", status);
+                }
                 if status != SessionStatus::Active {
                     new_auth = self.try_refresh_token(&session);
-                    if new_auth.is_none() && status == SessionStatus::Expired {
+                    if new_auth.is_none() && (status == SessionStatus::Expired || status == SessionStatus::NeedsRefresh) {
                         return Err(Error::ApiInvalidCredentials(
                             "Session expired, please login again".to_string(),
                         ));


### PR DESCRIPTION
Since the try\_refresh\_token return None if the Session can't be extended, we can safely add the condition SessionStatus::NeedsRefresh here.

This is sort of the future-proof version of this conditional check (I realise that right now, the whole conditional that deals with the SessionStatus variant can be removed here (since there's only three variants). As such this PR is a reminder, not a suggestion for the final code.