### PR TITLE
Log types passed to oso when trace is enabled

### DIFF
--- a/src/commons/actor.rs
+++ b/src/commons/actor.rs
@@ -205,8 +205,8 @@ impl Actor {
     #[cfg(feature = "multi-user")]
     pub fn is_allowed<A, R>(&self, action: A, resource: R) -> KrillResult<bool>
     where
-        A: ToPolar + Display + Clone,
-        R: ToPolar + Display + Clone,
+        A: ToPolar + Display + Debug + Clone,
+        R: ToPolar + Display + Debug + Clone,
     {
         if let Some(api_error) = &self.auth_error {
             trace!(
@@ -223,21 +223,13 @@ impl Actor {
             Some(policy) => match policy.is_allowed(self.clone(), action.clone(), resource.clone()) {
                 Ok(allowed) => {
                     if log_enabled!(log::Level::Trace) {
-                        if allowed {
-                            trace!(
-                                "Access granted: actor={}, action={}, resource={}",
-                                self.name(),
-                                &action,
-                                &resource
-                            );
-                        } else {
-                            trace!(
-                                "Access denied: actor={:?}, action={}, resource={}",
-                                self,
-                                &action,
-                                &resource
-                            );
-                        }
+                        trace!(
+                            "Access {}: actor={:?}, action={:?}, resource={:?}",
+                            if allowed { "granted" } else { "denied" },
+                            self,
+                            &action,
+                            &resource
+                        );
                     }
                     Ok(allowed)
                 }

--- a/src/daemon/auth/common/permissions.rs
+++ b/src/daemon/auth/common/permissions.rs
@@ -1,5 +1,5 @@
 #[allow(non_camel_case_types)]
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Permission {
     LOGIN,
     PUB_ADMIN,

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -502,7 +502,7 @@ impl Request {
 
 //------------ RequestPath ---------------------------------------------------
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RequestPath {
     path: PathAndQuery,
     segment: (usize, usize),


### PR DESCRIPTION
Sometimes when investigating an Oso policy problem you need to know which type was passed to the rule engine, not just the display value of that type. This change logs the Debug representation of the types passed when trace level logging is enabled.