### PR TITLE
Bump openidconnect dependency from beta to final

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,9 +1380,9 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.0.0-beta.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64828351c656346fb1b8cb0622b4170c4bb5a382bf4c19666ce395722d08594"
+checksum = "10ad4d0136960353683efa6160b9c867088b4b8f567b762cd37420a10ce32703"
 dependencies = [
  "base64 0.12.3",
  "chrono",
@@ -1416,9 +1416,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openidconnect"
-version = "2.0.0-beta.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c051ae25ec20dc81bb0308c6d7b84556caaefea0cbbae5ec5611f0fcc843e7"
+checksum = "18109beef43a1435463ec7b575b3bd5ab94084bc331b317e12b5e9fdb17143f4"
 dependencies = [
  "base64 0.12.3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ intervaltree    = "0.2.6"
 jmespatch       = { version = "^0.3", features = ["sync"], optional = true }
 libflate        = "^1.0"
 log             = "^0.4"
-openidconnect   = { version = "^2.0.0-beta", optional = true, default_features = false }
+openidconnect   = { version = "^2.0.0", optional = true, default_features = false }
 openssl         = { version = "^0.10", features = ["v110"] }
 oso             = { version = "^0.12", optional = true }
 regex           = { version = "^1.4", optional = true }


### PR DESCRIPTION
No functional changes, just promotion of the last pre-release build to final release status.