### PR TITLE
Monitor krill versions

### DIFF
--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -9,8 +9,8 @@ use rpki::uri;
 use crate::cli::options::KrillUserDetails;
 use crate::cli::report::{ApiResponse, ReportError};
 use crate::commons::api::{
-    AllCertAuthIssues, CaRepoDetails, CertAuthIssues, ChildCaInfo, ParentCaContact, ParentStatuses, PublisherDetails,
-    PublisherList, RepoStatus, Token,
+    AllCertAuthIssues, CaRepoDetails, CertAuthIssues, ChildCaInfo, ChildrenConnectionStats, ParentCaContact,
+    ParentStatuses, PublisherDetails, PublisherList, RepoStatus, Token,
 };
 use crate::commons::bgp::BgpAnalysisAdvice;
 use crate::commons::remote::rfc8183;
@@ -257,6 +257,11 @@ impl KrillClient {
                 let uri = format!("api/v1/cas/{}/children/{}", handle, child);
                 delete(&self.server, &self.token, &uri).await?;
                 Ok(ApiResponse::Empty)
+            }
+            CaCommand::ChildConnections(handle) => {
+                let uri = format!("api/v1/cas/{}/children", handle);
+                let stats: ChildrenConnectionStats = get_json(&self.server, &self.token, &uri).await?;
+                Ok(ApiResponse::ChildrenStats(stats))
             }
 
             CaCommand::KeyRollInit(handle) => {

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -259,7 +259,7 @@ impl KrillClient {
                 Ok(ApiResponse::Empty)
             }
             CaCommand::ChildConnections(handle) => {
-                let uri = format!("api/v1/cas/{}/children", handle);
+                let uri = format!("api/v1/cas/{}/stats/children/connections", handle);
                 let stats: ChildrenConnectionStats = get_json(&self.server, &self.token, &uri).await?;
                 Ok(ApiResponse::ChildrenStats(stats))
             }

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -9,9 +9,9 @@ use std::{env, fmt};
 use bytes::Bytes;
 use clap::{App, Arg, ArgMatches, SubCommand};
 
-use rpki::uri;
 use rpki::repository::crypto::KeyIdentifier;
 use rpki::repository::x509::Time;
+use rpki::uri;
 
 use crate::commons::crypto::{IdCert, SignSupport};
 use crate::commons::remote::rfc8183;
@@ -469,6 +469,15 @@ impl Options {
         app.subcommand(sub)
     }
 
+    fn make_cas_children_connections_sc<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
+        let mut sub = SubCommand::with_name("connections").about("Show connections stats for children of a CA");
+
+        sub = Self::add_general_args(sub);
+        sub = Self::add_my_ca_arg(sub);
+
+        app.subcommand(sub)
+    }
+
     fn make_cas_children_sc<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         let mut sub = SubCommand::with_name("children").about("Manage children for a CA");
 
@@ -477,6 +486,7 @@ impl Options {
         sub = Self::make_cas_children_info_sc(sub);
         sub = Self::make_cas_children_remove_sc(sub);
         sub = Self::make_cas_children_response_sc(sub);
+        sub = Self::make_cas_children_connections_sc(sub);
 
         app.subcommand(sub)
     }
@@ -1409,6 +1419,14 @@ impl Options {
         Ok(Options::make(general_args, command))
     }
 
