### PR TITLE
Try harder to use the right e2e framework branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,12 +58,12 @@ jobs:
           # corresponding branch in the framework repo, use that branch.
           echo "::set-output name=branch::${GITHUB_HEAD_REF}"
 
-        elif git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy ${GITHUB_HEAD_REF}; then
+        elif git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy ${GITHUB_BASE_REF}; then
           # If the e2e test framework has been modified for the branch we are merging into it will have a corresponding
           # branch in the framework repo and we will need to run that version of the framework, not the master version.
           echo "::set-output name=branch::${GITHUB_BASE_REF}"
 
-        elif git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy ${GITHUB_HEAD_REF}; then
+        else
           # Otherwise use the master branch version.
           echo "::set-output name=branch::master"
         fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,15 +53,18 @@ jobs:
       id: pick_e2e_branch
       shell: bash
       run: |
-        echo "GITHUB_REF=${GITHUB_REF}"
-        echo "GITHUB_HEAD_REF=${GITHUB_HEAD_REF}"
-        BRANCH=${GITHUB_REF#refs/heads/}
-
-        if git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy ${BRANCH}; then
-          echo "::set-output name=branch::${BRANCH}"
-        elif git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy ${GITHUB_HEAD_REF}; then
+        if git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy ${GITHUB_HEAD_REF}; then
+          # If the e2e test framework has been modified specifically for this branch and thus there exists a dedicated
+          # corresponding branch in the framework repo, use that branch.
           echo "::set-output name=branch::${GITHUB_HEAD_REF}"
-        else
+
+        elif git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy ${GITHUB_HEAD_REF}; then
+          # If the e2e test framework has been modified for the branch we are merging into it will have a corresponding
+          # branch in the framework repo and we will need to run that version of the framework, not the master version.
+          echo "::set-output name=branch::${GITHUB_BASE_REF}"
+
+        elif git ls-remote --exit-code --heads https://github.com/NLnetLabs/rpki-deploy ${GITHUB_HEAD_REF}; then
+          # Otherwise use the master branch version.
           echo "::set-output name=branch::master"
         fi
 


### PR DESCRIPTION
If there's no e2e framework branch for our branch, check if there is an e2e framework branch for our base branch before falling back to master.