### PR TITLE
Return null instead of an error on null input to JMESPath fn resub().

### DIFF
--- a/src/daemon/auth/providers/openid_connect/jmespathext.rs
+++ b/src/daemon/auth/providers/openid_connect/jmespathext.rs
@@ -33,17 +33,22 @@ fn make_recap_fn() -> Box<CustomFunction> {
 
         if let jmespath::Variable::String(str) = &*args[0] {
             if let jmespath::Variable::String(re_str) = &*args[1] {
-                let re = Regex::new(&re_str).unwrap_or_else(|_| {
-                    panic!(
-                        "Invalid regular expression for '{}' for recap() JMESPath function",
-                        &re_str
-                    )
-                });
-                let mut iter = re.captures_iter(&str);
-                if let Some(captures) = iter.next() {
-                    // captures[0] is the entire match
-                    // captures[1] is the value of the first capture group match
-                    res = captures[1].to_string();
+                match Regex::new(&re_str) {
+                    Ok(re) => {
+                        let mut iter = re.captures_iter(&str);
+                        if let Some(captures) = iter.next() {
+                            // captures[0] is the entire match
+                            // captures[1] is the value of the first capture group match
+                            res = captures[1].to_string();
+                        }
+                    }
+                    Err(err) => {
+                        return Err(JmespathError::new(
+                            &re_str,
+                            0,
+                            ErrorReason::Parse(format!("Invalid regular expression: {}", err)),
+                        ));
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a problem with JMESPath matching when using the custom `resub()` function with null input.

Prior to this PR this causes `resub()` to abort with an error. However, resub should return its input unchanged if there is no match to substitute, and null is a useful input to support when `resub()` is chained with another JMESPath expression.

For example, given this `krill.conf` fragment:
```
[auth_openidconnect.claims]
admin_role = { jmespath="resub(groups[?@ == '0bbdc586-e843-44e4-aece-a47ef113a2a0'] | [0], '^.+$', 'admin')", dest="role" }
readonly_role = { jmespath="resub(groups[?@ == '4d85e06b-2e0d-4554-b0bd-bf6030462f00'] | [0], '^.+$', 'readonly')", dest="role" }
```

Prior to this PR if the specified "admin" group is present in the users OpenID Connect claims but the "readonly" group is not, the user will not be granted the admin role as the claim matching process will abort with an error.

With this PR the null input (caused by `groups[?# == '...']` returning `[]` and the zeroth element of this empty collection being selected by `| [0]` which is not possible and thus results in null) simply causes the `readonly_role` use of `resub()` to fail to match, it no longer causes an error. At a JMESPath custom function level the problem occurred not within the custom `resub()` function itself but because the function was registered as only taking a String input and thus not being usable with a Null input. This PR registers the function as taking Any input and then checks for it being a String or not.

This PR also replaces some panics with error returns and adds a couple of unit tests for the null input case and for verifying that an invalid regular expression causes an error rather than a panic.

More tests should be added to this unit test suite but that's beyond the immediate scope of catching this null failure.