+    fn parse_matches_cas_children_connections(matches: &ArgMatches) -> Result<Options, Error> {
+        let general_args = GeneralArgs::from_matches(matches)?;
+        let my_ca = Self::parse_my_ca(matches)?;
+
+        let command = Command::CertAuth(CaCommand::ChildConnections(my_ca));
+        Ok(Options::make(general_args, command))
+    }
+
     fn parse_matches_cas_children(matches: &ArgMatches) -> Result<Options, Error> {
         if let Some(m) = matches.subcommand_matches("add") {
             Self::parse_matches_cas_children_add(m)
@@ -1420,6 +1438,8 @@ impl Options {
             Self::parse_matches_cas_children_update(m)
         } else if let Some(m) = matches.subcommand_matches("remove") {
             Self::parse_matches_cas_children_remove(m)
+        } else if let Some(m) = matches.subcommand_matches("connections") {
+            Self::parse_matches_cas_children_connections(m)
         } else {
             Err(Error::UnrecognizedSubCommand)
         }
@@ -2087,6 +2107,7 @@ pub enum CaCommand {
     ChildAdd(Handle, AddChildRequest),
     ChildUpdate(Handle, ChildHandle, UpdateChildRequest),
     ChildDelete(Handle, ChildHandle),
+    ChildConnections(Handle),
 
     // Key Management
     KeyRollInit(Handle),

--- a/src/cli/report.rs
+++ b/src/cli/report.rs
@@ -5,8 +5,8 @@ use serde::Serialize;
 
 use crate::commons::api::{
     AllCertAuthIssues, CaCommandDetails, CaRepoDetails, CertAuthInfo, CertAuthIssues, CertAuthList, ChildCaInfo,
-    CommandHistory, ParentCaContact, ParentStatuses, PublisherDetails, PublisherList, RepoStatus, RoaDefinitions,
-    RtaList, RtaPrepResponse, ServerInfo,
+    ChildrenConnectionStats, CommandHistory, ParentCaContact, ParentStatuses, PublisherDetails, PublisherList,
+    RepoStatus, RoaDefinitions, RtaList, RtaPrepResponse, ServerInfo,
 };
 use crate::commons::bgp::{BgpAnalysisAdvice, BgpAnalysisReport, BgpAnalysisSuggestion};
 use crate::commons::remote::api::ClientInfos;
@@ -36,6 +36,7 @@ pub enum ApiResponse {
     ParentStatuses(ParentStatuses),
 
     ChildInfo(ChildCaInfo),
+    ChildrenStats(ChildrenConnectionStats),
 
     PublisherDetails(PublisherDetails),
     PublisherList(PublisherList),
@@ -81,6 +82,7 @@ impl ApiResponse {
                 ApiResponse::ParentCaContact(contact) => Ok(Some(contact.report(fmt)?)),
                 ApiResponse::ParentStatuses(statuses) => Ok(Some(statuses.report(fmt)?)),
                 ApiResponse::ChildInfo(info) => Ok(Some(info.report(fmt)?)),
+                ApiResponse::ChildrenStats(stats) => Ok(Some(stats.report(fmt)?)),
                 ApiResponse::PublisherList(list) => Ok(Some(list.report(fmt)?)),
                 ApiResponse::PublisherDetails(details) => Ok(Some(details.report(fmt)?)),
                 ApiResponse::RepoStats(stats) => Ok(Some(stats.report(fmt)?)),
@@ -177,6 +179,7 @@ impl Report for CaCommandDetails {}
 impl Report for PublisherList {}
 
 impl Report for RepoStats {}
+impl Report for ChildrenConnectionStats {}
 
 impl Report for PublisherDetails {}
 

--- a/src/commons/api/ca.rs
+++ b/src/commons/api/ca.rs
@@ -1538,6 +1538,30 @@ impl fmt::Display for ExchangeResult {
     }
 }
 
+//------------ ChildrenStats -------------------------------------------------
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ChildrenStats {
+    children: Vec<ChildStats>,
+}
+
+impl ChildrenStats {
+    pub fn new(children: Vec<ChildStats>) -> Self {
+        ChildrenStats { children }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ChildStats {
+    handle: ChildHandle,
+    last_exchange: Option<ChildExchange>,
+}
+
+impl ChildStats {
+    pub fn new(handle: ChildHandle, last_exchange: Option<ChildExchange>) -> Self {
+        ChildStats { handle, last_exchange }
+    }
+}
+
 //------------ ChildStatus ---------------------------------------------------
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1566,6 +1590,12 @@ impl ChildStatus {
 impl Default for ChildStatus {
     fn default() -> Self {
         ChildStatus { last_exchange: None }
+    }
+}
+
+impl From<ChildStatus> for Option<ChildExchange> {
+    fn from(status: ChildStatus) -> Self {
+        status.last_exchange
     }
 }
 

--- a/src/commons/api/ca.rs
+++ b/src/commons/api/ca.rs
@@ -1538,27 +1538,57 @@ impl fmt::Display for ExchangeResult {
     }
 }
 
-//------------ ChildrenStats -------------------------------------------------
+//------------ ChildConnectionStats ------------------------------------------
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ChildrenStats {
-    children: Vec<ChildStats>,
+pub struct ChildrenConnectionStats {
+    children: Vec<ChildConnectionStats>,
 }
 
-impl ChildrenStats {
-    pub fn new(children: Vec<ChildStats>) -> Self {
-        ChildrenStats { children }
+impl ChildrenConnectionStats {
+    pub fn new(children: Vec<ChildConnectionStats>) -> Self {
+        ChildrenConnectionStats { children }
+    }
+}
+
+impl fmt::Display for ChildrenConnectionStats {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if !self.children.is_empty() {
+            writeln!(f, "handle, user_agent, last_exchange, result")?;
+            for child in &self.children {
+                match &child.last_exchange {
+                    None => {
+                        writeln!(f, "{}, n/a, never, n/a", child.handle)?;
+                    }
+                    Some(exchange) => {
+                        let agent = exchange.user_agent.as_deref().unwrap_or("");
+                        let time = Time::new(Utc.timestamp(exchange.timestamp, 0));
+
+                        writeln!(
+                            f,
+                            "{},{},{},{}",
+                            child.handle,
+                            agent,
+                            time.to_rfc3339(),
+                            exchange.result
+                        )?;
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ChildStats {
+pub struct ChildConnectionStats {
     handle: ChildHandle,
     last_exchange: Option<ChildExchange>,
 }
 
-impl ChildStats {
+impl ChildConnectionStats {
     pub fn new(handle: ChildHandle, last_exchange: Option<ChildExchange>) -> Self {
-        ChildStats { handle, last_exchange }
+        ChildConnectionStats { handle, last_exchange }
     }
 }
 

--- a/src/commons/api/ca.rs
+++ b/src/commons/api/ca.rs
@@ -1558,7 +1558,7 @@ impl fmt::Display for ChildrenConnectionStats {
             for child in &self.children {
                 match &child.last_exchange {
                     None => {
-                        writeln!(f, "{}, n/a, never, n/a", child.handle)?;
+                        writeln!(f, "{},n/a,never,n/a", child.handle)?;
                     }
                     Some(exchange) => {
                         let agent = exchange.user_agent.as_deref().unwrap_or("");

--- a/src/commons/api/ca.rs
+++ b/src/commons/api/ca.rs
@@ -1355,7 +1355,7 @@ impl ParentStatus {
         self.last_exchange = Some(ParentExchange {
             timestamp: Time::now().timestamp(),
             uri,
-            result: ParentExchangeResult::Failure(error),
+            result: ExchangeResult::Failure(error),
         });
         self.set_next_exchange_plus_seconds(next_seconds);
     }
@@ -1386,7 +1386,7 @@ impl ParentStatus {
         self.last_exchange = Some(ParentExchange {
             timestamp: Time::now().timestamp(),
             uri,
-            result: ParentExchangeResult::Success,
+            result: ExchangeResult::Success,
         });
         self.set_next_exchange_plus_seconds(next_run_seconds);
     }
@@ -1443,7 +1443,7 @@ impl RepoStatus {
         self.last_exchange = Some(ParentExchange {
             timestamp: Time::now().timestamp(),
             uri,
-            result: ParentExchangeResult::Failure(error),
+            result: ExchangeResult::Failure(error),
         });
         self.next_exchange_before = (Time::now() + Duration::minutes(5)).timestamp();
     }
@@ -1452,7 +1452,7 @@ impl RepoStatus {
         self.last_exchange = Some(ParentExchange {
             timestamp: Time::now().timestamp(),
             uri,
-            result: ParentExchangeResult::Success,
+            result: ExchangeResult::Success,
         });
         self.published = published;
         self.next_exchange_before = Self::now_plus_hours(next_hours);
@@ -1462,7 +1462,7 @@ impl RepoStatus {
         self.last_exchange = Some(ParentExchange {
             timestamp: Time::now().timestamp(),
             uri,
-            result: ParentExchangeResult::Success,
+            result: ExchangeResult::Success,
         });
         self.next_exchange_before = Self::now_plus_hours(next_hours);
     }
@@ -1491,7 +1491,7 @@ impl fmt::Display for RepoStatus {
 pub struct ParentExchange {
     timestamp: i64,
     uri: ServiceUri,
-    result: ParentExchangeResult,
+    result: ExchangeResult,
 }
 
 impl ParentExchange {
@@ -1503,39 +1503,77 @@ impl ParentExchange {
         &self.uri
     }
 
-    pub fn result(&self) -> &ParentExchangeResult {
+    pub fn result(&self) -> &ExchangeResult {
         &self.result
     }
 
     pub fn was_success(&self) -> bool {
         match &self.result {
-            ParentExchangeResult::Success => true,
-            ParentExchangeResult::Failure(_) => false,
+            ExchangeResult::Success => true,
+            ExchangeResult::Failure(_) => false,
         }
     }
 
     pub fn into_failure_opt(self) -> Option<ErrorResponse> {
         match self.result {
-            ParentExchangeResult::Success => None,
-            ParentExchangeResult::Failure(error) => Some(error),
+            ExchangeResult::Success => None,
+            ExchangeResult::Failure(error) => Some(error),
         }
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
-pub enum ParentExchangeResult {
+pub enum ExchangeResult {
     Success,
     Failure(ErrorResponse),
 }
 
-impl fmt::Display for ParentExchangeResult {
+impl fmt::Display for ExchangeResult {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ParentExchangeResult::Success => write!(f, "success"),
-            ParentExchangeResult::Failure(e) => write!(f, "failure: {}", e.msg()),
+            ExchangeResult::Success => write!(f, "success"),
+            ExchangeResult::Failure(e) => write!(f, "failure: {}", e.msg()),
         }
     }
+}
+
+//------------ ChildStatus ---------------------------------------------------
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ChildStatus {
+    last_exchange: Option<ChildExchange>,
+}
+
+impl ChildStatus {
+    pub fn set_success(&mut self, user_agent: Option<String>) {
+        self.last_exchange = Some(ChildExchange {
+            timestamp: Time::now().timestamp(),
+            result: ExchangeResult::Success,
+            user_agent,
+        });
+    }
+
+    pub fn set_failure(&mut self, user_agent: Option<String>, error_response: ErrorResponse) {
+        self.last_exchange = Some(ChildExchange {
+            timestamp: Time::now().timestamp(),
+            result: ExchangeResult::Failure(error_response),
+            user_agent,
+        });
+    }
+}
+
+impl Default for ChildStatus {
+    fn default() -> Self {
+        ChildStatus { last_exchange: None }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ChildExchange {
+    timestamp: i64,
+    result: ExchangeResult,
+    user_agent: Option<String>,
 }
 
 //------------ CertAuthInfo --------------------------------------------------

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -76,6 +76,7 @@ pub const ID_CERTIFICATE_VALIDITY_YEARS: i32 = 15;
 pub const BGP_RIS_REFRESH_MINUTES: i64 = 60;
 
 pub const HTTP_CLIENT_TIMEOUT_SECS: u64 = 120;
+pub const HTTP_USER_AGENT_TRUNCATE: usize = 256; // Will truncate received user-agent values at this size.
 pub const OPENID_CONNECT_HTTP_CLIENT_TIMEOUT_SECS: u64 = 30;
 
 pub const NO_RESOURCE: NoResourceType = NoResourceType;

--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -446,8 +446,8 @@ impl CaManager {
     }
 
     /// Show the (connection) stats for children under a CA.
-    pub async fn ca_children_stats(&self, ca: &Handle) -> KrillResult<ChildrenConnectionStats> {
-        self.status_store.lock().await.get_children_status(ca).await
+    pub async fn ca_stats_child_connections(&self, ca: &Handle) -> KrillResult<ChildrenConnectionStats> {
+        self.status_store.lock().await.get_stats_child_connections(ca).await
     }
 
     /// Show a contact for a child.

--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -1453,7 +1453,7 @@ impl CaManager {
 
         let uri = service_uri.to_string();
 
-        let res = httpclient::post_binary(&uri, &signed_msg, content_type)
+        let res = httpclient::post_binary_with_full_ua(&uri, &signed_msg, content_type)
             .await
             .map_err(Error::HttpClientError)?;
 

--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -15,7 +15,6 @@ use rpki::uri;
 use crate::{
     commons::{
         actor::Actor,
-        api::rrdp::PublishElement,
         api::{
             self, AddChildRequest, Base64, CaCommandDetails, CaCommandResult, CertAuthList, CertAuthSummary,
             ChildCaInfo, ChildHandle, CommandHistory, CommandHistoryCriteria, Entitlements, Handle, IssuanceRequest,
@@ -23,6 +22,7 @@ use crate::{
             PublishDelta, RcvdCert, RepoStatus, RepositoryContact, ResourceClassName, ResourceSet, RevocationRequest,
             RevocationResponse, RtaName, StoredEffect, UpdateChildRequest,
         },
+        api::{rrdp::PublishElement, ChildrenStats},
         crypto::{IdCert, KrillSigner, ProtocolCms, ProtocolCmsBuilder},
         error::Error,
         eventsourcing::{Aggregate, AggregateStore, Command, CommandKey},
@@ -443,6 +443,11 @@ impl CaManager {
         trace!("Finding details for CA: {} under parent: {}", child, ca);
         let ca = self.get_ca(ca).await?;
         ca.get_child(child).map(|details| details.clone().into())
+    }
+
+    /// Show the (connection) stats for children under a CA.
+    pub async fn ca_children_stats(&self, ca: &Handle) -> KrillResult<ChildrenStats> {
+        self.status_store.lock().await.get_children_status(ca).await
     }
 
     /// Show a contact for a child.

--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -22,7 +22,7 @@ use crate::{
             PublishDelta, RcvdCert, RepoStatus, RepositoryContact, ResourceClassName, ResourceSet, RevocationRequest,
             RevocationResponse, RtaName, StoredEffect, UpdateChildRequest,
         },
-        api::{rrdp::PublishElement, ChildrenStats},
+        api::{rrdp::PublishElement, ChildrenConnectionStats},
         crypto::{IdCert, KrillSigner, ProtocolCms, ProtocolCmsBuilder},
         error::Error,
         eventsourcing::{Aggregate, AggregateStore, Command, CommandKey},
@@ -446,7 +446,7 @@ impl CaManager {
     }
 
     /// Show the (connection) stats for children under a CA.
-    pub async fn ca_children_stats(&self, ca: &Handle) -> KrillResult<ChildrenStats> {
+    pub async fn ca_children_stats(&self, ca: &Handle) -> KrillResult<ChildrenConnectionStats> {
         self.status_store.lock().await.get_children_status(ca).await
     }
 

--- a/src/daemon/ca/status.rs
+++ b/src/daemon/ca/status.rs
@@ -4,8 +4,8 @@ use tokio::sync::RwLock;
 
 use crate::commons::{
     api::{
-        rrdp::PublishElement, ChildHandle, ChildStats, ChildStatus, ChildrenStats, Entitlements, ErrorResponse, Handle,
-        ParentHandle, ParentStatuses, RepoStatus,
+        rrdp::PublishElement, ChildConnectionStats, ChildHandle, ChildStatus, ChildrenConnectionStats, Entitlements,
+        ErrorResponse, Handle, ParentHandle, ParentStatuses, RepoStatus,
     },
     error::Error,
     eventsourcing::{KeyStoreKey, KeyValueStore},
@@ -25,14 +25,14 @@ struct CaStatus {
 }
 
 impl CaStatus {
-    pub fn get_children_stats(&self) -> ChildrenStats {
+    pub fn get_children_stats(&self) -> ChildrenConnectionStats {
         let children = self
             .children
             .clone()
             .into_iter()
-            .map(|(handle, status)| ChildStats::new(handle, status.into()))
+            .map(|(handle, status)| ChildConnectionStats::new(handle, status.into()))
             .collect();
-        ChildrenStats::new(children)
+        ChildrenConnectionStats::new(children)
     }
 }
 
@@ -155,7 +155,7 @@ impl StatusStore {
             .await
     }
 
-    pub async fn get_children_status(&self, ca: &Handle) -> KrillResult<ChildrenStats> {
+    pub async fn get_children_status(&self, ca: &Handle) -> KrillResult<ChildrenConnectionStats> {
         let _lock = self.lock.read().await;
         let status = self.get_ca_status(ca)?;
 

--- a/src/daemon/ca/status.rs
+++ b/src/daemon/ca/status.rs
@@ -202,11 +202,13 @@ impl StatusStore {
         F: FnOnce(&mut ChildStatus),
     {
         self.update_ca_status(ca, |status| {
-            if !status.children.contains_key(child) {
-                status.children.insert(child.clone(), ChildStatus::default());
-            }
-
-            let mut child_status = status.children.get_mut(child).unwrap();
+            let mut child_status = match status.children.get_mut(child) {
+                Some(child_status) => child_status,
+                None => {
+                    status.children.insert(child.clone(), ChildStatus::default());
+                    status.children.get_mut(child).unwrap()
+                }
+            };
             op(&mut child_status)
         })
         .await

--- a/src/daemon/ca/status.rs
+++ b/src/daemon/ca/status.rs
@@ -25,7 +25,7 @@ struct CaStatus {
 }
 
 impl CaStatus {
-    pub fn get_children_stats(&self) -> ChildrenConnectionStats {
+    pub fn get_children_connection_stats(&self) -> ChildrenConnectionStats {
         let children = self
             .children
             .clone()
@@ -155,11 +155,11 @@ impl StatusStore {
             .await
     }
 
-    pub async fn get_children_status(&self, ca: &Handle) -> KrillResult<ChildrenConnectionStats> {
+    pub async fn get_stats_child_connections(&self, ca: &Handle) -> KrillResult<ChildrenConnectionStats> {
         let _lock = self.lock.read().await;
         let status = self.get_ca_status(ca)?;
 
-        Ok(status.get_children_stats())
+        Ok(status.get_children_connection_stats())
     }
 
     pub async fn set_status_repo_failure(&self, ca: &Handle, uri: ServiceUri, error: &Error) -> KrillResult<()> {

--- a/src/daemon/ca/status.rs
+++ b/src/daemon/ca/status.rs
@@ -2,14 +2,14 @@ use std::path::Path;
 
 use tokio::sync::RwLock;
 
-use crate::commons::api::{
-    rrdp::PublishElement, Entitlements, ErrorResponse, Handle, ParentHandle, ParentStatuses, RepoStatus,
+use crate::commons::{
+    api::{rrdp::PublishElement, Entitlements, ErrorResponse, Handle, ParentHandle, ParentStatuses, RepoStatus},
+    error::Error,
+    eventsourcing::{KeyStoreKey, KeyValueStore},
+    remote::rfc8183::ServiceUri,
+    util::httpclient,
+    KrillResult,
 };
-use crate::commons::error::Error;
-use crate::commons::eventsourcing::{KeyStoreKey, KeyValueStore};
-use crate::commons::remote::rfc8183::ServiceUri;
-use crate::commons::util::httpclient;
-use crate::commons::KrillResult;
 
 //------------ CaStatus ------------------------------------------------------
 

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -1,3 +1,4 @@
+use hyper::header::USER_AGENT;
 use serde::de::DeserializeOwned;
 use std::io;
 use std::str::FromStr;
@@ -351,6 +352,13 @@ impl Request {
 
     pub fn headers(&self) -> &HeaderMap {
         self.request.headers()
+    }
+
+    pub fn user_agent(&self) -> Option<String> {
+        match self.headers().get(&USER_AGENT) {
+            None => None,
+            Some(value) => value.to_str().ok().map(|s| s.to_string()),
+        }
     }
 
     pub async fn upgrade_from_anonymous(&mut self, actor_def: ActorDef) {

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -17,6 +17,7 @@ use crate::commons::{
     actor::{Actor, ActorDef},
     KrillResult,
 };
+use crate::constants::HTTP_USER_AGENT_TRUNCATE;
 use crate::daemon::auth::LoggedInUser;
 use crate::daemon::http::server::State;
 
@@ -357,7 +358,13 @@ impl Request {
     pub fn user_agent(&self) -> Option<String> {
         match self.headers().get(&USER_AGENT) {
             None => None,
-            Some(value) => value.to_str().ok().map(|s| s.to_string()),
+            Some(value) => value.to_str().ok().map(|s| {
+                if s.len() > HTTP_USER_AGENT_TRUNCATE {
+                    s[..HTTP_USER_AGENT_TRUNCATE].to_string()
+                } else {
+                    s.to_string()
+                }
+            }),
         }
     }
 

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -359,6 +359,8 @@ impl Request {
         match self.headers().get(&USER_AGENT) {
             None => None,
             Some(value) => value.to_str().ok().map(|s| {
+                // Note: HeaderValue.to_str() only returns ok in case the value is plain
+                //       ascii so it's safe to treat bytes as characters here.
                 if s.len() > HTTP_USER_AGENT_TRUNCATE {
                     s[..HTTP_USER_AGENT_TRUNCATE].to_string()
                 } else {

--- a/src/daemon/http/server.rs
+++ b/src/daemon/http/server.rs
@@ -868,7 +868,10 @@ async fn api_cas(req: Request, path: &mut RequestPath) -> RoutingResult {
                 Some("parents") => api_ca_parents(req, path, ca).await,
                 Some("repo") => api_ca_repo(req, path, ca).await,
                 Some("routes") => api_ca_routes(req, path, ca).await,
+                Some("stats") => api_ca_stats(req, path, ca).await,
+
                 Some("rta") => api_ca_rta(req, path, ca).await,
+
                 _ => render_unknown_method(),
             }
         }),
@@ -932,6 +935,16 @@ async fn api_ca_routes(req: Request, path: &mut RequestPath, ca: Handle) -> Rout
             _ => render_unknown_method(),
         },
         Some("analysis") => api_ca_routes_analysis(req, path, ca).await,
+        _ => render_unknown_method(),
+    }
+}
+
+async fn api_ca_stats(req: Request, path: &mut RequestPath, ca: Handle) -> RoutingResult {
+    match path.next() {
+        Some("children") => match path.next() {
+            Some("connections") => api_ca_stats_child_connections(req, ca).await,
+            _ => render_unknown_method(),
+        },
         _ => render_unknown_method(),
     }
 }
@@ -1101,12 +1114,12 @@ async fn api_ca_child_show(req: Request, ca: Handle, child: ChildHandle) -> Rout
     )
 }
 
-async fn api_ca_children_stats(req: Request, ca: Handle) -> RoutingResult {
+async fn api_ca_stats_child_connections(req: Request, ca: Handle) -> RoutingResult {
     aa!(
         req,
         Permission::CA_READ,
         ca.clone(),
-        render_json_res(req.state().ca_children_stats(&ca).await)
+        render_json_res(req.state().ca_stats_child_connections(&ca).await)
     )
 }
 
@@ -1250,7 +1263,6 @@ async fn api_ca_children(req: Request, path: &mut RequestPath, ca: Handle) -> Ro
         },
         None => match *req.method() {
             Method::POST => api_ca_add_child(req, ca).await,
-            Method::GET => api_ca_children_stats(req, ca).await,
             _ => render_unknown_method(),
         },
     }

--- a/src/daemon/http/server.rs
+++ b/src/daemon/http/server.rs
@@ -1101,6 +1101,15 @@ async fn api_ca_child_show(req: Request, ca: Handle, child: ChildHandle) -> Rout
     )
 }
 
+async fn api_ca_children_stats(req: Request, ca: Handle) -> RoutingResult {
+    aa!(
+        req,
+        Permission::CA_READ,
+        ca.clone(),
+        render_json_res(req.state().ca_children_stats(&ca).await)
+    )
+}
+
 async fn api_ca_parent_contact(req: Request, ca: Handle, child: ChildHandle) -> RoutingResult {
     aa!(
         req,
@@ -1241,6 +1250,7 @@ async fn api_ca_children(req: Request, path: &mut RequestPath, ca: Handle) -> Ro
         },
         None => match *req.method() {
             Method::POST => api_ca_add_child(req, ca).await,
+            Method::GET => api_ca_children_stats(req, ca).await,
             _ => render_unknown_method(),
         },
     }

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -24,7 +24,7 @@ use crate::commons::eventsourcing::CommandKey;
 use crate::commons::remote::rfc8183;
 use crate::commons::{
     actor::{Actor, ActorDef},
-    api::ChildrenStats,
+    api::ChildrenConnectionStats,
 };
 use crate::commons::{KrillEmptyResult, KrillResult};
 use crate::constants::*;
@@ -440,7 +440,7 @@ impl KrillServer {
     }
 
     /// Show children stats under the CA.
-    pub async fn ca_children_stats(&self, ca: &Handle) -> KrillResult<ChildrenStats> {
+    pub async fn ca_children_stats(&self, ca: &Handle) -> KrillResult<ChildrenConnectionStats> {
         self.ca_manager.ca_children_stats(ca).await
     }
 }

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -440,8 +440,8 @@ impl KrillServer {
     }
 
     /// Show children stats under the CA.
-    pub async fn ca_children_stats(&self, ca: &Handle) -> KrillResult<ChildrenConnectionStats> {
-        self.ca_manager.ca_children_stats(ca).await
+    pub async fn ca_stats_child_connections(&self, ca: &Handle) -> KrillResult<ChildrenConnectionStats> {
+        self.ca_manager.ca_stats_child_connections(ca).await
     }
 }
 

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -7,10 +7,7 @@ use bytes::Bytes;
 use chrono::Duration;
 
 use rpki::{
-    repository::{
-        cert::Cert,
-        x509::Time,
-    },
+    repository::{cert::Cert, x509::Time},
     uri,
 };
 
@@ -457,14 +454,12 @@ impl KrillServer {
     ) -> KrillEmptyResult {
         let parent = parent_req.handle();
         let contact = parent_req.contact();
-        self.ca_manager.get_entitlements_from_contact(&ca, parent, contact, false).await?;
+        self.ca_manager
+            .get_entitlements_from_contact(&ca, parent, contact, false)
+            .await?;
 
-        Ok(self
-            .ca_manager
-            .ca_parent_add_or_update(ca, parent_req, actor)
-            .await?)
+        Ok(self.ca_manager.ca_parent_add_or_update(ca, parent_req, actor).await?)
     }
-
 
     pub async fn ca_parent_remove(&self, handle: Handle, parent: ParentHandle, actor: &Actor) -> KrillEmptyResult {
         Ok(self.ca_manager.ca_parent_remove(handle, parent, actor).await?)
@@ -646,8 +641,14 @@ impl KrillServer {
             .await?)
     }
 
-    pub async fn rfc6492(&self, handle: Handle, msg_bytes: Bytes, actor: &Actor) -> KrillResult<Bytes> {
-        Ok(self.ca_manager.rfc6492(&handle, msg_bytes, actor).await?)
+    pub async fn rfc6492(
+        &self,
+        handle: Handle,
+        msg_bytes: Bytes,
+        user_agent: Option<String>,
+        actor: &Actor,
+    ) -> KrillResult<Bytes> {
+        Ok(self.ca_manager.rfc6492(&handle, msg_bytes, user_agent, actor).await?)
     }
 }
 

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -11,7 +11,6 @@ use rpki::{
     uri,
 };
 
-use crate::commons::actor::{Actor, ActorDef};
 use crate::commons::api::{
     AddChildRequest, AllCertAuthIssues, CaCommandDetails, CaRepoDetails, CertAuthInfo, CertAuthInit, CertAuthIssues,
     CertAuthList, CertAuthStats, ChildCaInfo, ChildHandle, CommandHistory, CommandHistoryCriteria, Handle, ListReply,
@@ -23,6 +22,10 @@ use crate::commons::bgp::{BgpAnalyser, BgpAnalysisReport, BgpAnalysisSuggestion}
 use crate::commons::crypto::KrillSigner;
 use crate::commons::eventsourcing::CommandKey;
 use crate::commons::remote::rfc8183;
+use crate::commons::{
+    actor::{Actor, ActorDef},
+    api::ChildrenStats,
+};
 use crate::commons::{KrillEmptyResult, KrillResult};
 use crate::constants::*;
 #[cfg(feature = "multi-user")]
@@ -430,10 +433,15 @@ impl KrillServer {
         Ok(())
     }
 
-    /// Show details for a child under the TA.
-    pub async fn ca_child_show(&self, parent: &ParentHandle, child: &ChildHandle) -> KrillResult<ChildCaInfo> {
-        let child = self.ca_manager.ca_show_child(parent, child).await?;
+    /// Show details for a child under the CA.
+    pub async fn ca_child_show(&self, ca: &Handle, child: &ChildHandle) -> KrillResult<ChildCaInfo> {
+        let child = self.ca_manager.ca_show_child(ca, child).await?;
         Ok(child)
+    }
+
+    /// Show children stats under the CA.
+    pub async fn ca_children_stats(&self, ca: &Handle) -> KrillResult<ChildrenStats> {
+        self.ca_manager.ca_children_stats(ca).await
     }
 }
 


### PR DESCRIPTION
This PR adds the function to monitor child CA connections. The stats are kept outside of the CA state in the existing structure that we have in order to avoid churn in the parent CA. The stats include the last connection time, result and user agent of the child CA.

Furthermore Krill CAs will now send their version in the user agent when sending RFC 6492 or 8181 protocol messages to their parents and publication server. See issue: #620 