### PR TITLE
Use strongly typed permissions in policy rules.

### DIFF
--- a/defaults/aliases.polar
+++ b/defaults/aliases.polar
@@ -7,7 +7,7 @@
 # role to the name "Read Only" and does a quick sanity check to show that it
 # works.
 #
-# role_allow("Read Only", action, resource) if
+# role_allow("Read Only", action: Permission, resource) if
 #     role_allow("readonly", action, resource);
 #
-# ?= role_allow("Read Only", "CA_LIST", _);
+# ?= role_allow("Read Only", new Permission("CA_LIST"), _);

--- a/defaults/roles.polar
+++ b/defaults/roles.polar
@@ -25,16 +25,19 @@
 # are able to authenticate but for whom no role mapping exists, will not be
 # permitted to login to the UI or to use the REST API.
 #
-role_allow(some_role, "LOGIN", _) if
-    not some_role = nil;
+
+# TODO: Oso maps to Option::<T>::None in Rust, but role_allow is only ever called
+# with an instance of Actor, not with an Option, so this won't match?
+role_allow(some_role, action: Permission, _) if
+    not some_role = nil and action = new Permission("LOGIN");
 
 ### TEST: [
 # Actors with a role can login.
-?= role_allow("some role", "LOGIN", _);
+?= role_allow("some role", new Permission("LOGIN"), _);
 # Conversely, actors without a role cannot do anything.
-?= not role_allow(nil, "LOGIN", _);
+?= not role_allow(nil, new Permission("LOGIN"), _);
 ?= not role_allow(nil, nil, nil);
-?= not role_allow(nil, _, _);
+# ?= not role_allow(nil, _, _);
 ### ]
 
 
@@ -43,58 +46,56 @@ role_allow(some_role, "LOGIN", _) if
 role_allow("admin", _action, _resource);
 
 ### TEST: [
-?= role_allow("admin", _, _);
+# ?= role_allow("admin", _, _);
 ?= role_allow("admin", "take over", "the world");
 ?= not role_allow("other", "take over", "the world");
-?= role_allow("admin", "CA_CREATE", "/api/v1/cas");
+?= role_allow("admin", new Permission("CA_CREATE"), "/api/v1/cas");
 ### ]
 
 
 # The readonly role has the following rights:
 # -------------------------------------------
-role_allow("readonly", action, _resource) if
+role_allow("readonly", action: Permission, _resource) if
     action in [
-        "CA_LIST",
-        "CA_READ",
-        "PUB_LIST",
-        "PUB_READ",
-        "ROUTES_READ",
-        "ROUTES_ANALYSIS"
+        new Permission("CA_LIST"),
+        new Permission("CA_READ"),
+        new Permission("PUB_LIST"),
+        new Permission("PUB_READ"),
+        new Permission("ROUTES_READ"),
+        new Permission("ROUTES_ANALYSIS")
     ];
 
 ### TEST: [
-?= role_allow("readonly", "CA_LIST", _);
-?= role_allow("readonly", "CA_READ", "some resource");
-?= not role_allow("readonly", "CA_CREATE", _);
-?= not role_allow("readonly", "CA_CREATE", "some resource");
+?= role_allow("readonly", new Permission("CA_LIST"), _);
+?= role_allow("readonly", new Permission("CA_READ"), "some resource");
+?= not role_allow("readonly", new Permission("CA_CREATE"), _);
+?= not role_allow("readonly", new Permission("CA_CREATE"), "some resource");
 # etc
 ### ]
 
 
 # The readwrite role has the following rights:
 # --------------------------------------------
-role_allow("readwrite", action, _resource) if
+role_allow("readwrite", action: Permission, _resource) if
     action in [
-        "CA_LIST",
-        "CA_READ",
-        "CA_CREATE",
-        "CA_UPDATE",
-        "PUB_LIST",
-        "PUB_READ",
-        "PUB_CREATE",
-        "PUB_UPDATE",
-        "PUB_DELETE",
-        "ROUTES_READ",
-        "ROUTES_ANALYSIS",
-        "ROUTES_UPDATE",
-        "ROUTES_TRY_UPDATE"
+        new Permission("CA_LIST"),
+        new Permission("CA_READ"),
+        new Permission("CA_CREATE"),
+        new Permission("CA_UPDATE"),
+        new Permission("PUB_LIST"),
+        new Permission("PUB_READ"),
+        new Permission("PUB_CREATE"),
+        new Permission("PUB_DELETE"),
+        new Permission("ROUTES_READ"),
+        new Permission("ROUTES_ANALYSIS"),
+        new Permission("ROUTES_UPDATE")
     ];
 
 ### TEST: [
-?= role_allow("readwrite", "CA_LIST", _);
-?= role_allow("readwrite", "CA_READ", "some resource");
-?= role_allow("readwrite", "CA_CREATE", _);
-?= role_allow("readwrite", "CA_CREATE", "some resource");
+?= role_allow("readwrite", new Permission("CA_LIST"), _);
+?= role_allow("readwrite", new Permission("CA_READ"), "some resource");
+?= role_allow("readwrite", new Permission("CA_CREATE"), _);
+?= role_allow("readwrite", new Permission("CA_CREATE"), "some resource");
 # etc
 ### ]
 
@@ -104,20 +105,20 @@ role_allow("readwrite", action, _resource) if
 # Note: The testbed role is a special case which is automatically assigned
 # temporarily to anonymous users accessing the testbed UI/API. It should not be
 # used outside of this file.
-role_allow("testbed", action, _resource) if
+role_allow("testbed", action: Permission, _resource) if
     action in [
-        "CA_READ",
-        "CA_UPDATE",
-        "PUB_READ",
-        "PUB_CREATE",
-        "PUB_DELETE",
-        "PUB_ADMIN"
+        new Permission("CA_READ"),
+        new Permission("CA_UPDATE"),
+        new Permission("PUB_READ"),
+        new Permission("PUB_CREATE"),
+        new Permission("PUB_DELETE"),
+        new Permission("PUB_ADMIN")
     ];
 
 ### TEST: [
-?= role_allow("testbed", "CA_READ", _);
-?= role_allow("testbed", "CA_UPDATE", "some resource");
-?= role_allow("testbed", "PUB_ADMIN", _);
-?= not role_allow("testbed", "ROUTES_UPDATE", _);
+?= role_allow("testbed", new Permission("CA_READ"), _);
+?= role_allow("testbed", new Permission("CA_UPDATE"), "some resource");
+?= role_allow("testbed", new Permission("PUB_ADMIN"), _);
+?= not role_allow("testbed", new Permission("ROUTES_UPDATE"), _);
 # etc
 ### ]

