### PR TITLE
Migrate CA repository using key rollover (#480)

### DIFF
--- a/src/commons/error.rs
+++ b/src/commons/error.rs
@@ -223,7 +223,6 @@ pub enum Error {
 
     // CA Repo Issues
     CaRepoInUse(Handle),
-    CaRepoAlreadyConfigured(Handle),
     CaRepoIssue(Handle, String),
     CaRepoResponseInvalidXml(Handle, String),
     CaRepoResponseWrongXml(Handle),
@@ -371,7 +370,6 @@ impl fmt::Display for Error {
 
             // CA Repo Issues
             Error::CaRepoInUse(ca) => write!(f, "CA '{}' already uses this repository", ca),
-            Error::CaRepoAlreadyConfigured(ca) => write!(f, "CA '{}' already has a repository, see issue 481 for planned work to support migrations", ca),
             Error::CaRepoIssue(ca, e) => write!(f, "CA '{}' cannot get response from repository '{}'. Is the 'service_uri' in the XML reachable? Note that when upgrading Krill you should re-use existing configuration and data. For a fresh \
             re-install of Krill you will need to send XML to all other parties again: parent(s), children, and repository", ca,        e),
             Error::CaRepoResponseInvalidXml(ca, e) => write!(f, "CA '{}' got invalid repository response xml: {}", ca, e),
@@ -680,7 +678,6 @@ impl Error {
             Error::CaUnknown(ca) => ErrorResponse::new("ca-unknown", &self).with_ca(ca),
 
             Error::CaRepoInUse(ca) => ErrorResponse::new("ca-repo-same", &self).with_ca(ca),
-            Error::CaRepoAlreadyConfigured(ca) => ErrorResponse::new("ca-repo-already-configured", &self).with_ca(ca),
 
             Error::CaRepoIssue(ca, err) => ErrorResponse::new("ca-repo-issue", &self).with_ca(ca).with_cause(err),
 

--- a/tests/migrate_repository.rs
+++ b/tests/migrate_repository.rs
@@ -218,7 +218,6 @@ async fn state_becomes_active(handle: &Handle) -> bool {
 }
 
 #[tokio::test]
-#[ignore = "See issue 481"]
 async fn migrate_repository() {
     init_logging();
 
@@ -423,6 +422,19 @@ async fn migrate_repository() {
             );
         }
     }
+
+    info("##################################################################");
+    info("#                                                                #");
+    info("#            -------====== SUCCESS ======-------                 #");
+    info("#                                                                #");
+    info("#                                                                #");
+    info("#  Test finished successfully.. please ignore any errors after   #");
+    info("#  this point - you might see errors from CAs which cannot       #");
+    info("#  synchronize from background threads as the server is shutting #");
+    info("#  down.                                                         #");
+    info("#                                                                #");
+    info("##################################################################");
+
 
     let _ = fs::remove_dir_all(krill_dir);
     let _ = fs::remove_dir_all(pubd_dir);


### PR DESCRIPTION
As it turns out - this was broken earlier because of a failure to republish objects during a key roll during 0.9.0 development - fixed in issue #509 prior to the 0.9.0 release.

Note, there is a remaining - unrelated - issue that can lead to long running tests. The background job scheduler is based on 'clokwerk' and lives in runtime of its own (hiding async stuff). This can lead to the scheduler continuing to run for up to two minutes when the test (functional.rs) is being torn down. We should re-investigate the schedular in future - this is also relevant when we want to look at multi active-node clustering.