### PR TITLE
Trap startup error in tests

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -86,6 +86,12 @@ pub fn init_config(config: &Config) {
     config.verify().unwrap();
 }
 
+async fn start_krill_with_error_trap(config: Arc<Config>, mode: KrillMode) {
+    if let Err(err) = server::start_krill_daemon(config, mode).await {
+        error!("Krill failed to start: {}", err);
+    }
+}
+
 /// Starts krill server for testing, with embedded TA and repo.
 /// Creates a random base directory in the 'work' folder, and returns
 /// it. Be sure to clean it up when the test is done.
@@ -111,7 +117,7 @@ pub async fn start_krill(config: Option<Config>, enable_testbed: bool) -> PathBu
         }
     };
 
-    tokio::spawn(server::start_krill_daemon(Arc::new(config), mode));
+    tokio::spawn(start_krill_with_error_trap(Arc::new(config), mode));
     assert!(krill_server_ready().await);
     dir
 }
@@ -126,7 +132,7 @@ pub async fn start_krill_pubd() -> PathBuf {
     config.port = 3001;
     config.service_uri = "https://localhost:3001/".to_string();
 
-    tokio::spawn(server::start_krill_daemon(Arc::new(config), KrillMode::Pubd));
+    tokio::spawn(start_krill_with_error_trap(Arc::new(config), KrillMode::Pubd));
     assert!(krill_pubd_ready().await);
     dir
 }


### PR DESCRIPTION
When not running from a test a startup failure in Krill is logged by `fn main()`, but when run from a test such errors are lost. This change detects and logs them.