--- a/defaults/rules.polar
+++ b/defaults/rules.polar
@@ -16,14 +16,14 @@
 
 # Verify that the given actor has the required role to perform the requested
 # action on the given relative API request path.
-allow(actor: Actor, action, resource: RequestPath) if
+allow(actor: Actor, action: Permission, resource: RequestPath) if
     actor_has_role(actor, role) and
     role_allow(role, action, resource);
 
 ### TEST: [
 # Sanity check: verify that the built-in master-token test actor can login.
 # Exercises the rules above.
-?= allow(Actor.builtin("master-token"), "LOGIN", new RequestPath("/"));
+?= allow(Actor.builtin("master-token"), new Permission("LOGIN"), new RequestPath("/"));
 ### ]
 
 
@@ -42,13 +42,13 @@ actor_has_role(actor: Actor, role) if role in actor.attr("role");
 # default access isn't restricted per CA handle, or because the user is neither
 # explicitly or implicitly denied access to the CA or is explicitly granted
 # access to the CA.
-allow(actor: Actor, action, ca: Handle) if
+allow(actor: Actor, action: Permission, ca: Handle) if
     actor_has_role(actor, role) and
     role_allow(role, action, ca) and
     actor_can_access_ca(actor, ca);
 
 ### TEST: [
-?= allow(Actor.builtin("master-token"), "CA_READ", new RequestPath("/"));
+?= allow(Actor.builtin("master-token"), new Permission("CA_READ"), new RequestPath("/"));
 ### ]
 
 

--- a/doc/policies/team-based-access-control.polar
+++ b/doc/policies/team-based-access-control.polar
@@ -45,13 +45,13 @@ team_works_with_ca(team_name, ca: Handle) if team_name = "t2" and ca.name in ["c
 
 # verify admin can list CAs and read and write each CA
 ?= actor_has_role(new Actor("admin", { role: "admin" }), "admin");
-?= allow(new Actor("admin", { role: "admin" }), "CA_LIST", new RequestPath("/"));
-?= allow(new Actor("admin", { role: "admin" }), "CA_READ", new Handle("ca1"));
-?= allow(new Actor("admin", { role: "admin" }), "CA_READ", new Handle("ca2"));
-?= allow(new Actor("admin", { role: "admin" }), "CA_READ", new Handle("ca3"));
-?= allow(new Actor("admin", { role: "admin" }), "CA_UPDATE", new Handle("ca1"));
-?= allow(new Actor("admin", { role: "admin" }), "CA_UPDATE", new Handle("ca2"));
-?= allow(new Actor("admin", { role: "admin" }), "CA_UPDATE", new Handle("ca3"));
+?= allow(new Actor("admin", { role: "admin" }), Permission::CA_LIST, new RequestPath("/"));
+?= allow(new Actor("admin", { role: "admin" }), Permission::CA_READ, new Handle("ca1"));
+?= allow(new Actor("admin", { role: "admin" }), Permission::CA_READ, new Handle("ca2"));
+?= allow(new Actor("admin", { role: "admin" }), Permission::CA_READ, new Handle("ca3"));
+?= allow(new Actor("admin", { role: "admin" }), Permission::CA_UPDATE, new Handle("ca1"));
+?= allow(new Actor("admin", { role: "admin" }), Permission::CA_UPDATE, new Handle("ca2"));
+?= allow(new Actor("admin", { role: "admin" }), Permission::CA_UPDATE, new Handle("ca3"));
 
 
 # verify that an actor with a team attribute is considered to be in that team
@@ -62,11 +62,11 @@ team_works_with_ca(team_name, ca: Handle) if team_name = "t2" and ca.name in ["c
 
 
 # verify that team members can login
-?= team_members_can_login(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "LOGIN");
-?= team_members_can_login(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "LOGIN");
+?= team_members_can_login(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::LOGIN);
+?= team_members_can_login(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::LOGIN);
 
-?= team_members_can_login(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "LOGIN");
-?= team_members_can_login(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "LOGIN");
+?= team_members_can_login(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::LOGIN);
+?= team_members_can_login(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::LOGIN);
 
 
 # verify that the teams work with the right CAs
@@ -92,68 +92,68 @@ team_works_with_ca(team_name, ca: Handle) if team_name = "t2" and ca.name in ["c
 # verify that team members can perform only the expected actions on the expected CAs
 # this cannot be tested here, it can only be tested using an Oso query from within Rust
 # after the policy files have been loaded. Or is this an Oso bug?
-?= team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_READ", new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_READ", new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_READ", new Handle("ca3"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca3"));
+?= team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca3"));
 
-?= team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_READ", new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_READ", new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_READ", new Handle("ca3"));
-?= team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca3"));
+?= team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca3"));
+?= team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca3"));
 
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_READ", new Handle("ca1"));
-?= team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_READ", new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_READ", new Handle("ca3"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca1"));
+?= team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca3"));
 
-?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_READ", new Handle("ca1"));
-?= team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_READ", new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_READ", new Handle("ca3"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca1"));
-?= team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca1"));
+?= team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca1"));
+?= team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca3"));
 
 
 # only team members should satisfy a team member specific rule
-?= not team_member_can_perform_action_on_ca(new Actor("admin", {}), "CA_READ", new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("admin", {}), Permission::CA_READ, new Handle("ca1"));
 
 
 # verify from where Oso begins evaluation, at matching allow() rules.
-?= allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_READ", new Handle("ca1"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_READ", new Handle("ca2"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_READ", new Handle("ca3"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca1"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca2"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca3"));
+?= allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca1"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca2"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca3"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca1"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca2"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca3"));
 
-?= allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_READ", new Handle("ca1"));
-?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_READ", new Handle("ca2"));
-?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_READ", new Handle("ca3"));
-?= allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca1"));
-?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca2"));
-?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca3"));
+?= allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca1"));
+?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca2"));
+?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca3"));
+?= allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca1"));
+?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca2"));
+?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca3"));
 
-# verify user t2ur can read ca2 but not ca1 or ca3, and cannot write to them
-?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_READ", new Handle("ca1"));
-?= allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_READ", new Handle("ca2"));
-?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_READ", new Handle("ca3"));
-?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca1"));
-?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca2"));
-?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), "CA_UPDATE", new Handle("ca3"));
+# verify user t2ur can read ca2 but not ca1 or ca3, and cannot write tonew Permission( them
+?= )not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca1"));
+?= allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca2"));
+?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca3"));
+?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca1"));
+?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca2"));
+?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca3"));
 
