### PR TITLE
Schedule parent/repo syncs even if there is another sync on the queue (#445)

### DIFF
--- a/src/daemon/mq.rs
+++ b/src/daemon/mq.rs
@@ -3,12 +3,9 @@
 //! signed material, or asking a newly added parent for resource
 //! entitlements.
 
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::RwLock;
-use std::{
-    collections::{HashMap, VecDeque},
-    sync::RwLockWriteGuard,
-};
 
 use rpki::x509::Time;
 
@@ -86,73 +83,29 @@ impl MessageQueue {
         res
     }
 
-    pub fn schedule_sync_repo(&self, ca: Handle) {
+    fn schedule(&self, task: QueueTask) {
         let mut q = self.q.write().unwrap();
-        Self::push_back(&mut q, QueueTask::SyncRepo(ca));
+        q.push_back(task);
+    }
+
+    pub fn schedule_sync_repo(&self, ca: Handle) {
+        self.schedule(QueueTask::SyncRepo(ca));
     }
 
     pub fn reschedule_sync_repo(&self, ca: Handle, time: Time) {
-        let mut q = self.q.write().unwrap();
-        Self::push_back(&mut q, QueueTask::RescheduleSyncRepo(ca, time));
+        self.schedule(QueueTask::RescheduleSyncRepo(ca, time));
+    }
+
+    pub fn schedule_sync_parent(&self, ca: Handle, parent: ParentHandle) {
+        self.schedule(QueueTask::SyncParent(ca, parent));
     }
 
     pub fn reschedule_sync_parent(&self, ca: Handle, parent: ParentHandle, time: Time) {
+        self.schedule(QueueTask::RescheduleSyncParent(ca, parent, time));
+    }
+
+    fn drop_sync_parent(&self, ca: &Handle, parent: &ParentHandle) {
         let mut q = self.q.write().unwrap();
-        Self::push_back(&mut q, QueueTask::RescheduleSyncParent(ca, parent, time));
-    }
-
-    /// Add a queue event to the back of the queue UNLESS there is
-    /// already an equivalent event scheduled.
-    pub fn push_back(q: &mut RwLockWriteGuard<VecDeque<QueueTask>>, evt: QueueTask) {
-        match &evt {
-            QueueTask::SyncRepo(ca) | QueueTask::RescheduleSyncRepo(ca, _) => {
-                for existing in q.iter() {
-                    match existing {
-                        QueueTask::SyncRepo(existing_ca) | QueueTask::RescheduleSyncRepo(existing_ca, _) => {
-                            if existing_ca == ca {
-                                debug!(
-                                    "Not (re-)scheduling publication for '{}', because event exists on queue",
-                                    ca
-                                );
-                                return;
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            QueueTask::SyncParent(ca, parent) | QueueTask::RescheduleSyncParent(ca, parent, _) => {
-                for existing in q.iter() {
-                    match existing {
-                        QueueTask::SyncParent(existing_ca, existing_parent)
-                        | QueueTask::RescheduleSyncParent(existing_ca, existing_parent, _) => {
-                            if existing_ca == ca && existing_parent == parent {
-                                debug!(
-                                    "Not (re-)scheduling sync for '{}' with parent '{}', because event exists on queue",
-                                    ca, parent
-                                );
-                                return;
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            _ => {}
-        }
-
-        q.push_back(evt);
-    }
-
-    pub fn push_sync_repo(q: &mut RwLockWriteGuard<VecDeque<QueueTask>>, ca: Handle) {
-        Self::push_back(q, QueueTask::SyncRepo(ca))
-    }
-
-    pub fn push_sync_parent(q: &mut RwLockWriteGuard<VecDeque<QueueTask>>, ca: Handle, parent: ParentHandle) {
-        Self::push_back(q, QueueTask::SyncParent(ca, parent))
-    }
-
-    pub fn drop_sync_parent(q: &mut RwLockWriteGuard<VecDeque<QueueTask>>, ca: &Handle, parent: &ParentHandle) {
         q.retain(|existing| match existing {
             QueueTask::SyncParent(ex_ca, ex_parent) | QueueTask::RescheduleSyncParent(ex_ca, ex_parent, _) => {
                 ca != ex_ca || parent != ex_parent
@@ -168,8 +121,6 @@ unsafe impl Sync for MessageQueue {}
 /// Implement listening for CertAuth Published events.
 impl eventsourcing::PostSaveEventListener<CertAuth> for MessageQueue {
     fn listen(&self, ca: &CertAuth, events: &[CaEvt]) {
-        let mut queue = self.q.write().unwrap();
-
         for event in events {
             trace!("Seen CertAuth event '{}'", event);
 
@@ -181,20 +132,20 @@ impl eventsourcing::PostSaveEventListener<CertAuth> for MessageQueue {
                 | CaEvtDet::ChildKeyRevoked { .. }
                 | CaEvtDet::KeyPendingToNew { .. }
                 | CaEvtDet::KeyPendingToActive { .. }
-                | CaEvtDet::KeyRollFinished { .. } => Self::push_sync_repo(&mut queue, handle.clone()),
+                | CaEvtDet::KeyRollFinished { .. } => self.schedule_sync_repo(handle.clone()),
 
                 CaEvtDet::KeyRollActivated {
                     resource_class_name, ..
                 } => {
                     if let Ok(parent) = ca.parent_for_rc(resource_class_name) {
-                        Self::push_sync_parent(&mut queue, handle.clone(), parent.clone());
+                        self.schedule_sync_parent(handle.clone(), parent.clone());
                     }
-                    Self::push_sync_repo(&mut queue, handle.clone());
+                    self.schedule_sync_repo(handle.clone());
                 }
 
                 CaEvtDet::ParentRemoved { parent } => {
-                    Self::drop_sync_parent(&mut queue, &handle, parent);
-                    Self::push_sync_repo(&mut queue, handle.clone());
+                    self.drop_sync_parent(&handle, parent);
+                    self.schedule_sync_repo(handle.clone());
                 }
 
                 CaEvtDet::ResourceClassRemoved {
@@ -202,38 +153,40 @@ impl eventsourcing::PostSaveEventListener<CertAuth> for MessageQueue {
                     parent,
                     revoke_reqs,
                 } => {
-                    Self::push_sync_repo(&mut queue, handle.clone());
+                    self.schedule_sync_repo(handle.clone());
 
                     let mut revocations_map = HashMap::new();
                     revocations_map.insert(resource_class_name.clone(), revoke_reqs.clone());
 
-                    Self::push_back(
-                        &mut queue,
-                        QueueTask::ResourceClassRemoved(handle.clone(), parent.clone(), revocations_map),
-                    )
+                    self.schedule(QueueTask::ResourceClassRemoved(
+                        handle.clone(),
+                        parent.clone(),
+                        revocations_map,
+                    ))
                 }
 
                 CaEvtDet::UnexpectedKeyFound {
                     resource_class_name,
                     revoke_req,
-                } => Self::push_back(
-                    &mut queue,
-                    QueueTask::UnexpectedKey(handle.clone(), resource_class_name.clone(), revoke_req.clone()),
-                ),
+                } => self.schedule(QueueTask::UnexpectedKey(
+                    handle.clone(),
+                    resource_class_name.clone(),
+                    revoke_req.clone(),
+                )),
 
                 CaEvtDet::ParentAdded { parent, .. } => {
-                    Self::push_sync_parent(&mut queue, handle.clone(), parent.clone());
+                    self.schedule_sync_parent(handle.clone(), parent.clone());
                 }
                 CaEvtDet::RepoUpdated { .. } => {
                     for parent in ca.parents() {
-                        Self::push_sync_parent(&mut queue, handle.clone(), parent.clone());
+                        self.schedule_sync_parent(handle.clone(), parent.clone());
                     }
                 }
                 CaEvtDet::CertificateRequested {
                     resource_class_name, ..
                 } => {
                     if let Ok(parent) = ca.parent_for_rc(resource_class_name) {
-                        Self::push_sync_parent(&mut queue, handle.clone(), parent.clone());
+                        self.schedule_sync_parent(handle.clone(), parent.clone());
                     }
                 }
 


### PR DESCRIPTION
There was an optimisation to not synchronise with a repo, or parent, when it was already scheduled.

But it seems that this can lead to race conditions, especially on slow (virtual) hardware. Doing the synchronisation too often does not hurt, so this change just removes this optimisation.