### PR TITLE
Check the OpenID Connect CSRF token (resolves #383).

### DIFF
--- a/src/daemon/auth/authorizer.rs
+++ b/src/daemon/auth/authorizer.rs
@@ -4,6 +4,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::{commons::api::Token, daemon::auth::common::permissions::Permission};
 use crate::commons::error::Error;
 use crate::commons::KrillResult;
 use crate::constants::ACTOR_DEF_ANON;
@@ -15,7 +16,6 @@ use crate::{
     commons::actor::{Actor, ActorDef},
     daemon::http::RequestPath,
 };
-use crate::{commons::api::Token, daemon::auth::common::permissions::Permission};
 
 //------------ Authorizer ----------------------------------------------------
 

--- a/src/daemon/auth/authorizer.rs
+++ b/src/daemon/auth/authorizer.rs
@@ -4,7 +4,6 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::{commons::api::Token, daemon::auth::common::permissions::Permission};
 use crate::commons::error::Error;
 use crate::commons::KrillResult;
 use crate::constants::ACTOR_DEF_ANON;
@@ -16,6 +15,7 @@ use crate::{
     commons::actor::{Actor, ActorDef},
     daemon::http::RequestPath,
 };
+use crate::{commons::api::Token, daemon::auth::common::permissions::Permission};
 
 //------------ Authorizer ----------------------------------------------------
 
@@ -215,7 +215,7 @@ pub struct LoggedInUser {
 #[derive(Clone, Debug)]
 pub enum Auth {
     Bearer(Token),
-    AuthorizationCode { code: Token, state: String, nonce: String },
+    AuthorizationCode { code: Token, state: String, nonce: String, csrf_token_hash: String },
     IdAndPasswordHash { id: String, password_hash: Token },
 }
 
@@ -223,8 +223,8 @@ impl Auth {
     pub fn bearer(token: Token) -> Self {
         Auth::Bearer(token)
     }
-    pub fn authorization_code(code: Token, state: String, nonce: String) -> Self {
-        Auth::AuthorizationCode { code, state, nonce }
+    pub fn authorization_code(code: Token, state: String, nonce: String, csrf_token_hash: String) -> Self {
+        Auth::AuthorizationCode { code, state, nonce, csrf_token_hash }
     }
 
     pub fn id_and_password_hash(id: String, password_hash: Token) -> Self {

--- a/src/daemon/auth/providers/openid_connect/provider.rs
+++ b/src/daemon/auth/providers/openid_connect/provider.rs
@@ -552,7 +552,7 @@ impl OpenIDConnectAuthProvider {
     }
 
     fn extract_cookie(&self, request: &hyper::Request<hyper::Body>, cookie_name: &str) -> Option<String> {
-        if let Some(cookie_hdr_val) = request.headers().get(hyper::http::header::COOKIE) {
+        for cookie_hdr_val in request.headers().get_all(hyper::http::header::COOKIE) {
             if let Ok(cookie_hdr_val_str) = cookie_hdr_val.to_str() {
                 // Use a helper crate to parse the cookie string as it's
                 // actually a bit of a pain as the string is semi-colon-with-

--- a/src/daemon/auth/providers/openid_connect/provider.rs
+++ b/src/daemon/auth/providers/openid_connect/provider.rs
@@ -827,16 +827,16 @@ impl AuthProvider for OpenIDConnectAuthProvider {
                 // request to the user agent's state and refer to cryptographic binding and use of hashing and cookies
                 // to achieve such binding.
                 //
-                // We need a way to verify that the state value that we have received back is one that we issued to the
-                // client to use in the login process. Hashing it and issuing the hash to the client browser as a cookie
-                // could be used to verifiably relate the state value to a value that we can issue at the start of the
-                // login process and get back on redirect from the 3rd party back to Krill, and that won't be sent to
-                // the 3rd party (i.e. the cookie, which will be restricted to our domain and thus shouldn't be sent by
-                // the browser to the 3rd party domain). By using a cookie we automatically incorporate a mechanism for
-                // delivering the hash back to us (as the user agent will follow the 3rd party redirect back to us
-                // without giving client-side javascript a chance to inspect or modify it).
+                // We need a way to verify that the state value that we have received back is the one that we issued to
+                // the client to use in the login process. Hashing it and issuing the hash to the client browser as a
+                // cookie could be used to verifiably relate the state value to a value that we can issue at the start
+                // of the login process and get back on redirect from the 3rd party back to Krill, and that won't be
+                // sent to the 3rd party (i.e. the cookie, which will be restricted to our domain and thus shouldn't be
+                // sent by the browser to the 3rd party domain). By using a cookie we automatically incorporate a
+                // mechanism for delivering the hash back to us (as the user agent will follow the 3rd party redirect
+                // back to us without giving client-side javascript a chance to inspect or modify it).
                 //
-                // This is actually exactly the same mechanism used pass a nonce value to the 3rd party authorization
+                // This is actually exactly the same mechanism used to pass a nonce value to the 3rd party authorization
                 // server and check it afterwards, the only difference being that the state parameter is passed back to
                 // us as a request parameter on the authorisation code redirect response from the 3rd party, and the
                 // nonce is a value embedded in the ID token that is issued at the very end of the login process (after

--- a/src/daemon/auth/providers/openid_connect/provider.rs
+++ b/src/daemon/auth/providers/openid_connect/provider.rs
@@ -811,7 +811,7 @@ impl AuthProvider for OpenIDConnectAuthProvider {
                 // then yes we are using a secure random code.
                 //
                 // https://tools.ietf.org/html/rfc6749#section-4.2.2.1 says the state parameter "SHOULD NOT include
-                // sensitive client or reseource owner information in plain text" - it does not.
+                // sensitive client or resource owner information in plain text" - it does not.
                 //
                 // https://tools.ietf.org/html/rfc6749#section-10.12 says the state parameter "MUST contain a
                 // non-guessable value" - it does.

--- a/tests/ui/cypress/specs/multi_user_openid_connect.js
+++ b/tests/ui/cypress/specs/multi_user_openid_connect.js
@@ -84,9 +84,6 @@ describe('OpenID Connect users', () => {
           cy.get('#userinfo').click()
           cy.get('#userinfo_table').contains(ts.u)
           cy.get('#userinfo_table').contains('role')
-        } else if (ts.d == 'empty') {
-          cy.contains('The supplied login credentials were incorrect')
-          cy.contains('return to the login page')
         } else if (ts.d == 'badidtoken') {
           cy.contains('OpenID Connect: Code exchange failed: Failed to parse server response')
           cy.contains('return to the login page')
@@ -96,9 +93,10 @@ describe('OpenID Connect users', () => {
           )
           cy.contains('return to the login page')
         } else if (ts.d == 'wrongcsrfstate') {
-          cy.contains('TODO I DONT KNOW WHAT THIS ERROR MESSAGE SHOULD BE YET')
+          cy.contains('CSRF token mismatch')
         } else {
-          throw new Error("No handling has been defined for this test case!")
+          cy.contains('The supplied login credentials were incorrect')
+          cy.contains('return to the login page')
         }
       }
     )

--- a/tests/ui/cypress/specs/multi_user_openid_connect.js
+++ b/tests/ui/cypress/specs/multi_user_openid_connect.js
@@ -8,6 +8,7 @@ let badidtoken = { u: 'non-spec-compliant-idtoken-payload' }
 let badrole = { u: 'user-with-unknown-role' }
 let refreshinvalidrequest = { u: 'user-with-invalid-request-on-refresh' }
 let refreshinvalidclient = { u: 'user-with-invalid-client-on-refresh' }
+let wrongcsrfstate = { u: 'user-with-wrong-csrf-state-value' }
 let ca_name = 'dummy-ca-name'
 
 let login_test_settings = [
@@ -18,6 +19,7 @@ let login_test_settings = [
   { d: 'readwrite', u: readwrite.u, o: true },
   { d: 'badidtoken', u: badidtoken.u, o: false },
   { d: 'badrole', u: badrole.u, o: false },
+  { d: 'wrongcsrfstate', u: wrongcsrfstate.u, o: false },
 ]
 
 const create_ca_settings_401 = [
@@ -93,6 +95,10 @@ describe('OpenID Connect users', () => {
             'Your user does not have sufficient rights to perform this action. Please contact your administrator.'
           )
           cy.contains('return to the login page')
+        } else if (ts.d == 'wrongcsrfstate') {
+          cy.contains('TODO I DONT KNOW WHAT THIS ERROR MESSAGE SHOULD BE YET')
+        } else {
+          throw new Error("No handling has been defined for this test case!")
         }
       }
     )

--- a/tests/ui/openid_connect_mock.rs
+++ b/tests/ui/openid_connect_mock.rs
@@ -376,6 +376,14 @@ fn run_mock_openid_connect_server() {
                 ..Default::default()
             },
         );
+        known_users.insert(
+            "user-with-wrong-csrf-state-value",
+            KnownUser {
+                role: Some("admin"),
+                exc_cas: Some("ta,testbed"),
+                ..Default::default()
+            },
+        );
 
         let provider_metadata: CustomProviderMetadata = ProviderMetadata::new(
             IssuerUrl::new("http://localhost:1818".to_string()).unwrap(),
@@ -624,13 +632,14 @@ fn run_mock_openid_connect_server() {
 
                 match known_users.get(username.as_str()) {
                     Some(_user) => {
-                        let client_id = require_query_param(&query, "client_id")?;
-                        let nonce = require_query_param(&query, "nonce")?;
-                        let state = require_query_param(&query, "state")?;
-
-                        let client_id = base64_decode(client_id)?;
-                        let nonce = base64_decode(nonce)?;
-                        let state = base64_decode(state)?;
+                        let client_id = base64_decode(require_query_param(&query, "client_id")?)?;
+                        let nonce = base64_decode(require_query_param(&query, "nonce")?)?;
+                        let state = if username == "user-with-wrong-csrf-state-value" {
+                            info!("Deliberately returning the wrong CSRF state value to the client");
+                            "some-wrong-csrf-value".to_string()
+                        } else {
+                            base64_decode(require_query_param(&query, "state")?)?
+                        };
 
                         let mut code_bytes: [u8; 4] = [0; 4];
                         openssl::rand::rand_bytes(&mut code_bytes)


### PR DESCRIPTION
When logging in to an OpenID Connect provider via a 3rd party login form, the URL to which the user is HTTP redirected contains security features including a so-called CSRF token query parameter called `state`.

After the login form has been submitted and accepted by the 3rd party provider the provider redirects the end user back to Krill via their user agent (aka browser). This second redirect also includes a `state` query parameter and its value should be the same as that generated by Krill when the initial redirect URL is generated.

Prior to this PR the state value was generated per login request but was not checked upon receiving the redirect from the 3rd party provider. This PR:
- Adds a short lived secure Set-Cookie HTTP header to the initial redirect to the 3rd party login form, with its value being the hash of the CSRF token.
- On receipt of the 3rd party provider redirect to Krill, retrieves the cookie and checks if the hash of the `state` parameter matches the cookie value.
- Adds a test which deliberately returns the wrong `state` query parameter value from the OpenID Connect mock server and verifies that the end user is shown an error.

This PR has also been manually tested including with AWS Cognito and Azure ActiveDirectory.