-?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_READ", new Handle("ca1"));
-?= allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_READ", new Handle("ca2"));
-?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_READ", new Handle("ca3"));
-?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca1"));
-?= allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca2"));
-?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), "CA_UPDATE", new Handle("ca3"));
+?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca1"));
+?= allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca2"));
+?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca3"));
+?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca1"));
+?= allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca2"));
+?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca3"));
 
 
 ###
@@ -176,20 +176,20 @@ team_member_has_role(actor: Actor, role) if
 # Note: This rule cannot be tested in this file because it relies on
 # role_allow() which is not defined in this file. This CAN be tested using an
 # Oso query from within Rust after the policy files have been loaded.
-team_member_can_perform_action_on_ca(actor: Actor, action, ca: Handle) if
+team_member_can_perform_action_on_ca(actor: Actor, action: Permission, ca: Handle) if
     team_member_works_with_ca(actor, ca) and
     role in actor.attr("teamrole") and
     role_allow(role, action, ca);
 
-team_member_can_perform_action_on_resource(actor: Actor, action, resource: RequestPath) if
+team_member_can_perform_action_on_resource(actor: Actor, action: Permission, resource: RequestPath) if
     team_members_can_login(actor, action) or
     (
         team_member_has_role(actor, role) and
         role_allow(role, action, resource)
     );
 
-team_members_can_login(actor: Actor, action) if
-    action = "LOGIN" and
+team_members_can_login(actor: Actor, action: Permission) if
+    action = Permission::LOGIN and
     _ in actor.attr("team") and
     _ in actor.attr("teamrole");
 
@@ -200,9 +200,9 @@ team_members_can_login(actor: Actor, action) if
 ###
 
 
-allow(actor: Actor, action, resource: RequestPath) if
+allow(actor: Actor, action: Permission, resource: RequestPath) if
     team_member_can_perform_action_on_resource(actor, action, resource);
 
 
-allow(actor: Actor, action, ca: Handle) if
+allow(actor: Actor, action: Permission, ca: Handle) if
     team_member_can_perform_action_on_ca(actor, action, ca);

--- a/doc/policies/team-based-access-control.polar
+++ b/doc/policies/team-based-access-control.polar
@@ -45,13 +45,13 @@ team_works_with_ca(team_name, ca: Handle) if team_name = "t2" and ca.name in ["c
 
 # verify admin can list CAs and read and write each CA
 ?= actor_has_role(new Actor("admin", { role: "admin" }), "admin");
-?= allow(new Actor("admin", { role: "admin" }), Permission::CA_LIST, new RequestPath("/"));
-?= allow(new Actor("admin", { role: "admin" }), Permission::CA_READ, new Handle("ca1"));
-?= allow(new Actor("admin", { role: "admin" }), Permission::CA_READ, new Handle("ca2"));
-?= allow(new Actor("admin", { role: "admin" }), Permission::CA_READ, new Handle("ca3"));
-?= allow(new Actor("admin", { role: "admin" }), Permission::CA_UPDATE, new Handle("ca1"));
-?= allow(new Actor("admin", { role: "admin" }), Permission::CA_UPDATE, new Handle("ca2"));
-?= allow(new Actor("admin", { role: "admin" }), Permission::CA_UPDATE, new Handle("ca3"));
+?= allow(new Actor("admin", { role: "admin" }), new Permission("CA_LIST"), new RequestPath("/"));
+?= allow(new Actor("admin", { role: "admin" }), new Permission("CA_READ"), new Handle("ca1"));
+?= allow(new Actor("admin", { role: "admin" }), new Permission("CA_READ"), new Handle("ca2"));
+?= allow(new Actor("admin", { role: "admin" }), new Permission("CA_READ"), new Handle("ca3"));
+?= allow(new Actor("admin", { role: "admin" }), new Permission("CA_UPDATE"), new Handle("ca1"));
+?= allow(new Actor("admin", { role: "admin" }), new Permission("CA_UPDATE"), new Handle("ca2"));
+?= allow(new Actor("admin", { role: "admin" }), new Permission("CA_UPDATE"), new Handle("ca3"));
 
 
 # verify that an actor with a team attribute is considered to be in that team
@@ -62,11 +62,11 @@ team_works_with_ca(team_name, ca: Handle) if team_name = "t2" and ca.name in ["c
 
 
 # verify that team members can login
-?= team_members_can_login(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::LOGIN);
-?= team_members_can_login(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::LOGIN);
+?= team_members_can_login(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("LOGIN"));
+?= team_members_can_login(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("LOGIN"));
 
-?= team_members_can_login(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::LOGIN);
-?= team_members_can_login(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::LOGIN);
+?= team_members_can_login(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("LOGIN"));
+?= team_members_can_login(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("LOGIN"));
 
 
 # verify that the teams work with the right CAs
@@ -92,68 +92,68 @@ team_works_with_ca(team_name, ca: Handle) if team_name = "t2" and ca.name in ["c
 # verify that team members can perform only the expected actions on the expected CAs
 # this cannot be tested here, it can only be tested using an Oso query from within Rust
 # after the policy files have been loaded. Or is this an Oso bug?
-?= team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca3"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca3"));
+?= team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca3"));
 
-?= team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca3"));
-?= team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca3"));
+?= team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca3"));
+?= team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca3"));
 
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca1"));
-?= team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca3"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca1"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca1"));
+?= team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca3"));
 
-?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca1"));
-?= team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca3"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca1"));
-?= team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca2"));
-?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca1"));
+?= team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca3"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca1"));
+?= team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca2"));
+?= not team_member_can_perform_action_on_ca(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca3"));
 
 
 # only team members should satisfy a team member specific rule
-?= not team_member_can_perform_action_on_ca(new Actor("admin", {}), Permission::CA_READ, new Handle("ca1"));
+?= not team_member_can_perform_action_on_ca(new Actor("admin", {}), new Permission("CA_READ"), new Handle("ca1"));
 
 
 # verify from where Oso begins evaluation, at matching allow() rules.
-?= allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca1"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca2"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca3"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca1"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca2"));
-?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca3"));
+?= allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca1"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca2"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca3"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca1"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca2"));
+?= not allow(new Actor("t1ro", { team: "t1", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca3"));
 
-?= allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca1"));
-?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca2"));
-?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca3"));
-?= allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca1"));
-?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca2"));
-?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca3"));
+?= allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca1"));
+?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca2"));
+?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca3"));
+?= allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca1"));
+?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca2"));
+?= not allow(new Actor("t1rw", { team: "t1", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca3"));
 
 # verify user t2ur can read ca2 but not ca1 or ca3, and cannot write tonew Permission( them
-?= )not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca1"));
-?= allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca2"));
-?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_READ, new Handle("ca3"));
-?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca1"));
-?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca2"));
-?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), Permission::CA_UPDATE, new Handle("ca3"));
+?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca1"));
+?= allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca2"));
+?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_READ"), new Handle("ca3"));
+?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca1"));
+?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca2"));
+?= not allow(new Actor("t2ro", { team: "t2", teamrole: "readonly" }), new Permission("CA_UPDATE"), new Handle("ca3"));
 
-?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca1"));
-?= allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca2"));
-?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_READ, new Handle("ca3"));
-?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca1"));
-?= allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca2"));
-?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), Permission::CA_UPDATE, new Handle("ca3"));
+?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca1"));
+?= allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca2"));
+?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_READ"), new Handle("ca3"));
+?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca1"));
+?= allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca2"));
+?= not allow(new Actor("t2rw", { team: "t2", teamrole: "readwrite" }), new Permission("CA_UPDATE"), new Handle("ca3"));
 
 
 ###
