### PR TITLE
Run functional and UI tests in non-multi-user mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         rust: [stable, 1.45.0, beta]
-        args: ["", "--all-features"] 
+        args: ["--features functional-tests,ui-tests", "--all-features"] 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1


### PR DESCRIPTION
Without this we only run tests that are hidden behind the `functional-tests` and `ui-tests` feature flags when also enabling the `multi-user` feature flag. As the `multi-user` feature code makes (in theory non-breaking) changes to the authenticate and authorisation logic in Krill, and as these tests help validate the version of the code that most users will run (especially those who use a binary release such as the Docker image or DEB package as then the feature set is predetermined and cannot be changed), it would be good to make sure we run them before we release this branch.

Note: while most of the tests in the `ui-tests` feature are only enabled if the `multi-user` feature is also active, there is one UI test for the master token mode which is worth running even if the `multi-user` feature is disabled.