### PR TITLE
Improvements and fixes for e2e testing on the Krill dev branch

### DIFF
--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -405,7 +405,7 @@ paths:
         - $ref: '#/components/parameters/child_handle'
       responses:
         '200':
-          $ref: '#/components/responses/Rfc8183O'
+          $ref: '#/components/responses/Rfc6492'
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':
@@ -636,7 +636,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Rfc8181'
+              $ref: '#/components/schemas/Rfc8183'
       responses:
         '200':
           $ref: '#/components/responses/Success'
@@ -670,7 +670,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/rfc8181Base'
+                $ref: '#/components/schemas/Rfc8181'
             application/xml:
               schema:
                 $ref: '#/components/schemas/RFC8183PublisherRequestXML'
@@ -1205,10 +1205,16 @@ components:
         id_cert:
           $ref: '#/components/schemas/IdCert'
     Rfc6492:
-      allOf:
-        - $ref: '#/components/schemas/rfcCommon'
-        - type: object
+      type: object
+      properties:
+        rfc6492:
+          type: object
           properties:
+            tag:
+              type: string
+              nullable: true
+            id_cert:
+              $ref: '#/components/schemas/IdCert'
             parent_handle:
               $ref: '#/components/schemas/Handle'
             child_handle:
@@ -1223,14 +1229,19 @@ components:
             publisher_handle:
               $ref: '#/components/schemas/Handle'
     Rfc8181:
-      allOf:
-        - $ref: '#/components/schemas/rfc8181Base'
-        - type: object
-          properties:
-            service_uri:
-              $ref: '#/components/schemas/ServiceUri'
-            repo_info:
-              $ref: '#/components/schemas/RepoInfo'
+      type: object
+      properties:
+        tag:
+          type: string
+          nullable: true
+        id_cert:
+          $ref: '#/components/schemas/IdCert'
+        publisher_handle:
+          $ref: '#/components/schemas/Handle'
+        service_uri:
+          $ref: '#/components/schemas/ServiceUri'
+        repo_info:
+          $ref: '#/components/schemas/RepoInfo'
     Rfc8183:
       allOf:
         - $ref: '#/components/schemas/rfcCommon'

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -72,11 +72,6 @@ EOF
     fi
 fi
 
-if [ "${KRILL_USE_TA}" == "true" ]; then
-    export KRILL_TESTBED_RSYNC="rsync://${KRILL_FQDN}/repo/"
-    export KRILL_TESTBED_RRDP="https://${KRILL_FQDN}/rrdp/"
-fi
-
 # Launch the command supplied either by the default CMD (krill) in the
 # Dockerfile or that given by the operator when invoking Docker run. Use exec
 # to ensure krill runs as PID 1 as required by Docker for proper signal

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -63,16 +63,18 @@ if [ "$1" == "krill" ]; then
         # script via a "-e KRILL_FQDN=some.domain.name" argument to
         # "docker run".
         cat << EOF >> ${KRILL_CONF}
-rsync_base  = "rsync://${KRILL_FQDN}/repo/" ${MAGIC}
-service_uri = "https://${KRILL_FQDN}/" ${MAGIC}
 log_level   = "${KRILL_LOG_LEVEL}" ${MAGIC}
-use_ta      = ${KRILL_USE_TA} ${MAGIC}
 EOF
 
         log_info "Dumping ${KRILL_CONF} config file"
         cat ${KRILL_CONF}
         log_info "End of dump"
     fi