@@ -189,7 +189,7 @@ team_member_can_perform_action_on_resource(actor: Actor, action: Permission, res
     );
 
 team_members_can_login(actor: Actor, action: Permission) if
-    action = Permission::LOGIN and
+    action = new Permission("LOGIN") and
     _ in actor.attr("team") and
     _ in actor.attr("teamrole");
 

--- a/src/daemon/auth/authorizer.rs
+++ b/src/daemon/auth/authorizer.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::commons::api::Token;
+use crate::{commons::api::Token, daemon::auth::common::permissions::Permission};
 use crate::commons::error::Error;
 use crate::commons::KrillResult;
 use crate::constants::ACTOR_DEF_ANON;
@@ -165,7 +165,7 @@ impl Authorizer {
         // which cannot be done by the AuthProvider. Check that now.
         let actor_def = ActorDef::user(user.id.clone(), user.attributes.clone(), None);
         let actor = self.actor_from_def(actor_def);
-        if !actor.is_allowed("LOGIN", RequestPath::from_request(&request))? {
+        if !actor.is_allowed(Permission::LOGIN, RequestPath::from_request(&request))? {
             let reason = format!("Login denied for user '{}': User is not permitted to 'LOGIN'", user.id);
             warn!("{}", reason);
             return Err(Error::ApiInsufficientRights(reason));

--- a/src/daemon/auth/common/mod.rs
+++ b/src/daemon/auth/common/mod.rs
@@ -1,2 +1,7 @@
+#[cfg(feature = "multi-user")]
 pub mod crypt;
+
+pub mod permissions;
+
+#[cfg(feature = "multi-user")]
 pub mod session;

--- a/src/daemon/auth/common/permissions.rs
+++ b/src/daemon/auth/common/permissions.rs
@@ -1,0 +1,69 @@
+#[allow(non_camel_case_types)]
+#[derive(Clone, PartialEq)]
+pub enum Permission {
+    LOGIN,
+    PUB_ADMIN,
+    PUB_LIST,
+    PUB_READ,
+    PUB_CREATE,
+    PUB_DELETE,
+    CA_LIST,
+    CA_READ,
+    CA_CREATE,
+    CA_UPDATE,
+    ROUTES_READ,
+    ROUTES_UPDATE,
+    ROUTES_ANALYSIS,
+    RTA_LIST,
+    RTA_READ,
+    RTA_UPDATE,
+}
+
+impl std::fmt::Display for Permission {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Permission::LOGIN => write!(f, "LOGIN"),
+            Permission::PUB_ADMIN => write!(f, "PUB_ADMIN"),
+            Permission::PUB_LIST => write!(f, "PUB_LIST"),
+            Permission::PUB_READ => write!(f, "PUB_READ"),
+            Permission::PUB_CREATE => write!(f, "PUB_CREATE"),
+            Permission::PUB_DELETE => write!(f, "PUB_DELETE"),
+            Permission::CA_LIST => write!(f, "CA_LIST"),
+            Permission::CA_READ => write!(f, "CA_READ"),
+            Permission::CA_CREATE => write!(f, "CA_CREATE"),
+            Permission::CA_UPDATE => write!(f, "CA_UPDATE"),
+            Permission::ROUTES_READ => write!(f, "ROUTES_READ"),
+            Permission::ROUTES_UPDATE => write!(f, "ROUTES_UPDATE"),
+            Permission::ROUTES_ANALYSIS => write!(f, "ROUTES_ANALYSIS"),
+            Permission::RTA_LIST => write!(f, "RTA_LIST"),
+            Permission::RTA_READ => write!(f, "RTA_READ"),
+            Permission::RTA_UPDATE => write!(f, "RTA_UPDATE"),
+        }
+    }
+}
+
+impl std::str::FromStr for Permission {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "LOGIN" => Ok(Permission::LOGIN),
+            "PUB_ADMIN" => Ok(Permission::PUB_ADMIN),
+            "PUB_LIST" => Ok(Permission::PUB_LIST),
+            "PUB_READ" => Ok(Permission::PUB_READ),
+            "PUB_CREATE" => Ok(Permission::PUB_CREATE),
+            "PUB_DELETE" => Ok(Permission::PUB_DELETE),
+            "CA_LIST" => Ok(Permission::CA_LIST),
+            "CA_READ" => Ok(Permission::CA_READ),
+            "CA_CREATE" => Ok(Permission::CA_CREATE),
+            "CA_UPDATE" => Ok(Permission::CA_UPDATE),
+            "ROUTES_READ" => Ok(Permission::ROUTES_READ),
+            "ROUTES_UPDATE" => Ok(Permission::ROUTES_UPDATE),
+            "ROUTES_ANALYSIS" => Ok(Permission::ROUTES_ANALYSIS),
+            "RTA_LIST" => Ok(Permission::RTA_LIST),
+            "RTA_READ" => Ok(Permission::RTA_READ),
+            "RTA_UPDATE" => Ok(Permission::RTA_UPDATE),
+            _ => Err(format!("Unknown permission '{}'", input))
+        }
+    }
+}

--- a/src/daemon/auth/mod.rs
+++ b/src/daemon/auth/mod.rs
@@ -1,7 +1,6 @@
 pub mod authorizer;
 pub mod providers;
 
-#[cfg(feature = "multi-user")]
 pub mod common;
 
 #[cfg(feature = "multi-user")]

--- a/src/daemon/ca/server.rs
+++ b/src/daemon/ca/server.rs
@@ -11,7 +11,7 @@ use chrono::Duration;
 use rpki::crypto::KeyIdentifier;
 use rpki::uri;
 
-use crate::commons::crypto::{IdCert, KrillSigner, ProtocolCms, ProtocolCmsBuilder};
+use crate::{commons::crypto::{IdCert, KrillSigner, ProtocolCms, ProtocolCmsBuilder}, daemon::auth::common::permissions::Permission};
 use crate::commons::error::Error;
 use crate::commons::eventsourcing::{Aggregate, AggregateStore, Command, CommandKey};
 use crate::commons::remote::cmslogger::CmsLogger;
@@ -617,7 +617,7 @@ impl CaServer {
             self.ca_store
                 .list()?
                 .into_iter()
-                .filter(|handle| matches!(actor.is_allowed("CA_READ", handle.clone()), Ok(true)))
+                .filter(|handle| matches!(actor.is_allowed(Permission::CA_READ, handle.clone()), Ok(true)))
                 .map(CertAuthSummary::new)
                 .collect(),
         ))

--- a/src/daemon/http/server.rs
+++ b/src/daemon/http/server.rs
@@ -757,7 +757,7 @@ macro_rules! aa {
                 let msg = format!(
                     "User '{}' does not have permission '{}' on resource '{}'",
                     $req.actor().name(),
-                    stringify!($perm),
+                    $perm,
                     $resource
                 );
                 Ok(HttpResponse::forbidden(msg).with_benign($benign))

--- a/src/daemon/http/server.rs
+++ b/src/daemon/http/server.rs
@@ -34,6 +34,7 @@ use crate::commons::util::file;
 use crate::commons::{KrillEmptyResult, KrillResult};
 use crate::constants::{KRILL_ENV_UPGRADE_ONLY, KRILL_VERSION_MAJOR, KRILL_VERSION_MINOR, KRILL_VERSION_PATCH};
 use crate::daemon::auth::Auth;
+use crate::daemon::auth::common::permissions::Permission;
 use crate::daemon::ca::RouteAuthorizationUpdates;
 use crate::daemon::config::Config;
 use crate::daemon::http::auth::auth;
@@ -737,20 +738,20 @@ fn add_new_auth_to_response(res: Result<HttpResponse, Error>, opt_auth: Option<A
 // Which would insert the generated code at the start of the function body,
 // similar to how this macro is used in each function.
 macro_rules! aa {
-    (no_warn $req:ident, $perm:ident, $action:expr) => {{
+    (no_warn $req:ident, $perm:expr, $action:expr) => {{
         aa!($req, $perm, $req.path().clone(), $action, true)
     }};
-    ($req:ident, $perm:ident, $action:expr) => {{
+    ($req:ident, $perm:expr, $action:expr) => {{
         aa!($req, $perm, $req.path().clone(), $action, false)
     }};
-    (no_warn $req:ident, $perm:ident, $resource:expr, $action:expr) => {{
+    (no_warn $req:ident, $perm:expr, $resource:expr, $action:expr) => {{
         aa!($req, $perm, $req.path().clone(), $action, true)
     }};
-    ($req:ident, $perm:ident, $resource:expr, $action:expr) => {{
+    ($req:ident, $perm:expr, $resource:expr, $action:expr) => {{
         aa!($req, $perm, $req.path().clone(), $action, false)
     }};
-    ($req:ident, $perm:ident, $resource:expr, $action:expr, $benign:expr) => {{
-        match $req.actor().is_allowed(stringify!($perm), $resource) {
+    ($req:ident, $perm:expr, $resource:expr, $action:expr, $benign:expr) => {{
+        match $req.actor().is_allowed($perm, $resource) {
             Ok(true) => $action,
             Ok(false) => {
                 let msg = format!(
@@ -789,12 +790,12 @@ async fn api(req: Request) -> RoutingResult {
             Some("authorized") => api_authorized(req).await,
             restricted_endpoint => {
                 // Make sure access is allowed
-                aa!(req, LOGIN, {
+                aa!(req, Permission::LOGIN, {
                     match restricted_endpoint {
                         Some("bulk") => api_bulk(req, &mut path).await,
                         Some("cas") => api_cas(req, &mut path).await,
                         Some("publishers") => api_publishers(req, &mut path).await,
-                        Some("pubd") => aa!(req, PUB_ADMIN, api_publication_server(req, &mut path).await),
+                        Some("pubd") => aa!(req, Permission::PUB_ADMIN, api_publication_server(req, &mut path).await),
                         _ => render_unknown_method(),
                     }
                 })
@@ -810,7 +811,7 @@ async fn api_authorized(req: Request) -> RoutingResult {
     // triggers Lagosta to show a login form, not something to warn about!
     aa!(no_warn
         req,
-        LOGIN,
+        Permission::LOGIN,
         match *req.method() {
             Method::GET => render_ok(),
             _ => render_unknown_method(),
@@ -830,7 +831,7 @@ async fn api_bulk(req: Request, path: &mut RequestPath) -> RoutingResult {
 
 async fn api_cas(req: Request, path: &mut RequestPath) -> RoutingResult {
     match path.path_arg::<Handle>() {
-        Some(ca) => aa!(req, CA_READ, ca.clone(), {
+        Some(ca) => aa!(req, Permission::CA_READ, ca.clone(), {
             match path.next() {
                 None => match *req.method() {
                     Method::GET => api_ca_info(req, ca).await,
@@ -965,7 +966,7 @@ async fn api_publishers(req: Request, path: &mut RequestPath) -> RoutingResult {
 /// Returns a list of publisher which have not updated for more
 /// than the given number of seconds.
 pub async fn api_stale_publishers(req: Request, seconds: Option<&str>) -> RoutingResult {
-    aa!(req, PUB_LIST, {
+    aa!(req, Permission::PUB_LIST, {
         let seconds = seconds.unwrap_or("");
         match i64::from_str(seconds) {
             Ok(seconds) => render_json_res(
@@ -982,7 +983,7 @@ pub async fn api_stale_publishers(req: Request, seconds: Option<&str>) -> Routin
 
 /// Returns a json structure with all publishers in it.
 pub async fn api_list_pbl(req: Request) -> RoutingResult {
-    aa!(req, PUB_LIST, {
+    aa!(req, Permission::PUB_LIST, {
         render_json_res(
             req.state()
                 .read()
@@ -995,7 +996,7 @@ pub async fn api_list_pbl(req: Request) -> RoutingResult {
 
 /// Adds a publisher
 pub async fn api_add_pbl(req: Request) -> RoutingResult {
-    aa!(req, PUB_CREATE, {
+    aa!(req, Permission::PUB_CREATE, {
         let actor = req.actor();
         let server = req.state().clone();
         match req.json().await {
@@ -1008,7 +1009,7 @@ pub async fn api_add_pbl(req: Request) -> RoutingResult {
 /// Removes a publisher. Should be idempotent! If if did not exist then
 /// that's just fine.
 pub async fn api_remove_pbl(req: Request, publisher: Handle) -> RoutingResult {
-    aa!(req, PUB_DELETE, {
+    aa!(req, Permission::PUB_DELETE, {
         let actor = req.actor();
         render_empty_res(req.state().write().await.remove_publisher(publisher, &actor))
     })
@@ -1018,7 +1019,7 @@ pub async fn api_remove_pbl(req: Request, publisher: Handle) -> RoutingResult {
 pub async fn api_show_pbl(req: Request, publisher: Handle) -> RoutingResult {
     aa!(
         req,
-        PUB_READ,
+        Permission::PUB_READ,
         render_json_res(req.state().read().await.get_publisher(&publisher))
     )
 }
@@ -1026,7 +1027,7 @@ pub async fn api_show_pbl(req: Request, publisher: Handle) -> RoutingResult {
 //------------ repository_response ---------------------------------------------
 
 pub async fn api_repository_response_xml(req: Request, publisher: Handle) -> RoutingResult {
-    aa!(req, PUB_READ, {
+    aa!(req, Permission::PUB_READ, {
         match repository_response(&req, &publisher).await {
             Ok(res) => Ok(HttpResponse::xml(res.encode_vec())),
             Err(e) => render_error(e),
@@ -1035,7 +1036,7 @@ pub async fn api_repository_response_xml(req: Request, publisher: Handle) -> Rou
 }
 
 pub async fn api_repository_response_json(req: Request, publisher: Handle) -> RoutingResult {
-    aa!(req, PUB_READ, {
+    aa!(req, Permission::PUB_READ, {
         match repository_response(&req, &publisher).await {
             Ok(res) => render_json(res),
             Err(e) => render_error(e),
@@ -1048,7 +1049,7 @@ async fn repository_response(req: &Request, publisher: &Handle) -> Result<rfc818
 }
 
 pub async fn api_ca_add_child(req: Request, parent: ParentHandle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         let server = req.state().clone();
         match req.json().await {
@@ -1059,7 +1060,7 @@ pub async fn api_ca_add_child(req: Request, parent: ParentHandle) -> RoutingResu
 }
 
 async fn api_ca_child_update(req: Request, ca: Handle, child: ChildHandle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         let server = req.state().clone();
         match req.json().await {
@@ -1070,7 +1071,7 @@ async fn api_ca_child_update(req: Request, ca: Handle, child: ChildHandle) -> Ro
 }
 
 pub async fn api_ca_child_remove(req: Request, ca: Handle, child: ChildHandle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         render_empty_res(req.state().read().await.ca_child_remove(&ca, child, &actor).await)
     })
@@ -1079,7 +1080,7 @@ pub async fn api_ca_child_remove(req: Request, ca: Handle, child: ChildHandle) -
 async fn api_ca_child_show(req: Request, ca: Handle, child: ChildHandle) -> RoutingResult {
     aa!(
         req,
-        CA_READ,
+        Permission::CA_READ,
         render_json_res(req.state().read().await.ca_child_show(&ca, &child).await)
     )
 }
@@ -1087,7 +1088,7 @@ async fn api_ca_child_show(req: Request, ca: Handle, child: ChildHandle) -> Rout
 async fn api_ca_parent_contact(req: Request, ca: Handle, child: ChildHandle) -> RoutingResult {
     aa!(
         req,
-        CA_READ,
+        Permission::CA_READ,
         render_json_res(req.state().read().await.ca_parent_contact(&ca, child.clone()).await)
     )
 }
@@ -1095,13 +1096,13 @@ async fn api_ca_parent_contact(req: Request, ca: Handle, child: ChildHandle) -> 
 async fn api_ca_parent_res_json(req: Request, ca: Handle, child: ChildHandle) -> RoutingResult {
     aa!(
         req,
-        CA_READ,
+        Permission::CA_READ,
         render_json_res(req.state().read().await.ca_parent_response(&ca, child.clone()).await)
     )
 }
 
 pub async fn api_ca_parent_res_xml(req: Request, ca: Handle, child: ChildHandle) -> RoutingResult {
-    aa!(req, CA_READ, {
+    aa!(req, Permission::CA_READ, {
         match req.state().read().await.ca_parent_response(&ca, child.clone()).await {
             Ok(res) => Ok(HttpResponse::xml(res.encode_vec())),
             Err(e) => render_error(e),
@@ -1113,7 +1114,7 @@ pub async fn api_ca_parent_res_xml(req: Request, ca: Handle, child: ChildHandle)
 
 async fn api_all_ca_issues(req: Request) -> RoutingResult {
     match *req.method() {
-        Method::GET => aa!(req, CA_READ, {
+        Method::GET => aa!(req, Permission::CA_READ, {
             let actor = req.actor();
             render_json_res(req.state().read().await.all_ca_issues(&actor).await)
         }),
@@ -1126,7 +1127,7 @@ async fn api_ca_issues(req: Request, ca: Handle) -> RoutingResult {
     match *req.method() {
         Method::GET => aa!(
             req,
-            CA_READ,
+            Permission::CA_READ,
             render_json_res(req.state().read().await.ca_issues(&ca).await)
         ),
         _ => render_unknown_method(),
@@ -1134,14 +1135,14 @@ async fn api_ca_issues(req: Request, ca: Handle) -> RoutingResult {
 }
 
 async fn api_cas_list(req: Request) -> RoutingResult {
-    aa!(req, CA_LIST, {
+    aa!(req, Permission::CA_LIST, {
         let actor = req.actor();
         render_json_res(req.state().read().await.ca_list(&actor))
     })
 }
 
 pub async fn api_ca_init(req: Request) -> RoutingResult {
-    aa!(req, CA_CREATE, {
+    aa!(req, Permission::CA_CREATE, {
         let state = req.state().clone();
 
         match req.json().await {
@@ -1153,7 +1154,7 @@ pub async fn api_ca_init(req: Request) -> RoutingResult {
 
 async fn api_ca_regenerate_id(req: Request, handle: Handle) -> RoutingResult {
     match *req.method() {
-        Method::POST => aa!(req, CA_UPDATE, {
+        Method::POST => aa!(req, Permission::CA_UPDATE, {
             let actor = req.actor();
             render_empty_res(req.state().read().await.ca_update_id(handle, &actor).await)
         }),
@@ -1164,7 +1165,7 @@ async fn api_ca_regenerate_id(req: Request, handle: Handle) -> RoutingResult {
 async fn api_ca_info(req: Request, handle: Handle) -> RoutingResult {
     aa!(
         req,
-        CA_READ,
+        Permission::CA_READ,
         render_json_res(req.state().read().await.ca_info(&handle).await)
     )
 }
@@ -1173,7 +1174,7 @@ async fn api_ca_deactivate(req: Request, handle: Handle) -> RoutingResult {
     let actor = req.actor();
     aa!(
         req,
-        CA_READ,
+        Permission::CA_READ,
         render_json_res(req.state().read().await.ca_deactivate(&handle, &actor).await)
     )
 }
@@ -1181,7 +1182,7 @@ async fn api_ca_deactivate(req: Request, handle: Handle) -> RoutingResult {
 async fn api_ca_my_parent_contact(req: Request, ca: Handle, parent: ParentHandle) -> RoutingResult {
     aa!(
         req,
-        CA_READ,
+        Permission::CA_READ,
         render_json_res(req.state().read().await.ca_my_parent_contact(&ca, &parent).await)
     )
 }
@@ -1189,7 +1190,7 @@ async fn api_ca_my_parent_contact(req: Request, ca: Handle, parent: ParentHandle
 async fn api_ca_my_parent_statuses(req: Request, ca: Handle) -> RoutingResult {
     aa!(
         req,
-        CA_READ,
+        Permission::CA_READ,
         render_json_res(req.state().read().await.ca_my_parent_statuses(&ca).await)
     )
 }
@@ -1222,7 +1223,7 @@ async fn api_ca_history(req: Request, path: &mut RequestPath, handle: Handle) ->
     };
 
     match *req.method() {
-        Method::GET => aa!(req, CA_READ, {
+        Method::GET => aa!(req, Permission::CA_READ, {
             match req.state().read().await.ca_history(&handle, crit).await {
                 Ok(history) => render_json(history),
                 Err(e) => render_error(e),
@@ -1271,7 +1272,7 @@ async fn api_ca_command_details(req: Request, path: &mut RequestPath, handle: Ha
     // /api/v1/cas/{ca}/command/<command-key>
     match path.path_arg() {
         Some(key) => match *req.method() {
-            Method::GET => aa!(req, CA_READ, {
+            Method::GET => aa!(req, Permission::CA_READ, {
                 match req.state().read().await.ca_command_details(&handle, key) {
                     Ok(details) => render_json(details),
                     Err(e) => match e {
@@ -1292,7 +1293,7 @@ async fn api_ca_child_req_xml(req: Request, handle: Handle) -> RoutingResult {
     match *req.method() {
         Method::GET => aa!(
             req,
-            CA_READ,
+            Permission::CA_READ,
             match ca_child_req(&req, &handle).await {
                 Ok(req) => Ok(HttpResponse::xml(req.encode_vec())),
                 Err(e) => render_error(e),
@@ -1306,7 +1307,7 @@ async fn api_ca_child_req_json(req: Request, handle: Handle) -> RoutingResult {
     match *req.method() {
         Method::GET => aa!(
             req,
-            CA_READ,
+            Permission::CA_READ,
             match ca_child_req(&req, &handle).await {
                 Ok(req) => render_json(req),
                 Err(e) => render_error(e),
@@ -1324,7 +1325,7 @@ async fn api_ca_publisher_req_json(req: Request, handle: Handle) -> RoutingResul
     match *req.method() {
         Method::GET => aa!(
             req,
-            CA_READ,
+            Permission::CA_READ,
             render_json_res(req.state().read().await.ca_publisher_req(&handle).await)
         ),
         _ => render_unknown_method(),
@@ -1335,7 +1336,7 @@ async fn api_ca_publisher_req_xml(req: Request, handle: Handle) -> RoutingResult
     match *req.method() {
         Method::GET => aa!(
             req,
-            CA_READ,
+            Permission::CA_READ,
             match req.state().read().await.ca_publisher_req(&handle).await {
                 Ok(res) => Ok(HttpResponse::xml(res.encode_vec())),
                 Err(e) => render_error(e),
@@ -1348,7 +1349,7 @@ async fn api_ca_publisher_req_xml(req: Request, handle: Handle) -> RoutingResult
 async fn api_ca_repo_details(req: Request, handle: Handle) -> RoutingResult {
     aa!(
         req,
-        CA_READ,
+        Permission::CA_READ,
         render_json_res(req.state().read().await.ca_repo_details(&handle).await)
     )
 }
@@ -1357,7 +1358,7 @@ async fn api_ca_repo_status(req: Request, handle: Handle) -> RoutingResult {
     match *req.method() {
         Method::GET => aa!(
             req,
-            CA_READ,
+            Permission::CA_READ,
             render_json_res(req.state().read().await.ca_repo_status(&handle).await)
         ),
         _ => render_unknown_method(),
@@ -1382,7 +1383,7 @@ fn extract_repository_update(handle: &Handle, bytes: Bytes) -> Result<Repository
 }
 
 pub async fn api_ca_repo_update(req: Request, handle: Handle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         let server = req.state().clone();
 
@@ -1398,7 +1399,7 @@ pub async fn api_ca_repo_update(req: Request, handle: Handle) -> RoutingResult {
 }
 
 async fn api_ca_add_parent(req: Request, ca: Handle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         let server = req.state().clone();
 
@@ -1415,7 +1416,7 @@ async fn api_ca_add_parent(req: Request, ca: Handle) -> RoutingResult {
 }
 
 async fn api_ca_add_parent_xml(req: Request, path: &mut RequestPath, ca: Handle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         let server = req.state().clone();
 
@@ -1477,7 +1478,7 @@ fn extract_parent_ca_contact(ca: &Handle, bytes: Bytes) -> Result<ParentCaContac
 }
 
 async fn api_ca_update_parent(req: Request, ca: Handle, parent: ParentHandle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         let server = req.state().clone();
 
@@ -1497,7 +1498,7 @@ async fn api_ca_update_parent(req: Request, ca: Handle, parent: ParentHandle) ->
 }
 
 async fn api_ca_remove_parent(req: Request, ca: Handle, parent: Handle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         render_empty_res(req.state().read().await.ca_parent_remove(ca, parent, &actor).await)
     })
@@ -1505,7 +1506,7 @@ async fn api_ca_remove_parent(req: Request, ca: Handle, parent: Handle) -> Routi
 
 /// Force a key roll for a CA, i.e. use a max key age of 0 seconds.
 async fn api_ca_kr_init(req: Request, handle: Handle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         render_empty_res(req.state().read().await.ca_keyroll_init(handle, &actor).await)
     })
@@ -1513,7 +1514,7 @@ async fn api_ca_kr_init(req: Request, handle: Handle) -> RoutingResult {
 
 /// Force key activation for all new keys, i.e. use a staging period of 0 seconds.
 async fn api_ca_kr_activate(req: Request, handle: Handle) -> RoutingResult {
-    aa!(req, CA_UPDATE, {
+    aa!(req, Permission::CA_UPDATE, {
         let actor = req.actor();
         render_empty_res(req.state().read().await.ca_keyroll_activate(handle, &actor).await)
     })
@@ -1521,7 +1522,7 @@ async fn api_ca_kr_activate(req: Request, handle: Handle) -> RoutingResult {
 
 /// Update the route authorizations for this CA
 async fn api_ca_routes_update(req: Request, handle: Handle) -> RoutingResult {
-    aa!(req, ROUTES_UPDATE, {
+    aa!(req, Permission::ROUTES_UPDATE, {
         let actor = req.actor();
         let state = req.state().clone();
 
@@ -1536,7 +1537,7 @@ async fn api_ca_routes_update(req: Request, handle: Handle) -> RoutingResult {
 /// for the resources in the update have no remaining invalids, apply it. Otherwise
 /// return the analysis and a suggestion.
 async fn api_ca_routes_try_update(req: Request, ca: Handle) -> RoutingResult {
-    aa!(req, ROUTES_UPDATE, {
+    aa!(req, Permission::ROUTES_UPDATE, {
         let actor = req.actor();
         let state = req.state().clone();
 
@@ -1573,7 +1574,7 @@ async fn api_ca_routes_try_update(req: Request, ca: Handle) -> RoutingResult {
 
 /// show the route authorizations for this CA
 async fn api_ca_routes_show(req: Request, handle: Handle) -> RoutingResult {
-    aa!(req, ROUTES_READ, {
+    aa!(req, Permission::ROUTES_READ, {
         match req.state().read().await.ca_routes_show(&handle).await {
             Ok(roas) => render_json(roas),
             Err(_) => render_unknown_resource(),
@@ -1583,7 +1584,7 @@ async fn api_ca_routes_show(req: Request, handle: Handle) -> RoutingResult {
 
 /// Show the state of ROAs vs BGP for this CA
 async fn api_ca_routes_analysis(req: Request, path: &mut RequestPath, handle: Handle) -> RoutingResult {
-    aa!(req, ROUTES_ANALYSIS, {
+    aa!(req, Permission::ROUTES_ANALYSIS, {
         match path.next() {
             Some("full") => render_json_res(req.state().read().await.ca_routes_bgp_analysis(&handle).await),
             Some("dryrun") => match *req.method() {
@@ -1624,7 +1625,7 @@ async fn api_ca_routes_analysis(req: Request, path: &mut RequestPath, handle: Ha
 
 async fn api_republish_all(req: Request) -> RoutingResult {
     match *req.method() {
-        Method::POST => aa!(req, CA_UPDATE, {
+        Method::POST => aa!(req, Permission::CA_UPDATE, {
             let actor = req.actor();
             render_empty_res(req.state().read().await.republish_all(&actor).await)
         }),
@@ -1634,7 +1635,7 @@ async fn api_republish_all(req: Request) -> RoutingResult {
 
 async fn api_resync_all(req: Request) -> RoutingResult {
     match *req.method() {
-        Method::POST => aa!(req, CA_UPDATE, {
+        Method::POST => aa!(req, Permission::CA_UPDATE, {
             let actor = req.actor();
             render_empty_res(req.state().read().await.resync_all(&actor).await)
         }),
@@ -1645,7 +1646,7 @@ async fn api_resync_all(req: Request) -> RoutingResult {
 /// Refresh all CAs
 async fn api_refresh_all(req: Request) -> RoutingResult {
     match *req.method() {
-        Method::POST => aa!(req, CA_UPDATE, {
+        Method::POST => aa!(req, Permission::CA_UPDATE, {
             let actor = req.actor();
             render_empty_res(req.state().read().await.cas_refresh_all(&actor).await)
         }),
@@ -1710,7 +1711,7 @@ async fn api_ca_rta(req: Request, path: &mut RequestPath, ca: Handle) -> Routing
 async fn api_ca_rta_list(req: Request, ca: Handle) -> RoutingResult {
     aa!(
         req,
-        RTA_LIST,
+        Permission::RTA_LIST,
         render_json_res(req.state().read().await.rta_list(ca).await)
     )
 }
@@ -1718,13 +1719,13 @@ async fn api_ca_rta_list(req: Request, ca: Handle) -> RoutingResult {
 async fn api_ca_rta_show(req: Request, ca: Handle, name: RtaName) -> RoutingResult {
     aa!(
         req,
-        RTA_READ,
+        Permission::RTA_READ,
         render_json_res(req.state().read().await.rta_show(ca, name).await)
     )
 }
 
 async fn api_ca_rta_sign(req: Request, ca: Handle, name: RtaName) -> RoutingResult {
-    aa!(req, RTA_UPDATE, {
+    aa!(req, Permission::RTA_UPDATE, {
         let actor = req.actor();
         let state = req.state().clone();
         match req.json().await {
@@ -1735,7 +1736,7 @@ async fn api_ca_rta_sign(req: Request, ca: Handle, name: RtaName) -> RoutingResu
 }
 
 async fn api_ca_rta_multi_prep(req: Request, ca: Handle, name: RtaName) -> RoutingResult {
-    aa!(req, RTA_UPDATE, {
+    aa!(req, Permission::RTA_UPDATE, {
         let actor = req.actor();
         let state = req.state().clone();
 
@@ -1747,7 +1748,7 @@ async fn api_ca_rta_multi_prep(req: Request, ca: Handle, name: RtaName) -> Routi
 }
 
 async fn api_ca_rta_multi_sign(req: Request, ca: Handle, name: RtaName) -> RoutingResult {
-    aa!(req, RTA_UPDATE, {
+    aa!(req, Permission::RTA_UPDATE, {
         let actor = req.actor();
         let state = req.state().clone();
         match req.json().await {


### PR DESCRIPTION
Use strongly typed permissions in the policy rules to ensure that rules cannot be written that reference non-existent permissions or to catch typos early, e.g. CA_CEATE instead of CA_CREATE. This also creates a single location in which the set of supported permissions is defined (`Permissions.rs`) instead of the set of supported permissions being defined by various static string references sprinkled across the code.