+fi
+
+if [ "${KRILL_USE_TA}" == "true" ]; then
+    export KRILL_TESTBED_RSYNC="rsync://${KRILL_FQDN}/repo/"
+    export KRILL_TESTBED_RRDP="https://${KRILL_FQDN}/rrdp/"
 fi
 
 # Launch the command supplied either by the default CMD (krill) in the

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -221,7 +221,7 @@ impl KrillServer {
 
                     let repo_info: RepoInfo = pubserver.repo_info_for(&ta_handle)?;
 
-                    let ta_uri = format!("{}ta/ta.cer", uris.rrdp_base_uri());
+                    let ta_uri = format!("{}ta/ta.cer", service_uri);
                     let ta_uri = uri::Https::from_string(ta_uri).unwrap();
 
                     let ta_aia = format!("{}ta/ta.cer", uris.rsync_jail().to_string());

--- a/tests/e2e/data.py
+++ b/tests/e2e/data.py
@@ -1,4 +1,4 @@
-from krill_api.models.roa import ROA
+from krill_ca_api.models.roa import ROA
 
 
 TEST_ROAS = [

--- a/tests/e2e/simple_rp_roa_test.py
+++ b/tests/e2e/simple_rp_roa_test.py
@@ -5,7 +5,8 @@ import rtrlib
 from retrying import retry, RetryError
 from time import time
 from operator import attrgetter
-from krill_api import *
+import krill_ca_api as krill_ca_api_lib
+import krill_pub_api as krill_pub_api_lib
 
 from tests.util import krill
 from tests.util.docker import docker_project, class_service_manager, function_service_manager, run_command, docker_host_fqdn
@@ -29,7 +30,7 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
     #
     def no_retry_if_forbidden(e):
         """Return True if we should retry, False otherwise"""
-        return not (isinstance(e, ApiException) and e.status == 403)
+        return not (isinstance(e, krill_ca_api_lib.ApiException) and e.status == 403)
 
     def retry_if_not(result):
         """Return True if we should retry, False otherwise"""
@@ -50,10 +51,11 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
         wait_exponential_max=10000,
         retry_on_result=retry_if_not,
         wrap_exception=True)
-    def wait_until_ca_has_at_least_one(ca_handle, property):
+    def wait_until_ca_has(ca_handle, property, matcher_func):
         ca = krill_ca_api.get_ca(ca_handle)
         f = attrgetter(property)
-        return f(ca)
+        cas = f(ca)
+        return [ca for ca in cas if matcher_func(ca)]
 
     @retry(
         stop_max_attempt_number=3,
@@ -64,8 +66,7 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
     def wait_until_child_ca_has_at_least_one(parent_handle, child_handle, property):
         ca = krill_ca_api.get_child_ca(parent_handle, child_handle)
         f = attrgetter(property)
-        a = f(ca)
-        return a
+        return f(ca)
 
     @retry(
         stop_max_attempt_number=3,
@@ -77,7 +78,55 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
         ca = krill_ca_api.get_ca(ca_handle)
         f = attrgetter("resources")
         res = f(ca)
-        return res.asn == asn and res.v4 == v4 and res.v6 == v6
+        return set(res.asn) == set(asn) and set(res.v4) == set(v4) and set(res.v6) == set(v6)
+
+    def add_ca(ca_handle):
+        logging.info(f'-> Adding CA "{ca_handle}"')
+        krill_ca_api.add_ca(krill_ca_api_lib.AddCARequest(ca_handle))
+
+        # rfc8183_request = krill_ca_api.get_ca_publisher_request("ta", format="json")
+        # logging.info(f'XIMON: req={rfc8183_request}')
+        krill_ca_api.update_ca_repository(
+            ca_handle,
+            rfc8183='embedded')
+        logging.info(f'-> Added CA "{ca_handle}"')
+
+    def link_child_ca_under_parent_ca(child_ca_handle, parent_ca_handle, resources):
+        logging.info(f'-> Getting RFC 8183 child request for CA "{child_ca_handle}"')
+        rfc8183_request = krill_ca_api.get_ca_child_request(child_ca_handle, format="json")
+
+        logging.info(f'-> Adding CA "{child_ca_handle}" as a child of "{parent_ca_handle}"')
+        req = krill_ca_api_lib.AddCAChildRequest(
+            handle=child_ca_handle,
+            resources=resources,
+            auth='embedded')
+            # auth={'rfc8183': rfc8183_request})
+        krill_ca_api.add_child_ca(parent_ca_handle, req)
+        logging.info(f'-> Added CA "{child_ca_handle} as a child of "{parent_ca_handle}"')
+
+        logging.info(f'-> Waiting for CA "{child_ca_handle}" to be registered as a child of "{parent_ca_handle}"')
+        wait_until_ca_has(parent_ca_handle, 'children', lambda handle: handle == child_ca_handle)
+
+        logging.info(f'-> Waiting for resources of child CA "{child_ca_handle}" to be registered')
+        wait_until_child_ca_has_at_least_one(parent_ca_handle, child_ca_handle, 'entitled_resources.asn')
+    
+    def link_parent_ca_above_child_ca(parent_ca_handle, child_ca_handle, resources):
+        logging.info(f'-> Getting RFC 6492 parent contact for CA "{child_ca_handle}"')
+        # rfc6492_request = krill_ca_api.get_child_ca_parent_contact(child_handle=child_ca_handle, ca_handle=parent_ca_handle)
+
+        logging.info(f'-> Adding CA "{parent_ca_handle}" as a parent of "{child_ca_handle}"')
+        req = krill_ca_api_lib.AddParentCARequest(
+            handle=parent_ca_handle,
+            contact='embedded')
+            # contact=rfc6492_request)
+        krill_ca_api.add_ca_parent(child_ca_handle, req)
+        logging.info(f'-> Added CA "{parent_ca_handle}" as a parent of "{child_ca_handle}"')
+
+        logging.info(f'-> Waiting for CA "{parent_ca_handle}" to be registered as a parent of "{child_ca_handle}"')
+        wait_until_ca_has(child_ca_handle, 'parents', lambda ca: ca.handle == parent_ca_handle)
+
+        logging.info(f'-> Waiting for resources of CA "{child_ca_handle}" to be issued:')
+        wait_until_ca_has_resources(child_ca_handle, resources.asn, resources.v4, resources.v6)
 
     #
     # Go!
@@ -93,10 +142,13 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
         # when investigating problems.
 
         # Get the API helper objects we need
-        krill_api_client = ApiClient(krill_api_config)
-        krill_ca_api = CertificateAuthoritiesApi(krill_api_client)
-        krill_roa_api = RouteAuthorizationsApi(krill_api_client)
-        krill_other_api = OtherApi(krill_api_client)
+        krill_ca_api_client = krill_ca_api_lib.ApiClient(krill_api_config)
+        krill_ca_api = krill_ca_api_lib.CertificateAuthoritiesApi(krill_ca_api_client)
+        krill_roa_api = krill_ca_api_lib.RouteAuthorizationsApi(krill_ca_api_client)
+        krill_other_api = krill_ca_api_lib.OtherApi(krill_ca_api_client)
+
+        krill_pub_api_client = krill_pub_api_lib.ApiClient(krill_api_config)
+        krill_pub_api = krill_pub_api_lib.PublishersApi(krill_pub_api_client)
 
         # Define the CA handles that we will work with
         ta_handle = 'ta'
@@ -111,90 +163,45 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
         # Create the desired state inside Krill
         #
 
-        logging.info('Checking if Krill has an embedded TA')
+        parent_resources = krill_ca_api_lib.Resources(asn=KRILL_PARENT_ASNS, v4=KRILL_PARENT_IPV4S, v6=KRILL_PARENT_IPV6S)
+        child_resources = krill_ca_api_lib.Resources(asn=KRILL_CHILD_ASNS, v4=KRILL_CHILD_IPV4S, v6=KRILL_CHILD_IPV6S)
+
+        pubs = krill_pub_api.list_publishers()
+
+        logging.info(f'Checking if Krill has an embedded TA "{ta_handle}"')
         ca_handles = [ca.handle for ca in krill_ca_api.list_cas().cas]
 
         if ta_handle in ca_handles:
-            logging.info('Configuring Krill for use with embedded TA')
+            logging.info(f'Configuring Krill for use with embedded TA "{ta_handle}"')
 
-            logging.info('Adding CA if not already present')
+            logging.info(f'Adding CA "{parent_handle}" if not already present')
             if not parent_handle in ca_handles:
-                logging.debug('No CA, adding...')
-                krill_ca_api.add_ca(AddCARequest(parent_handle))
-                krill_ca_api.update_ca_repository(parent_handle, 'embedded')
-                logging.debug('Added')
+                add_ca(parent_handle)
 
-            logging.info('Creating TA -> CA relationship if not already present')
-            if len(krill_ca_api.get_ca(ta_handle).children) == 0:
-                logging.debug('No children, adding...')
-                req = AddCAChildRequest(
-                    parent_handle,
-                    Resources(
-                        asn=KRILL_PARENT_ASNS,
-                        v4=KRILL_PARENT_IPV4S,
-                        v6=KRILL_PARENT_IPV6S),
-                    'embedded')
-                krill_ca_api.add_child_ca(ta_handle, req)
-                logging.debug('Added')
+            logging.info(f'Creating TA "{ta_handle}" -> CA "{parent_handle}" relationship if not already present')
+            ta_children = krill_ca_api.get_ca(ta_handle).children
+            if not parent_handle in ta_children:
+                link_child_ca_under_parent_ca(parent_handle, ta_handle, parent_resources)
 
-                logging.debug('Waiting for children to be registered')
-                wait_until_ca_has_at_least_one(ta_handle, 'children')
-
-                logging.debug('Waiting for child resources to be registered')
-                wait_until_child_ca_has_at_least_one(ta_handle, parent_handle, 'entitled_resources.asn')
-
-            logging.info('Creating TA <- CA relationship if not already present')
+            logging.info(f'Creating TA "{ta_handle}" <- CA "{parent_handle}" relationship if not already present')
             if len(krill_ca_api.get_ca(parent_handle).parents) == 0:
-                logging.debug('No parents, adding...')
-                req = AddParentCARequest(ta_handle, 'embedded')
-                krill_ca_api.add_ca_parent(parent_handle, req)
-                logging.debug('Added')
+                link_parent_ca_above_child_ca(ta_handle, parent_handle, parent_resources)
 
-                logging.debug('Waiting for parents to be registered')
-                wait_until_ca_has_at_least_one(parent_handle, 'parents')
-
-                logging.debug('Waiting for parent resources to be issued')
-                wait_until_ca_has_resources(parent_handle, KRILL_PARENT_ASNS,  KRILL_PARENT_IPV4S, KRILL_PARENT_IPV6S)
-
-            logging.info('Adding child CA if not already present')
+            logging.info(f'Adding CA "{child_handle}" if not already present')
             if not child_handle in ca_handles:
-                logging.debug('No CA, adding...')
-                krill_ca_api.add_ca(AddCARequest(child_handle))
-                krill_ca_api.update_ca_repository(child_handle, 'embedded')
-                logging.debug('Added')
+                add_ca(child_handle)
 
-            logging.info('Creating CA -> CA relationship if not already present')
+            logging.info(f'Creating CA "{parent_handle}" -> CA "{child_handle}" relationship if not already present')
             if len(krill_ca_api.get_ca(parent_handle).children) == 0:
-                logging.debug('No children, adding...')
-                req = AddCAChildRequest(
-                    child_handle,
-                    Resources(
-                        asn=KRILL_CHILD_ASNS,
-                        v4=KRILL_CHILD_IPV4S,
-                        v6=KRILL_CHILD_IPV6S),
-                    'embedded')
-                krill_ca_api.add_child_ca(parent_handle, req)
-                logging.debug('Added')
+                link_child_ca_under_parent_ca(child_handle, parent_handle, child_resources)
 
-                logging.debug('Waiting for children to be registered')
-                wait_until_ca_has_at_least_one(parent_handle, 'children')
-
-                logging.debug('Waiting for child resources to be registered')
-                wait_until_child_ca_has_at_least_one(parent_handle, child_handle, 'entitled_resources.asn')
-
-            logging.info('Creating CA <- CA relationship if not already present')
+            logging.info(f'Creating CA "{parent_handle}" <- CA "{child_handle}" relationship if not already present')
             if len(krill_ca_api.get_ca(child_handle).parents) == 0:
-                logging.debug('No parents, adding...')
-                req = AddParentCARequest(parent_handle, 'embedded')
-                krill_ca_api.add_ca_parent(child_handle, req)
-                logging.debug('Added')
+                link_parent_ca_above_child_ca(parent_handle, child_handle, child_resources)
 
-                logging.debug('Waiting for parents to be registered')
-                wait_until_ca_has_at_least_one(child_handle, 'parents')
-
-            logging.info('Creating CA ROAs if not already present')
+            logging.info(f'Creating CA "{child_handle}" ROAs if not already present')
             if len(krill_roa_api.list_route_authorizations(child_handle)) == 0:
-                delta = ROADelta(added=TEST_ROAS, removed=[])
+                delta = krill_ca_api_lib.ROADelta(added=TEST_ROAS, removed=[])
 
                 @retry(
                     stop_max_attempt_number=3,
@@ -202,7 +209,7 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
                     wait_exponential_max=10000,
                     wrap_exception=True)
                 def update_roas():
-                    logging.debug('Updating ROAs...')
+                    logging.info('Updating ROAs...')
                     krill_roa_api.update_route_authorizations(child_handle, delta)
 
                 update_roas()
@@ -215,7 +222,7 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
         else:
             pytest.fail(f'Retries exhausted while configuring Krill: {e}')
 
-    yield krill_api_client
+    yield (krill_ca_api_client, krill_pub_api_client)
 
 
 @pytest.mark.usefixtures("krill_with_roas")
@@ -230,28 +237,40 @@ class TestKrillWithRelyingParties:
     def test_rtr(self, docker_host_fqdn, docker_project, function_service_manager, service, metadata):
         function_service_manager.start_services_with_dependencies(docker_project, service.name)
 
-        try:
-            rtr_start_time = int(time())
-            logging.info(f'Connecting RTR client to {docker_host_fqdn}:{service.rtr_port}')
-            received_roas = set(rtr_fetch_one(docker_host_fqdn, service.rtr_port, service.rtr_timeout_seconds))
-            rtr_elapsed_time = int(time()) - rtr_start_time
+        def retry_if_sync_timeout(exception):
+            return isinstance(exception, rtrlib.exceptions.SyncTimeout)
 
-            # r is now a list of PFXRecord
-            # see: https://python-rtrlib.readthedocs.io/en/latest/api.html#rtrlib.records.PFXRecord
-            logging.info(f'Received {len(received_roas)} ROAs via RTR from {service.name} in {rtr_elapsed_time} seconds')
-
-            # are each of the TEST_ROAS items in r?
-            # i.e. is the intersection of the two sets equal to that of the TEST_ROAS set?
-
-            logging.info(f'Comparing {len(received_roas)} received ROAs to {len(TEST_ROAS)} expected ROAs...')
-            expected_roas = set([roa_to_roa_string(r) for r in TEST_ROAS])
-            assert received_roas == expected_roas
-        except rtrlib.exceptions.SyncTimeout as e:
-            logging.error(f'Timeout (>{service.rtr_timeout_seconds} seconds) while syncing RTR with {service.name} at {docker_host_fqdn}:{service.rtr_port}')
+        @retry(
+            stop_max_attempt_number=3,
+            wait_exponential_multiplier=1000,
+            wait_exponential_max=10000,
+            retry_on_exception=retry_if_sync_timeout,
+            wrap_exception=True)
+        def fetch_from_rtr_server():
             try:
-                if not service.is_ready():
-                    logging.error(f'{service.name} is not ready')
-            except Exception as innerE:
-                logging.error(f'Unable to determine if {service.name} is ready: {innerE}')
+                rtr_start_time = int(time())
+                logging.info(f'Connecting RTR client to {docker_host_fqdn}:{service.rtr_port}')
+                received_roas = set(rtr_fetch_one(docker_host_fqdn, service.rtr_port, service.rtr_timeout_seconds))
+                rtr_elapsed_time = int(time()) - rtr_start_time
+    
+                # r is now a list of PFXRecord
+                # see: https://python-rtrlib.readthedocs.io/en/latest/api.html#rtrlib.records.PFXRecord
+                logging.info(f'Received {len(received_roas)} ROAs via RTR from {service.name} in {rtr_elapsed_time} seconds')
+    
+                # are each of the TEST_ROAS items in r?
+                # i.e. is the intersection of the two sets equal to that of the TEST_ROAS set?
+    
+                logging.info(f'Comparing {len(received_roas)} received ROAs to {len(TEST_ROAS)} expected ROAs...')
+                expected_roas = set([roa_to_roa_string(r) for r in TEST_ROAS])
+                assert received_roas == expected_roas
+            except rtrlib.exceptions.SyncTimeout as e:
+                logging.error(f'Timeout (>{service.rtr_timeout_seconds} seconds) while syncing RTR with {service.name} at {docker_host_fqdn}:{service.rtr_port}')
+                try:
+                    if not service.is_ready():
+                        logging.error(f'{service.name} is not ready')
+                except Exception as innerE:
+                    logging.error(f'Unable to determine if {service.name} is ready: {innerE}')
+    
+                raise e
 
-            raise e
+        fetch_from_rtr_server()

--- a/tests/e2e/simple_rp_roa_test.py
+++ b/tests/e2e/simple_rp_roa_test.py
@@ -80,6 +80,9 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
         res = f(ca)
         return set(res.asn) == set(asn) and set(res.v4) == set(v4) and set(res.v6) == set(v6)
 
+    #
+    # define some helper functions
+    #
     def add_ca(ca_handle):
         logging.info(f'-> Adding CA "{ca_handle}"')
         krill_ca_api.add_ca(krill_ca_api_lib.AddCARequest(ca_handle))

--- a/tests/e2e/simple_rp_roa_test.py
+++ b/tests/e2e/simple_rp_roa_test.py
@@ -238,6 +238,10 @@ class TestKrillWithRelyingParties:
 
     @pytest.mark.parametrize("service", [Routinator, FortValidator, OctoRPKI, Rcynic, RPKIClient, RPKIValidator3])
     def test_rtr(self, docker_host_fqdn, docker_project, function_service_manager, service, metadata):
+        #
+        # Use Docker Compose to deploy the given Relying Party service and its dependendencies.
+        # On tear down the service container and its dependent containers will be killed and removed.
+        #
         function_service_manager.start_services_with_dependencies(docker_project, service.name)
 
         def retry_if_sync_timeout(exception):

--- a/tests/e2e/simple_rp_roa_test.py
+++ b/tests/e2e/simple_rp_roa_test.py
@@ -87,8 +87,6 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
         logging.info(f'-> Adding CA "{ca_handle}"')
         krill_ca_api.add_ca(krill_ca_api_lib.AddCARequest(ca_handle))
 
-        # rfc8183_request = krill_ca_api.get_ca_publisher_request("ta", format="json")
-        # logging.info(f'XIMON: req={rfc8183_request}')
         krill_ca_api.update_ca_repository(
             ca_handle,
             rfc8183='embedded')
@@ -115,13 +113,11 @@ def krill_with_roas(docker_project, krill_api_config, class_service_manager):
     
     def link_parent_ca_above_child_ca(parent_ca_handle, child_ca_handle, resources):
         logging.info(f'-> Getting RFC 6492 parent contact for CA "{child_ca_handle}"')
-        # rfc6492_request = krill_ca_api.get_child_ca_parent_contact(child_handle=child_ca_handle, ca_handle=parent_ca_handle)
 
         logging.info(f'-> Adding CA "{parent_ca_handle}" as a parent of "{child_ca_handle}"')
         req = krill_ca_api_lib.AddParentCARequest(
             handle=parent_ca_handle,
             contact='embedded')
-            # contact=rfc6492_request)
         krill_ca_api.add_ca_parent(child_ca_handle, req)
         logging.info(f'-> Added CA "{parent_ca_handle}" as a parent of "{child_ca_handle}"')
 


### PR DESCRIPTION
(depends on [rpki-deploy PR #28](https://github.com/NLnetLabs/rpki-deploy/pull/28))

- OpenAPI YML corrections.
- Support the new way to activate the TA (in the Krill Docker image).
- FIX: Include the correct ta.cer URI in the TAL.
- Use two seprarate Python libraries for Krill: one for CA REST SAPIs and one for PUB REST APIs.
- FIX: Test for the actual CAs and resources to create, as the presence of the testbed CA violates the previous check assumptions.
- FIX: Resource ASN, v4 and v6 values can no longer be assumed to have the same sort order as when given to Krill.
- Factor out test suite code into helper functions for better readability and maintainability.
- Retry RTR fetching (needed for ROAs obtained from Rcynic Lihttpd server served JSON as otherwise connecting too early results in SyncTimeout).

Note:
- Works locally, not yet tested via GH Actions.
- Currently depends on a personal test build of a Docker image of the main RTRTR branch. v0.1.1 could not be used as it requires the `signature` metadata field to be present which is not the case for the custom scripting that creates ROA JSON output for Rcynic and rpk-client in the Krill e2e test. With goRTR it worked because goRTR supports using unsigned ROA JSON as input.