### PR TITLE
PKCS#11 walking skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
         path: target/ui/
         if-no-files-found: ignore
 
-  hsmtest:
-    name: hsmtest
+  pykmip-test:
+    name: pykmip-test
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -103,10 +103,45 @@ jobs:
         sleep 5s
         openssl s_client -connect 127.0.0.1:5696 || true
         cd -
-        cargo test --no-default-features --features hsm,hsm-tests-kmip -- --test-threads=1 2>&1
+        cargo test --no-default-features --features ${{ matrix.features }} -- --test-threads=1 2>&1
 
-    - name: Dump PyKMIP log
+    - name: Dump the PyKMIP log
+      if: always()
       working-directory: test-resources/pykmip
       run: |
         ls -la
         cat server.log
+
+  softhsm2-test:
+    name: softhsm2-test
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        features: ["hsm,hsm-tests-pkcs11"]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+
+    - name: Install Rust
+      uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: stable
+
+    - name: Install SoftHSM2
+      run: |
+        apt update
+        apt install -y softhsm2
+        softhsm2-util --init-token --slot 0 --label "My token 1" --pin 1234 --so-pin 1234
+
+    - name: Compile the tests
+      run: |
+        cargo build --tests --no-default-features --features ${{ matrix.features }}
+
+    - name: Run the tests against SoftHSM2
+      run: |
+        cargo test --no-default-features --features ${{ matrix.features }} -- --test-threads=1 2>&1
+
+    - name: Dump the SoftHSM2 log
+      if: always()
+      run: |
+        cat /var/log/syslog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,7 @@ jobs:
         sudo apt update
         sudo apt install -y softhsm2
         sudo usermod -aG softhsm $(whoami)
-        newgrp softhsm
-        softhsm2-util --init-token --slot 0 --label "My token 1" --pin 1234 --so-pin 1234
+        sg softhsm -c "softhsm2-util --init-token --slot 0 --label \"My token 1\" --pin 1234 --so-pin 1234"
 
     - name: Compile the tests
       run: |
@@ -141,8 +140,7 @@ jobs:
 
     - name: Run the tests against SoftHSM2
       run: |
-        newgrp softhsm
-        cargo test --no-default-features --features ${{ matrix.features }} -- --test-threads=1 2>&1
+        sg softhsm -c "cargo test --no-default-features --features ${{ matrix.features }} -- --test-threads=1 2>&1"
 
     - name: Dump the SoftHSM2 log
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        features: ["hsm", "hsm,hsm-tests"]
+        features: ["hsm", "hsm,hsm-tests-kmip"]
     steps:
     - name: Checkout repository
       uses: actions/checkout@v1
@@ -103,7 +103,7 @@ jobs:
         sleep 5s
         openssl s_client -connect 127.0.0.1:5696 || true
         cd -
-        cargo test --no-default-features --features hsm,hsm-tests -- --test-threads=1 2>&1
+        cargo test --no-default-features --features hsm,hsm-tests-kmip -- --test-threads=1 2>&1
 
     - name: Dump PyKMIP log
       working-directory: test-resources/pykmip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y softhsm2
+        sudo usermod -aG softhsm $(whoami)
+        newgrp softhsm
         softhsm2-util --init-token --slot 0 --label "My token 1" --pin 1234 --so-pin 1234
 
     - name: Compile the tests
@@ -139,6 +141,7 @@ jobs:
 
     - name: Run the tests against SoftHSM2
       run: |
+        newgrp softhsm
         cargo test --no-default-features --features ${{ matrix.features }} -- --test-threads=1 2>&1
 
     - name: Dump the SoftHSM2 log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,8 @@ jobs:
 
     - name: Install SoftHSM2
       run: |
-        apt update
-        apt install -y softhsm2
+        sudo apt update
+        sudo apt install -y softhsm2
         softhsm2-util --init-token --slot 0 --label "My token 1" --pin 1234 --so-pin 1234
 
     - name: Compile the tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,6 +1661,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.12.3-dev"
+source = "git+https://github.com/ximon18/rpki-rs?branch=reverse-signer#cb4fad5d61c810c76d1fee412339b81d38a625a9"
 dependencies = [
  "base64 0.13.0",
  "bcder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,8 +133,9 @@ dependencies = [
 
 [[package]]
 name = "bcder"
-version = "0.6.1-dev"
-source = "git+https://github.com/NLnetLabs/bcder#0e0ef26d23afe18603768b7f6757df997b87568b"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e7c3bae57b01ec5b1b028af1f77b7d41dd2bd97a41bab7968739b5329c0e39"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,9 +867,11 @@ dependencies = [
  "libc",
  "libflate",
  "log",
+ "once_cell",
  "openidconnect",
  "openssl",
  "oso",
+ "pkcs11",
  "r2d2",
  "regex",
  "reqwest",
@@ -952,6 +954,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
 dependencies = [
  "rle-decode-fast",
+]
+
+[[package]]
+name = "libloading"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+dependencies = [
+ "cc",
+ "winapi",
 ]
 
 [[package]]
@@ -1101,6 +1113,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1339,6 +1362,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs11"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aca6d67e4c8613bfe455599d0233d00735f85df2001f6bfd9bb7ac0496b10af"
+dependencies = [
+ "libloading",
+ "num-bigint",
+]
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "kmip-protocol"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d14b178aa24791515237541993de1853ec7c91eec10c6ff18255ea9852b9cac"
+checksum = "c232c81ccbf10282ec2830fbd81f7f002e2548e4c169aada86c6b444bcfa89e3"
 dependencies = [
  "cfg-if",
  "enum-display-derive",
@@ -831,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "kmip-ttlv"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4829d1eaf141b0fd93402d9e219a2453984106931de6e0cdbd8ca02bec58f2bc"
+checksum = "99f11aebbf4a381db6ea786b4148d6e03285c0e58bd778d5f407b4b5ef8b57c2"
 dependencies = [
  "cfg-if",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ hex                   = "^0.4"
 hyper                 = { version = "^0.14", features = ["server"] }
 intervaltree          = "0.2.6"
 jmespatch             = { version = "^0.3", features = ["sync"], optional = true }
-kmip                  = { version = "0.4.0", package = "kmip-protocol", features = ["tls-with-openssl"], optional = true }
+kmip                  = { version = "0.4.1", package = "kmip-protocol", features = ["tls-with-openssl"], optional = true }
 libflate              = "^1"
 log                   = "^0.4"
 once_cell             = { version = "^1.7.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ build = "build.rs"
 backoff               = { version = "0.3.0", optional = true }
 base64                = "^0.13"
 basic-cookies         = { version = "^0.1", optional = true }
-bcder                 = "0.6.1-dev"
+bcder                 = "0.6.1"
 bytes                 = "1"
 chrono                = { version = "^0.4", features = ["serde"] }
 clap                  = "^2.33"
@@ -200,5 +200,4 @@ shadow-utils = "*"
 # ------------------------------------------------------------------------------
 
 [patch.crates-io]
-bcder = { git = 'https://github.com/NLnetLabs/bcder' }
 rpki = { git = 'https://github.com/ximon18/rpki-rs', branch = 'reverse-signer' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,4 +194,4 @@ shadow-utils = "*"
 
 [patch.crates-io]
 bcder = { git = 'https://github.com/NLnetLabs/bcder' }
-rpki = { path = '../rpki-rs-fork/' }
+rpki = { git = 'https://github.com/ximon18/rpki-rs', branch = 'reverse-signer' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,13 @@ urlparse              = { version = "^0.7", optional = true }
 uuid                  = { version = "^0.8", features = [ "v4"] }
 xml-rs                = "^0.8"
 
+# Disable compiler optimizations for the pkcs11 crate because otherwise with a release build the
+# `pReserved = ptr::null_mut()` assignment done by `CK_C_INITIALIZE_ARGS::default()` appears to be optimized out. This
+# causes SoftHSMv2 to fail with error CKR_ARGUMENTS_BAD and to log to syslog "SoftHSM.cpp(436): pReserved must be set to
+# NULL_PTR". Disabling optimizations for the pkcs11 crate "solves" this problem.
+[profile.release.package.pkcs11]
+opt-level = 0
+
 [target.'cfg(unix)'.dependencies]
 libc            = "^0.2"
 syslog          = "^4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,8 @@ hsm = ["backoff", "kmip", "r2d2"]
 # Internal features - not for external use
 all-except-ui-tests = [ "multi-user", "rta", "static-openssl" ]
 ui-tests = []
-hsm-tests = []
+hsm-tests-kmip = []
+hsm-tests-pkcs11 = []
 
 # Make sure that Krill crashes on panics, rather than losing threads and
 # limping on in a bad state.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,11 @@ jmespatch             = { version = "^0.3", features = ["sync"], optional = true
 kmip                  = { version = "0.4.0", package = "kmip-protocol", features = ["tls-with-openssl"], optional = true }
 libflate              = "^1"
 log                   = "^0.4"
+once_cell             = { version = "^1.7.2", optional = true }
 openidconnect         = { version = "^2.0.0", optional = true, default_features = false }
 openssl               = { version = "^0.10", features = ["v110"] }
 oso                   = { version = "^0.12", optional = true, default_features = false }
+pkcs11                = { version = "^0.5", optional = true }
 r2d2                  = { version = "0.8.9", optional = true }
 regex                 = { version = "^1.4", optional = true, default_features = false, features = ["std"] }
 reqwest               = { version = "0.11", features = ["json"] }
@@ -73,7 +75,7 @@ static-openssl = [ "openssl/vendored" ]
 
 # Preview features - not ready for production use
 rta = []
-hsm = ["backoff", "kmip", "r2d2"]
+hsm = ["backoff", "kmip", "once_cell", "pkcs11", "r2d2"]
 
 # Internal features - not for external use
 all-except-ui-tests = [ "multi-user", "rta", "static-openssl" ]

--- a/doc/development/hsm/architecture.md
+++ b/doc/development/hsm/architecture.md
@@ -1,158 +1,197 @@
 # HSM: Architecture
 
-## Key data
+## Terminology
 
-- Krill `KeyIdentifier`: SHA-1 of the binary DER encoding of the X.509 ASN.1 SubjectPublicKeyInfo data structure) used
-  by Krill. Cannot be changed as it is stored in certificates as per standards and then later the certificate is the
-  only information available to the calling code, i.e. it doesn't have anything else to identify the key involved.
+- `Signer` trait: A trait defined by the `rpki` Rust crate, used by functions offered by the `rpki` Rust crate, and implemented by the Krill. Defines an interface for creation and deletion of key pairs, lookup of and signing of data by a key known to the `Signer`, and generation of random byte sequences.
 
-## Key architectural decisions
+- `Signer` implementation: Until now Krill had a single implementation, `OpenSslSigner`. The `HSM` feature adds two new signers to Krill: `Pkcs11Signer` and `KmipSigner`.
 
-- Create our own KMIP Rust library as no actively maintained Rust support for KMIP with sufficient functionality for 
-  Krill existed at the time of writing. The closest candidate, https://github.com/visa/kmip, was used to explore KMIP
-  support in the Krill HSM prototype code. However, it was decided to create our own KMIP library because the visa 
-  crate:
+- `Signer`: An instance of an implementation of the `Signer` trait. Krill can be configured to create multiple instances of the same `Signer` trait each using a different configuration. When referring to a Signer this is what is usually being referred to.
 
-  - Was not published on crates.io.
-  - Had only rudimentary error reporting (as it targets no-std environments).
-  - Lacked documentation, support for needed KMIP operations & TCP+TLS client support.
+- `Signer` backend: 3rd party logic and storage, usually running outside Krill either on the same host or remotely, that works with keys on behalf of Krill. The backend details vary per signer implementation and configuration.
 
-  Don't include the KMIP library in the main Krill code base as it is orthogonal to and independently useful outside of
-  Krill, and the Krill codebase is already quite large & slow to compile.
+- `KeyIdentifier`: This is the SHA-1 hash of the bits of the binary DER encoding of the `SubjectPublicKey` field of the X.509 ASN.1 `SubjectPublicKeyInfo` data structure. It uniquely (or the likelyhood of collisions is sufficiently low that it can be considered unique) identifies a public/private key pair, e.g. the private key that was used to sign a certificate.
 
-- Support multiple concurrently active signers to support rollover to a new signer (creation of new keys with the new
-  signer while continued use of keys created by the previous signer), fallback to the OpenSSL signer for random number
-  generation whne the chosen doesn't support this capability, generation of one-time keys using OpenSSL as doing this
-  with an HSM would be slow (create, activate, sign, deactivate, destroy, potentially each being a network round trip
-  plus relatively slow execution of operations compared to local OpenSSL) and because the security benefits of an HSM
-  are not needed for one-time signing keys.
+## Signer backends
 
-- Maintain a mapping of Krill `KeyIdentifier` to signer identifier so that we can dispatch signing requests to the
-  correct signer.
+The introduction of HSM support greatly expands the kinds of issues Krill can encounter and complexities it must handle when working with signing keys.
 
-- Maintain a mapping of Krill `KeyIdentifier` to signer specific key identifiers.
+- The backend for the existing `OpenSslSigner` implementation is the OpenSSL library (either provided by the host O/S provided or embedded into Krill at compilation time) with key material being stored on the local file system and identified by `KeyIdentifier`.
+
+- The backend for the new `Pkcs11Signer` implementation is a composite of logic provided by a 3rd party library loaded at runtime by Krill from a file on the host filesystem specified by the Krill configuration, and any services and storage used by that library.
+  
+  The PKCS#11 library MUST implement the "Cryptoki" interface defined by the **_stateful_** PKCS#11 v2.20 specification ([HTML](https://www.cryptsoft.com/pkcs11doc/v220/), [PDF](https://www.cryptsoft.com/pkcs11doc/STANDARD/pkcs-11v2-20.pdf)), _"the most widely used version of the PKCS#11 standard"_ (according to [Cryptsoft](https://www.cryptsoft.com/pkcs11doc/)).  The Krill process invokes functions loaded into its process space from the configured PKCS#11 library.
+
+  The PKCS#11 interface is a synchronous design meaning that Krill has to invoke the functions and wait for them to complete. The specification does not include any capability to poll for completion of a previously started task. It is also stateful such that Krill must open and close sessions with the interface and that key identifiers used in a session for a given key will be different to the identifiers used for the same key in a later session (the specification says _"A particular object on a token does not necessarily have a handle which is fixed for the lifetime of the object"_). Krill therefore labels keys and stores a mapping from `KeyIdentifier` to label so that it can later lookup the session specific key identifier in order to work with the key.
+
+  Implementations vary signficantly in their design. Examples include [SoftHSMv2](https://github.com/opendnssec/SoftHSMv2) which uses logic provided by the library and local file system storage for keys, or the [Yubico SDK PKCS#11 library](https://www.yubico.com/press-releases/yubico-introduces-open-source-yubihsm-sdk-for-securing-infrastructures-and-hardware-private-key-storage/) which communicates via HTTP(S) with a "Connector" daemon which in turn communicates with the cryptographic device, to the [AWS CloudHSM PKCS#11 Client SDK 5 library](https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-library.html) that makes outbound TCP/IP connections to a cluster of servers running on, and storing key data in, the Amazon Web Services cloud.
+
+- The backend for the new `KmipSigner` implementation is a 3rd party service that offers an interface compatible with the _stateless_ [Key Management Interoperability Protocol (KMIP) v1.2](http://docs.oasis-open.org/kmip/spec/v1.2/os/kmip-spec-v1.2-os.html) specification.
+
+  Krill establishes one or more TCP/IP connections to the offered interface. Data exchanged with the interface is protected by TLS encryption and is encoded according to the TTLV binary protocol defined by the KMIP specification.
+  
+  KMIP is primarily a synchronous design, i.e. Krill must wait for requests to complete, Krill does not poll to see if a previously started task has since completed. Key identifiers issued by KMIP are persistent and unchanging. Krill stores a mapping from `KeyIdentifier` to KMIP key identifier so that it can work with the keys again later.
+  
+  Connections are kept alive for a period to reduce the overhead and delay that would otherwise be incurred when processing several KMIP requests in quick succession. Krill will attempt to reconnect if it encounters difficulty in communicating with the KMIP compatible service.
+  
+  KMIP supports batching of several requests together and some limited provision for referencing the output of a previous request in a subsequent request in the same batch, but Krill doesn't use this capability at present.
+
+
+## The all important `KeyIdentifier`
+
+The design revolves in many ways around the Krill `KeyIdentifier` which uniquely identifies a particular signing key pair.
+
+> **A note about the uniqueness of the KeyIdentifier**
+> 
+> It is theoretically possible for more than one `Signer` backend to possess a copy of the same key pair identified by the same `KeyIdentifier`, e.g. if the key pair were extracted from one backend and imported to another, or if one backend instance is part of a cluster of instances with access to the same data or where one instance is a spare kept (reasonably) in sync with a primary or if multiple instances were restored from the same backup data. However, for a given piece of data the same signature will be generated by each backend that signs the data using a key identified by the same key pair. For a given `KeyIdentifier` Krill will use the `Signer` that it noted as owning the key (which under-the-hood)
+
+The `KeyIdentifier` is used in many places by Krill. While theoretically the `Signer` interface permits individual implementations to designate their own key identifier, the type of identifer used by Krills implementations cannot be changed. Standards require that the `KeyIdentifier` be recorded in certificates that Krill generates and works with. When working with a certificate the `KeyIdentifier` is the only information available to Krill to identify the related key, nor should code in such parts of Krill be extended to to know about the internals of how keys are actually stored and identified in order to overcome this limitation.
+
+The `KeyIdentifier` is passed to implementers of the `rpki` crate `Signer` trait meaning in turn that `Signer` implementations must be able to locate the key that is associated with the `KeyIdentifier`. For the existing `OpenSslSigner` this isn't a problem as the keys are stored on disk using the `KeyIdentifier` as the file name. For other signers a mapping has to be maintained from `KeyIdentifier` to owning `Signer` and from `KeyIdentifier` to implementation specific key identifier.
+
+## Relating `KeyIdentifier` to RFC terms used in the PKCS#11 and KMIP specifications
+
+When reading the KMIP and PKCS#11 specifications various RFC defined terms are used which are relevant to our need to relate HSM keys to the Krill `KeyIdentifier`. It is useful to understand how terminology used by the code in Krill relates to the terms defined in the related specifications and RFCs.
+
+We can trace some of the relationships as follows:
+
+- The [`rpki::PublicKey::key_identifier()`](https://docs.rs/rpki/0.5.0/rpki/crypto/keys/struct.PublicKey.html#method.key_identifier) function uses the [`bcder::BitString::octets_slice()`](https://docs.rs/bcder/0.6.0/bcder/string/struct.BitString.html#method.octet_slice) function to obtain the inner [`bcder::BitString::bits`](https://docs.rs/bcder/0.6.0/src/bcder/string/bit.rs.html#64-70) subfield of the [`rpki::PublicKey::bits`](https://docs.rs/rpki/0.5.0/src/rpki/crypto/keys.rs.html#87-90) field and then invokes the [`ring::digest::digest()`](https://docs.rs/ring/0.16.20/ring/digest/fn.digest.html) function to SHA-1 hash it. The resulting value is the Krill `KeyIdentifier`.
+
+- SHA-1 is mandated by [section 3 Asymmetric Key Pair Formats of RFC 7935](https://datatracker.ietf.org/doc/html/rfc7935#section-3) which says _"The RSA key pairs used to compute the signatures MUST have a 2048-bit modulus and a public exponent (e) of 65,537"_ (more below on RSA modulus and public exponent for why this is relevant).
+
+- Assuming that `length` is implied and `tag` is not included then the `bits` to be hashed correspond to the `value of the BIT STRING` mentioned in [section 4.2.1.2 "Subject Key Identifier" of RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) when it states that _"The **keyIdentifier** is composed of the 160-bit **SHA-1** hash of the value of the **BIT STRING** subjectPublicKey (excluding the tag, length, and number of unused bits)"_.
+
+- The `bcder::BitString::bits` inner subfield of the `rpki::PublicKey::bits` field is an encoded form of the public key format defined in [section 3.1 Public Key Format of RFC 7935](https://datatracker.ietf.org/doc/html/rfc7935#section-3.1) and _"subjectPublicKey"_ defined in [Appendix A.1 of RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280#appendix-A.1):
+
+  ```rust
+  Rust rpki::PublicKey               RFC 7935            RFC 5280 Appendix A.1
+  ===============================    ================    =============================================
+  pub struct PublicKey {                                 SubjectPublicKeyInfo  ::=  SEQUENCE  {
+      algorithm: PublicKeyFormat,    algorithm               algorithm            AlgorithmIdentifier,
+      bits: BitString,               subjectPublicKey        subjectPublicKey     BIT STRING  }
+  }
+  ```
+
+- [Section 3.1 Public Key Format of RFC 7935](https://datatracker.ietf.org/doc/html/rfc7935#section-3.1) defines `subjectPublicKey` as _"RSAPublicKey MUST be used to encode the certificate's subjectPublicKey field, as specified in [RFC4055]"_ and [section 1.2 RSA Public Keys of RFC 4055](https://datatracker.ietf.org/doc/html/rfc4055#section-1.2) states:
+
+  > The RSA public key MUST be encoded using the type RSAPublicKey type:
+  > ```
+  >    RSAPublicKey  ::=  SEQUENCE  {
+  >       modulus            INTEGER,    -- n
+  >       publicExponent     INTEGER  }  -- e
+  > ```
+  > Here, the modulus is the modulus n, and publicExponent is the public
+  > exponent e.  The DER encoded RSAPublicKey is carried in the
+  > subjectPublicKey BIT STRING within the subject public key
+  > information.
+
+Understanding these structures, meanings and relationships is important when considering how to get the desired information out of a PKC#11 or KMIP compliant HSM and why the Krill HSM supporting code is able to derive the `KeyIdentifier` from RSA modulus and public exponent values.
+
+References:
+- [PKCS#11 v2.20](https://www.cryptsoft.com/pkcs11doc/STANDARD/pkcs-11v2-20.pdf): Cryptographic Token Interface Standard
+- [KMIP v1.2](http://docs.oasis-open.org/kmip/spec/v1.2/os/kmip-spec-v1.2-os.html): Key Management Interoperability Protocol Specification Version 1.2
+- [RFC 4055](https://datatracker.ietf.org/doc/html/rfc4055): Additional Algorithms and Identifiers for RSA Cryptography for use in the Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile
+- [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280): Internet X.509 Public Key Infrastructure Certificate and Certificate Revocation List (CRL) Profile
+- [RFC 7935](https://datatracker.ietf.org/doc/html/rfc7935): The Profile for Algorithms and Key Sizes for Use in the Resource Public Key Infrastructure
+
+
+## Decision log
+
+- Roll our own Rust KMIP library as no actively maintained Rust support for KMIP with sufficient functionality for Krill existed at the time of writing.
+
+  The best candidate I found for use instead of rolling our own was the https://github.com/visa/kmip crate. This crate was used to explore KMIP support in the Krill HSM prototype. However, I considered it insufficient for use in final Krill HSM support because:
+
+  - It lacked the ability to execute some KMIP operations needed by Krill (e.g. `Destroy`, `ModifyAttribute`, `RngRetrieve`, `Sign`).
+  - It did not offer any TCP/IP TLS client capability, only byte level (de)serialization.
+  - It did not have any tests of its own functionality.
+  - It did not have any tests showing conformance with the KMIP specification.
+  - It was not published on https://crates.io/ and thus a new version of Krill that depended on it would not be releasable to https://crates.io/ unless we embedded the `visa/kmip` crate code inside Krill.
+  - Error reporting was quite basic (presumably because it targets no-std environments which limits its ability to construct abitrary complex error messages).
+  - There was no indication that the crate was intended for use by others nor any advertisement of support or potential for support.
+  - There was no indication of activity at the time of writing (no releases, issues or pull requests) since the initial release in July 2020.
+
+- Don't include the KMIP code in the main Krill code base as it is orthogonal to and independently useful outside of
+  Krill, and the Krill code base is already quite large & slow to compile.
+
+- Support multiple concurrently active signers for use cases such as:
+  
+  - Rollover to a new signer (creation of new keys with the new signer while continued use of keys created by the previous signer).
+
+  - Fallback to the OpenSSL signer for random number generation when the chosen doesn't support this capability.
+
+  - Generation of one-time keys using OpenSSL even when using a separate signer for creation of other keys, as doing this with an HSM can require multiple potentially slow requests (create, activate, sign, deactivate, destroy, potentially each being a network round trip plus relatively slow execution of operations compared to local OpenSSL) and because the security benefits of an HSM are not thought to be necessary for one-time signing keys.
+
+- Maintain mappings of Krill `KeyIdentifier` to signer identifier (so that we can dispatch signing requests to the
+  correct signer) and `KeyIdentifier` to signer specific key identifiers (so that we can instruct the signer to work with the correct key).
+  
+  Initially it was hoped that this would not be needed as keys could be tagged on creation or maybe even created with a supplied primary identifier, but in testing with actual PKCS#11 and KMIP providers it was discovered to be necessary. 
+  
+  For example the KMIP specification says that the key Unique Identifier _"SHALL be assigned by the key management system at creation or registration time, and then SHALL NOT be changed or deleted before the object is destroyed"_ and thus cannot be modified after creation to be the `KeyIdentifier` nor at the time of writing did the AWS CloudHSM support the PKCS#11 `C_SetAttributeValue` function that would be needed to apply some sort of identifier or label to the key after creation.
+  
+  Instead some other identifier must be stored with the key in another attribute at key creation time. For PKCS#11 the `CKA_ID` attribute was chosen for this as `CKA_LABEL` was thought to be better used for storing a descriptive label to be shown by HSM client tooling. For KMIP the `Name` attribute is used.
 
 - Support generation of the `KeyIdentifier` from component parts (RSA modulus and exponent) for cases where the signer
-  doesn't (guarantee) support for exposing that for us itself but only provides access to the component parts.
+  doesn't support (or guarantee support for) exposing that itself but does provides access to the component parts which can be used to reconstitute it.
+
+  For example the PKCS#11 v2.20 specification defines the `CKA_HASH_OF_SUBJECT_PUBLIC_KEY` key attribute which might be used to to obtain the `KeyIdentifier` for a created key, but the AWS CloudHSM PKCS#11 implementation didn't support it at the time of writing.
+  
+  There is also the v2.40 definied `CKA_PUBLIC_KEY_INFO` key attribute (_"DER-encoding of the SubjectPublicKeyInfo (see above) for the public key contained in this certificate (default empty)"_) whose value could be deconstructed to obtain the `KeyIdentifier` (see the notes above the relationship between `SubjectPublicKeyInfo` and `KeyIdentifier`), but it is an optional field which is allowed to be empty (and at least with SoftHSMv2 at the time of writing was always empty) and the [AWS CloudHSM list of supported PKCS#11 attributes](https://docs.aws.amazon.com/cloudhsm/latest/userguide/pkcs11-attributes.html) didn't inlcude it) and would not anyway be supported by clients that implement an earlier version of the PKCS#11 specification.
+  
+  In theory PKCS#11 clients support locating a key by its `CKA_MODULUS` and `CKA_PUBLIC_EXPONENT` but KMIP doesn't support this, though should support locating a key by its "digest".
 
 - Don't fail to start Krill if a signer backend is not reachable or lacks required capabilities. Preventing Krill from
   operating won't fix the problem and prevents Krill from doing anything else useful with keys from other signers or
   offering its API or UI.
 
+- Be robust in case of network delays and errors and problems in external signing services. Retry requests that fail due to issues potentially caused by transient network degradation. Re-use TCP+TLS sessions to avoid costly TCP+TLS setup and teardown costs per request to the signer service.
+
 ## Design
 
-- KrillSigner acts as the central hub aware of all signers and key mappings and dispatches requests to the correct
-  signer based on the action being performed and/or the `KeyIdentifier` involved.
-
-- Persist key mappings to: TBD
-
-- Permit signers to be async: TBD
-
-- Be robust in case of network delays and errors and problems in external signing services. Retry requests that fail
-  due to issues potentially caused by transient network degradation. Re-use TCP+TLS sessions to avoid costly TCP+TLS
-  setup and teardown costs per request to the signer service.
-
-- The signer can be in one of three statuses:
-  - Proving  - Rather than constantly attempt to "probe" (contact the server and check its capabilities) we track in
-               this state when we last probed the server so that we can limit how often we try probing the server.
-  - Unusable - Probing was able to contact the server and found it unusable.
-  - Usable   - Probing was able to contact the server and found it usable.
-
-## Implementation details
-
-- Connection pooling is handled by the `r2d2` crate.
-- Retry and backoff is handled by the `backoff` crate.
-- TLS is handled by the `openssl` crate as `rustls` may impose stricter limits on outbound connectivity to HSMs than
-  can be pragmatically expected to work in all customer environments.
-- TBD: Switch to `tokio-native-tls` to keep the benefits of and control of local O/S native TLS providers and avoid the
-  'modern security' limitations of `rustls` while switching to an `async` model.
-
-## Control flow
-
-Prior to the addition of HSM support there was only ever a single Signer and control flow looked like this:
+Old: Prior to the addition of HSM support there was only ever a single Signer and control flow looked like this:
 
 ```
 Krill calling code -> KrillSigner -> OpenSslSigner
 ```
 
-With the addition of HSM support there may be multiple concurrently active Signers and the control flow becomes this:
+New: With the addition of HSM support there may be multiple concurrently active Signers and the control flow becomes this:
 
 ```
-Krill calling code -> KrillSigner -> SignerRouter -> SignerProvider -> One of: OpenSslSigner, KmipSigner or Pkcs11Signer.
-                                          |                              |
-                                          +-------> SignerMapper <-------+
+                                       + Pending Signers: [SignerProvider, SignerProvider, ...]
+                                       |
+Krill calling code -> KrillSigner -> SignerRouter
+                                       |
+  where:                               + Ready Signers:   [SignerProvider, SignerProvider, ...]
+    SignerProvider is one of:          |                    ^               ^
+      - KmipSigner                     + SignerMapper ------+---------------+
+      - OpenSslSigner                          |
+      - Pkcs11Signer                           + AggregateStore<SignerInfo>
 ```
 
-The SignerRouter either:
-- Uses the SignerMapper to determine which Signer owns the KeyIdentifier being used, OR
-- Uses internal rules to decide which Signer to invoke (e.g. always generate random values and do one-off signing using
-  the OpenSslSigner for example)
+- `KrillSigner` remains the central interface between Krill and the signer backends,, handling conversion of error types and providing some higher level functions that make use of the underlying signers. `KrillSigner` delegates signer setup and dispatch to `SignerRouter`.
+  
+- `SignerRouter` uses an instance of `SignerMapper` to record which signer backends exist and which keys they possess. Signers use the same `SignerMapper` instance to register the keys as their own and to register the mapping between Krill `KeyIdentifier` and signer backend specific internal identifier(s).
+  
+- `SignerRouter` creates, registers/binds and dispatches to signers. Signers start in the pending set and are not yet usable. Registration and binding are the process of probing a singer backend to establish if we can connect to it and if so if it is usable. New signers are registered by creating an identity key inside it and recording it in the `SignerMapper`. Later invocations of Krill will verify the identity of the signer (and thus which `SignerMapper` ID relates to it and which keys it possesses) using this identity key. A signer is moved to the ready set once it has been successfully probed and registered/bound and its `SignerMapper` ID has been determined and communicated to it. Signers that fail to be probed or are discovered to be unusable are dropped from the pending set without being added to the ready set.
 
-The Signers:
-- Update the SignerMapper when new keys are created to indicate that this Signer owns the key.
-- Store KeyIdentifier to HSM internal key identifier mappings in the SignerMapper.
-- Retrieve HSM internal key identifiers from the SignerMapper based on the KeyIdentifier being used.
+- `SignerRouter` identifies the appropriate signer for a given request. Signer selection happens in one of two ways:
+  - For requests relating to an existing key the request is routed to the signer that owns the key, as identified by the `SignerMapper`. 
+  - For all other requests a signer is selected based on its assigned roles, e.g. rollover signer, one-off signer or random generator signer roles can be assigned to specific signers.
+ 
+  Actual dispatch is delegated to an instance of `SignerProvider` because enum based dispatch is noisy and the "Provider" enum dispatch pattern was alrady established in the multi-user auth code.
 
-The SignerRouter also manages signer instances based on configuration settings:
-  (note: in the current version the configuration is hard-coded)
-- Create instances of the appropriate signers (structs that implement the Signer trait) based on configuration.
-- On attempts to use signers:
-  1. Bind all pending signers.
-  2. Select the appropriate signer for the request.
-  3. Delegate to the signer, if bound.
+- `SignerProvider` dispatchses requests using enum based dispatching. This approach was chosen over use of Rust traits due to complexities associated with traits (e.g. async traits are not yet officially supported) and the lack of requirement to support an arbitrary number of as yet unseen implementations of some trait. We know exactly how many different signer implementations we need to support: OpenSSL soft signer, PKCS#11 based signer and KMIP based signer.
 
-Binding of signers is done by cryptographically connecting the signer configuration/backend to the SignerMapper stored
-keys:
-- Created signers have a reference to the `SignerMapper` and an uninitialized `Handle`.
-- Created signers are added to an in-memory collection of "pending" signers in the `SignerRouter`.
-- When the `SignerRouter` receives a signing request, when no signers previously existed:
-  - For each pending signer request that it create a key pair. If it is not yet contactable we will try again later.
-  - Combine the string forms of the KeyIdentifier from the public key and the signer internal id of the private half of
-    the key and use that as a "handle" for the newly created signer. This proves that we can connect to the signer and
-    use it and that it can create RSA key pairs.
-  - Verify that the signer is able to correctly sign a given challenge string such that verification of the created
-    signature using the public key works. This proves that the signer can perform signing operations and that the 
-    created signatures are valid.
-  - Add a `SignerInfo` to the `SignerMapper` internal `AggregateStore` using the new signer handle, and store the entire
-    created public key as metadata attached to the `SignerInfo`. We also attach at this point any details about the
-    signer backend, e.g. type, vendor, FQDN and port number (for KMIP) or path on disk (for OpenSSL) etc.
-  - Tell the `Signer` instance the `Handle` it should use with the `SignerMapper` reference it has to lookup existing
-    keys and record new keys. The `SignerMapper` store is located on disk as a `signers` subdirectory under the Krill
-    data directory.
-  - Remove the signer from the pending collection.
+## Crate dependencies
 
-On subsequent restarts of Krill:
-- When the `SignerRouter` receives a signing request and signers previously existed:
-  - For each `SignerInfo` `Handle` stored in the `SignerMapper` extract the signer internal private key id from the
-    `Handle` and ask the signer to sign a challenge string using the specified private key.
-    - If we can't contact the signer at this point we will try again later.
-    - If we can contact the signer and it doesn't know the private key id then this signer configuration/signe
-      instance is not associated with this `SignerInfo` `Handle` and key store.
-    - If the signer returns signed data, verify it using the public key stored with this `Handle` `SignerInfo`. If
-      the verification fails it might be that the signer used simple internal key ids (e.g. PyKMIP uses ascending
-      integer numbers) and so we accidentally found the "right" key but this isn't the right signer.
-    - Otherwise this is the right signer so tell the `Signer` instance the `Handle` it should use with the
-     `SignerMapper` reference that it has.
-     - We also record a "name" metadata property with each `SignerInfo`. If the name and/or signer backend details
-       have changed then they are updated in the `SignerStore` 
-    - Remove the signer from the pending collection.
+- Loading and interfacing with PKCS#11 libraries is handled by the [`pkcs11`](https://crates.io/crates/pkcs11) crate.
+- Communicating with KMIP servers is handled by the NLnet Labs [`kmip-protocol`](https://crates.io/crates/kmip-protocol) crate.
+- Connection pooling is handled by the [`r2d2`](https://crates.io/crates/r2d2) crate.
+- Retry and backoff is handled by the [`backoff`](https://crates.io/crates/backoff) crate.
+- KMIP TLS is handled by the (already used) [`openssl`](https://crates.io/crates/openssl) crate rather than the [`rustls`](https://crates.io/crates/rustls) crate as the latter may impose stricter limits on outbound connectivity to HSMs than can be pragmatically expected to work in all customer environments.
 
-This gives us verified connections and confirmation of capability in a standard way irrespective of signer type,
-between the configuration specified by an operator and the actual signer backend such as a local OpenSSL key store or
-a "remote" PKCS#11 or KMIP HSM service. The operator can rename the instance without impacting the mapping and
-doesn't need to manage a signer specific identifier correctly, and we can correctly route signing requests to the
-right signer without knowing anything about how to relate the configuration to the actual signer backend. If the
-operator replaces a HSM server and restores data from backup and the new one is on a different IP address and/or
-uses different authentication credentials we can work out for ourself which existing keys it should be used with.
-If the operator connects a new HSM not used by this Krill instance before, even if used by a different Krill instance,
-we can use it. We're also capable of using HSMs when they come online without blocking the operation of Krill.
+## Known issues
 
-If we were to also drop signers from the active set when they are unreachable we could automagically migrate from
-a live HSM to a cold spare (assuming the spare has most of the data from the live HSM, in particular the "registration"
-key that we created).
-
-No connection details or secrets are stored in the `SignerInfo` store. If later the `AggregateStore` mechanism is
-upgraded to work with some central key value store service used between multiple Krill instances then each Krill
-instance could have its own connection details and secrets and connect to separate HSMs in a cluster and both
-think that they are talking to the same "signer" because of the presence of the "registration" signing key in
-both HSM nodes and the public half being available to both Krill nodes via the central KV store.
+- Ideally signers would be Rust async and async changes to the `rpki` crate were designed. At the time of writing however, supporting async signing would require deeper changes in core Krill code that we will leave for now as it's not yet clear whether or not blocking signers with potentially slow backends is really a problem or not.
+- TBD: Switch to `tokio-native-tls` to keep the benefits of and control of local O/S native TLS providers and avoid the
+  'modern security' limitations of `rustls` while switching to an `async` model.
+- There are no timeouts on PKCS#11 operations.

--- a/doc/development/hsm/architecture.md
+++ b/doc/development/hsm/architecture.md
@@ -181,6 +181,34 @@ Krill calling code -> KrillSigner -> SignerRouter
 
 - `SignerProvider` dispatchses requests using enum based dispatching. This approach was chosen over use of Rust traits due to complexities associated with traits (e.g. async traits are not yet officially supported) and the lack of requirement to support an arbitrary number of as yet unseen implementations of some trait. We know exactly how many different signer implementations we need to support: OpenSSL soft signer, PKCS#11 based signer and KMIP based signer.
 
+## Signer mapper stored data example
+
+From `<krill_data_dir>/signers/<signer_uuid>/snapshot.json`:
+```json
+{
+  "id": "a32392f6-da5d-4341-98c1-cecdb0c12416",
+  "version": 9,
+  "signer_name": "Pkcs11Signer - No config file name available yet",
+  "signer_info": "PKCS#11 Signer [token: My token 1 (model: SoftHSM v2, vendor: SoftHSM project), slot: 2146913893, server: SoftHSM (Cryptoki v2.6), library: libsofthsm2.so]",
+  "signer_identity": {
+    "public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwbJR0aHy3tFzXhs/lWlCfWpFH7xFk+HRyGA3GYTIsUBwwu2uS9QAZXb8X3NjPLSvw+0Cfcy9n7yHC6B4pQda13bxVSvshC1f4mUc/iXWtMLg4x/F2fJNcTGVW3DbmPWKMXQVeBboFMwF+FZll7EgMsvmiZXn6qeoLm5hfcjihqb88k+HUuMvsGcz939jOIirxv8xP6jT/vJGDxidgoBSIBL3AUSbjh0WEopAzGX8Z+nNvaAPtanhWEB7n0mktyTis4G+GPh1N0pOT5pGxEPf7BnOb1gnPTbb0sTz7M64vkXkxCL69Yxlz3c3MxW4zncwKmGwXo4cmEpN8CTWC5ORbQIDAQAB",
+    "private_key_internal_id": "32b25442dbf26971ffa556d2415810f80e3139d2"
+  },
+  "keys": {
+    "422A26E19291F094B5182FC993DF32B14682D9D2": "b740d70d1e6ad8ebc91d7011753cdb43b76b719b",
+    "87F9B52806A0E7B3812D87DDCC943FF51C8749B6": "03332ef8050c393a42395c4e55aba64c3d64c953",
+    "7858DEB28A517BF21F2B2D540A904FDB22615B76": "d322f65668fc7821c18f037237facce403a331df",
+    "63CDB21953376A88588990E77F423B4832A03F5A": "61f0c63e9288aed063fdfe8ca7482cd62544fc70",
+    "AB41906ECA2F59D7A8DC76DADF46F63062FE765B": "bc49cd8983ddc3177b47a87d19365d75cb4ecfc6",
+    "B83D0D7B9B8264F2170EA21C6CECE54A4D9F4549": "a76440202b5ab2113b4b9cdca199b5b38f23308e",
+    "395B687CB0BCAAE074A299BB08DA82911A83D971": "c0c0b61047dec3514d9f9ce19c0253c0c381bb3a",
+    "05770B676863B9459A19480B283E025DF0AD96BC": "a9a7bd64a9c48a112c639910b5528feede52dff9"
+  }
+}
+```
+
+Here we see an example of a PKCS#11 signer using the SoftHSMv2 PKCS#11 library. The snapshot includes the set of keys created by this signer with both their Krill `KeyIdentifier` and the CKA_ID stored with the key in SoftHSMv2. We also see the identity details needed to confirm that the backend is indeed the owner of these keys.
+
 ## Crate dependencies
 
 - Loading and interfacing with PKCS#11 libraries is handled by the [`pkcs11`](https://crates.io/crates/pkcs11) crate.

--- a/src/commons/crypto/cert.rs
+++ b/src/commons/crypto/cert.rs
@@ -756,7 +756,7 @@ pub mod tests {
     #[test]
     fn should_create_self_signed_ta_id_cert() {
         test_under_tmp(|d| {
-            let s = KrillSigner::build(&d).unwrap();
+            let s = KrillSigner::build(&d, false).unwrap();
             let key_id = s.create_key().unwrap();
 
             let id_cert = IdCertBuilder::new_ta_id_cert(&key_id, &s).unwrap();

--- a/src/commons/crypto/cms.rs
+++ b/src/commons/crypto/cms.rs
@@ -545,7 +545,7 @@ mod tests {
     #[test]
     fn should_create_crl_for_protocol() {
         test_under_tmp(|d| {
-            let s = KrillSigner::build(&d).unwrap();
+            let s = KrillSigner::build(&d, false).unwrap();
             let key_id = s.create_key().unwrap();
             let key_info = s.get_key_info(&key_id).unwrap();
 
@@ -557,7 +557,7 @@ mod tests {
     #[test]
     fn should_create_signed_publication_message() {
         test_under_tmp(|d| {
-            let s = KrillSigner::build(&d).unwrap();
+            let s = KrillSigner::build(&d, false).unwrap();
             let key_id = s.create_key().unwrap();
             let id_cert = IdCertBuilder::new_ta_id_cert(&key_id, &s).unwrap();
 

--- a/src/commons/crypto/signing/dispatch/krillsigner.rs
+++ b/src/commons/crypto/signing/dispatch/krillsigner.rs
@@ -42,9 +42,9 @@ pub struct KrillSigner {
 }
 
 impl KrillSigner {
-    pub fn build(work_dir: &Path) -> KrillResult<Self> {
+    pub fn build(work_dir: &Path, second_signer_hack: bool) -> KrillResult<Self> {
         Ok(KrillSigner {
-            router: SignerRouter::build(work_dir)?,
+            router: SignerRouter::build(work_dir, second_signer_hack)?,
         })
     }
 

--- a/src/commons/crypto/signing/dispatch/krillsigner.rs
+++ b/src/commons/crypto/signing/dispatch/krillsigner.rs
@@ -42,9 +42,9 @@ pub struct KrillSigner {
 }
 
 impl KrillSigner {
-    pub fn build(work_dir: &Path, second_signer_hack: bool) -> KrillResult<Self> {
+    pub fn build(work_dir: &Path, alternate_config: bool) -> KrillResult<Self> {
         Ok(KrillSigner {
-            router: SignerRouter::build(work_dir, second_signer_hack)?,
+            router: SignerRouter::build(work_dir, alternate_config)?,
         })
     }
 

--- a/src/commons/crypto/signing/dispatch/signerinfo.rs
+++ b/src/commons/crypto/signing/dispatch/signerinfo.rs
@@ -369,7 +369,7 @@ impl SignerMapper {
         Ok(())
     }
 
-    pub fn remove_key(&self, signer_handle: &Handle, key_id: &KeyIdentifier) -> KrillResult<()> {
+    pub fn _remove_key(&self, signer_handle: &Handle, key_id: &KeyIdentifier) -> KrillResult<()> {
         // TODO: should version be something other than None here?
         let cmd = SignerInfoCommand::remove_key(signer_handle, None, key_id);
         self.store.command(cmd)?;
@@ -383,20 +383,6 @@ impl SignerMapper {
             .get(key_id)
             .cloned()
             .ok_or_else(|| Error::SignerError(format!("Key with key id '{}' not found", key_id)))
-    }
-
-    pub fn get_any_key(&self, signer_handle: &Handle) -> KrillResult<String> {
-        self.store
-            .get_latest(signer_handle)?
-            .keys
-            .values()
-            .next()
-            .cloned()
-            .ok_or_else(|| Error::SignerError("Signer does not have any keys".to_string()))
-    }
-
-    pub fn has_signer(&self, signer_handle: &Handle) -> KrillResult<bool> {
-        self.store.has(signer_handle).map_err(Error::AggregateStoreError)
     }
 
     pub fn get_signer_handles(&self) -> KrillResult<Vec<Handle>> {

--- a/src/commons/crypto/signing/dispatch/signerinfo.rs
+++ b/src/commons/crypto/signing/dispatch/signerinfo.rs
@@ -1,6 +1,6 @@
 //! An event sourcing aggregate store for capturing information about signer backends and set of keys they possess.
 
-use std::{collections::HashMap, fmt, path::Path};
+use std::{collections::HashMap, fmt, path::Path, str::FromStr};
 
 use rpki::repository::crypto::{KeyIdentifier, PublicKey};
 

--- a/src/commons/crypto/signing/dispatch/signerinfo.rs
+++ b/src/commons/crypto/signing/dispatch/signerinfo.rs
@@ -231,10 +231,6 @@ impl SignerInfo {
     pub fn id(&self) -> &Handle {
         &self.id
     }
-    pub fn _signer_name(&self) -> &String {
-        &self.signer_name
-    }
-    // TODO: more getters?
 }
 
 impl Aggregate for SignerInfo {

--- a/src/commons/crypto/signing/dispatch/signerinfo.rs
+++ b/src/commons/crypto/signing/dispatch/signerinfo.rs
@@ -18,7 +18,7 @@ type InitSignerInfoEvent = StoredEvent<InitSignerInfoDetails>;
 
 impl InitSignerInfoEvent {
     pub fn init(id: &Handle, signer_name: &str, signer_info: &str, public_key: &PublicKey) -> Self {
-        let public_key = hex::encode(public_key.to_info_bytes());
+        let public_key = base64::encode(public_key.to_info_bytes());
 
         StoredEvent::new(
             id,
@@ -216,7 +216,7 @@ struct SignerInfo {
     /// Information about the signer backend being used.
     signer_info: String,
 
-    /// The hex encoded bytes of an X.509 Subject Public Key Info
+    /// The base6 encoded bytes of an X.509 Subject Public Key Info
     /// public key that can be used to verify the identity of the
     /// signer. Should match the KeyIdentifier used in the id.
     public_key: String,
@@ -350,7 +350,7 @@ impl SignerMapper {
 
     pub fn get_signer_public_key(&self, signer_handle: &Handle) -> KrillResult<PublicKey> {
         let public_key_hex_str = self.store.get_latest(signer_handle)?.public_key.clone();
-        let public_key_bytes = hex::decode(public_key_hex_str).map_err(Error::signer)?;
+        let public_key_bytes = base64::decode(public_key_hex_str).map_err(Error::signer)?;
         let public_key = PublicKey::decode(&*public_key_bytes).map_err(Error::signer)?;
         Ok(public_key)
     }

--- a/src/commons/crypto/signing/dispatch/signerprovider.rs
+++ b/src/commons/crypto/signing/dispatch/signerprovider.rs
@@ -4,7 +4,7 @@ use rpki::repository::crypto::{
 
 use crate::commons::crypto::signers::{error::SignerError, softsigner::OpenSslSigner};
 
-#[cfg(all(test, features = "hsm"))]
+#[cfg(all(test, feature = "hsm"))]
 use crate::commons::crypto::signers::mocksigner::MockSigner;
 
 #[cfg(feature = "hsm")]
@@ -29,7 +29,7 @@ pub(crate) enum SignerProvider {
     #[cfg(feature = "hsm")]
     Pkcs11(Pkcs11Signer),
 
-    #[cfg(all(test, features = "hsm"))]
+    #[cfg(all(test, feature = "hsm"))]
     Mock(MockSigner),
 }
 
@@ -41,7 +41,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.supports_random(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.supports_random(),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.supports_random(),
         }
     }
@@ -54,7 +54,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.create_registration_key(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.create_registration_key(),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.create_registration_key(),
         }
     }
@@ -71,7 +71,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.sign_registration_challenge(signer_private_key_id, challenge),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.sign_registration_challenge(signer_private_key_id, challenge),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.sign_registration_challenge(signer_private_key_id, challenge),
         }
     }
@@ -84,7 +84,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.set_handle(handle),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.set_handle(handle),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.set_handle(handle),
         }
     }
@@ -97,7 +97,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.get_name(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.get_name(),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.get_name(),
         }
     }
@@ -110,7 +110,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.get_info(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.get_info(),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.get_info(),
         }
     }
@@ -128,7 +128,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.create_key(algorithm),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.create_key(algorithm),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.create_key(algorithm),
         }
     }
@@ -140,7 +140,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.get_key_info(key),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.get_key_info(key),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.get_key_info(key),
         }
     }
@@ -152,7 +152,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.destroy_key(key),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.destroy_key(key),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.destroy_key(key),
         }
     }
@@ -169,7 +169,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.sign(key, algorithm, data),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.sign(key, algorithm, data),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.sign(key, algorithm, data),
         }
     }
@@ -185,7 +185,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.sign_one_off(algorithm, data),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.sign_one_off(algorithm, data),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.sign_one_off(algorithm, data),
         }
     }
@@ -197,7 +197,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.rand(target),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.rand(target),
-            #[cfg(all(test, features = "hsm"))]
+            #[cfg(all(test, feature = "hsm"))]
             SignerProvider::Mock(signer) => signer.rand(target),
         }
     }

--- a/src/commons/crypto/signing/dispatch/signerprovider.rs
+++ b/src/commons/crypto/signing/dispatch/signerprovider.rs
@@ -4,6 +4,9 @@ use rpki::repository::crypto::{
 
 use crate::commons::crypto::signers::{error::SignerError, softsigner::OpenSslSigner};
 
+#[cfg(test)]
+use crate::commons::crypto::signers::mocksigner::MockSigner;
+
 #[cfg(feature = "hsm")]
 use crate::commons::{
     api::Handle,
@@ -17,7 +20,7 @@ use crate::commons::{
 /// Named and modelled after the similar AuthProvider concept that already exists in Krill.
 #[allow(dead_code)] // Needed as we currently only ever construct one variant
 #[derive(Debug)]
-pub enum SignerProvider {
+pub(crate) enum SignerProvider {
     OpenSsl(OpenSslSigner),
 
     #[cfg(feature = "hsm")]
@@ -25,6 +28,9 @@ pub enum SignerProvider {
 
     #[cfg(feature = "hsm")]
     Pkcs11(Pkcs11Signer),
+
+    #[cfg(test)]
+    Mock(MockSigner),
 }
 
 impl SignerProvider {
@@ -35,6 +41,8 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.supports_random(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.supports_random(),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.supports_random(),
         }
     }
 
@@ -46,6 +54,8 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.create_registration_key(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.create_registration_key(),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.create_registration_key(),
         }
     }
 
@@ -61,6 +71,8 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.sign_registration_challenge(signer_private_key_id, challenge),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.sign_registration_challenge(signer_private_key_id, challenge),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.sign_registration_challenge(signer_private_key_id, challenge),
         }
     }
 
@@ -72,6 +84,8 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.set_handle(handle),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.set_handle(handle),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.set_handle(handle),
         }
     }
 
@@ -83,6 +97,8 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.get_name(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.get_name(),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.get_name(),
         }
     }
 
@@ -94,6 +110,8 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.get_info(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.get_info(),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.get_info(),
         }
     }
 }
@@ -110,6 +128,8 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.create_key(algorithm),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.create_key(algorithm),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.create_key(algorithm),
         }
     }
 
@@ -120,6 +140,8 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.get_key_info(key),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.get_key_info(key),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.get_key_info(key),
         }
     }
 
@@ -130,6 +152,8 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.destroy_key(key),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.destroy_key(key),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.destroy_key(key),
         }
     }
 
@@ -145,6 +169,8 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.sign(key, algorithm, data),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.sign(key, algorithm, data),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.sign(key, algorithm, data),
         }
     }
 
@@ -159,6 +185,8 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.sign_one_off(algorithm, data),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.sign_one_off(algorithm, data),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.sign_one_off(algorithm, data),
         }
     }
 
@@ -169,6 +197,8 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.rand(target),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.rand(target),
+            #[cfg(test)]
+            SignerProvider::Mock(signer) => signer.rand(target),
         }
     }
 }

--- a/src/commons/crypto/signing/dispatch/signerprovider.rs
+++ b/src/commons/crypto/signing/dispatch/signerprovider.rs
@@ -4,7 +4,7 @@ use rpki::repository::crypto::{
 
 use crate::commons::crypto::signers::{error::SignerError, softsigner::OpenSslSigner};
 
-#[cfg(test)]
+#[cfg(all(test, features = "hsm"))]
 use crate::commons::crypto::signers::mocksigner::MockSigner;
 
 #[cfg(feature = "hsm")]
@@ -29,7 +29,7 @@ pub(crate) enum SignerProvider {
     #[cfg(feature = "hsm")]
     Pkcs11(Pkcs11Signer),
 
-    #[cfg(test)]
+    #[cfg(all(test, features = "hsm"))]
     Mock(MockSigner),
 }
 
@@ -41,7 +41,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.supports_random(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.supports_random(),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.supports_random(),
         }
     }
@@ -54,7 +54,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.create_registration_key(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.create_registration_key(),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.create_registration_key(),
         }
     }
@@ -71,7 +71,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.sign_registration_challenge(signer_private_key_id, challenge),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.sign_registration_challenge(signer_private_key_id, challenge),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.sign_registration_challenge(signer_private_key_id, challenge),
         }
     }
@@ -84,7 +84,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.set_handle(handle),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.set_handle(handle),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.set_handle(handle),
         }
     }
@@ -97,7 +97,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.get_name(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.get_name(),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.get_name(),
         }
     }
@@ -110,7 +110,7 @@ impl SignerProvider {
             SignerProvider::Kmip(signer) => signer.get_info(),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.get_info(),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.get_info(),
         }
     }
@@ -128,7 +128,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.create_key(algorithm),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.create_key(algorithm),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.create_key(algorithm),
         }
     }
@@ -140,7 +140,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.get_key_info(key),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.get_key_info(key),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.get_key_info(key),
         }
     }
@@ -152,7 +152,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.destroy_key(key),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.destroy_key(key),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.destroy_key(key),
         }
     }
@@ -169,7 +169,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.sign(key, algorithm, data),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.sign(key, algorithm, data),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.sign(key, algorithm, data),
         }
     }
@@ -185,7 +185,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.sign_one_off(algorithm, data),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.sign_one_off(algorithm, data),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.sign_one_off(algorithm, data),
         }
     }
@@ -197,7 +197,7 @@ impl Signer for SignerProvider {
             SignerProvider::Kmip(signer) => signer.rand(target),
             #[cfg(feature = "hsm")]
             SignerProvider::Pkcs11(signer) => signer.rand(target),
-            #[cfg(test)]
+            #[cfg(all(test, features = "hsm"))]
             SignerProvider::Mock(signer) => signer.rand(target),
         }
     }

--- a/src/commons/crypto/signing/dispatch/signerrouter.rs
+++ b/src/commons/crypto/signing/dispatch/signerrouter.rs
@@ -247,7 +247,11 @@ impl SignerRouter {
 
     // TODO: Delete me once setup from Krill configuration is supported.
     #[cfg(feature = "hsm-tests-kmip")]
-    fn build_signers(work_dir: &Path, signer_mapper: Arc<SignerMapper>) -> KrillResult<SignerRoleAssignments> {
+    fn build_signers(
+        work_dir: &Path,
+        signer_mapper: Arc<SignerMapper>,
+        _alternate_config: bool,
+    ) -> KrillResult<SignerRoleAssignments> {
         // When the HSM feature is activated AND test mode is activated:
         //   - Use the HSM for as much as possible to depend on it as broadly as possible in the Krill test suite..
         //   - Fallback to OpenSSL for random number generation if the HSM doesn't support it.

--- a/src/commons/crypto/signing/dispatch/signerrouter.rs
+++ b/src/commons/crypto/signing/dispatch/signerrouter.rs
@@ -399,7 +399,7 @@ impl SignerRouter {
             // signers is actually one of these or is a new signer that we haven't seen before.
             let candidate_handles = self.get_candidate_signer_handles()?;
             trace!("{} signers were previously registered", candidate_handles.len());
-            
+
             // Block until we can get a write lock on the set of pending_signers as we will hopefully remove one or
             // more items from the set. Standard practice in Krill is to panic if a lock cannot be obtained.
             let mut pending_signers = self.pending_signers.write().unwrap();

--- a/src/commons/crypto/signing/dispatch/signerrouter.rs
+++ b/src/commons/crypto/signing/dispatch/signerrouter.rs
@@ -144,7 +144,7 @@ struct SignerRoleAssignments {
 /// operations.
 #[cfg(not(feature = "hsm"))]
 impl SignerRouter {
-    pub fn build(work_dir: &Path) -> KrillResult<Self> {
+    pub fn build(work_dir: &Path, _alternate_config: bool) -> KrillResult<Self> {
         let openssl_signer = Arc::new(SignerProvider::OpenSsl(OpenSslSigner::build(work_dir)?));
 
         Ok(SignerRouter {

--- a/src/commons/crypto/signing/dispatch/signerrouter.rs
+++ b/src/commons/crypto/signing/dispatch/signerrouter.rs
@@ -222,7 +222,11 @@ impl SignerRouter {
     }
 
     #[cfg(all(feature = "hsm", not(any(feature = "hsm-tests-kmip", feature = "hsm-tests-pkcs11"))))]
-    fn build_signers(work_dir: &Path, signer_mapper: Arc<SignerMapper>) -> KrillResult<SignerRoleAssignments> {
+    fn build_signers(
+        work_dir: &Path,
+        signer_mapper: Arc<SignerMapper>,
+        _alternate_config: bool,
+    ) -> KrillResult<SignerRoleAssignments> {
         // When the HSM feature is activated and we are not in test mode:
         //   - Use the HSM for key creation, signing, deletion, except for one-off keys.
         //   - Use the HSM for random number generation, if supported, else use the OpenSSL signer.

--- a/src/commons/crypto/signing/dispatch/signerrouter.rs
+++ b/src/commons/crypto/signing/dispatch/signerrouter.rs
@@ -524,7 +524,7 @@ impl SignerRouter {
 
         let challenge = "Krill signer verification challenge".as_bytes();
         let signature = match signer_provider.sign_registration_challenge(&signer_private_key_id, challenge) {
-            Err(SignerError::SignerUnavailable) => {
+            Err(SignerError::TemporarilyUnavailable) => {
                 debug!("Signer '{}' could not be contacted", signer_name);
                 return Ok(IdentifyResult::Unavailable);
             }
@@ -581,14 +581,14 @@ impl SignerRouter {
         let signer_name = signer_provider.get_name().to_string();
 
         let (public_key, signer_private_key_id) = match signer_provider.create_registration_key() {
-            Err(SignerError::SignerUnavailable) => return Ok(RegisterResult::NotReady),
+            Err(SignerError::TemporarilyUnavailable) => return Ok(RegisterResult::NotReady),
             Err(_) => return Ok(RegisterResult::ReadyUnusable),
             Ok(res) => res,
         };
 
         let challenge = "Krill signer verification challenge".as_bytes();
         let signature = match signer_provider.sign_registration_challenge(&signer_private_key_id, challenge) {
-            Err(SignerError::SignerUnavailable) => return Ok(RegisterResult::NotReady),
+            Err(SignerError::TemporarilyUnavailable) => return Ok(RegisterResult::NotReady),
             Err(_) => return Ok(RegisterResult::ReadyUnusable),
             Ok(res) => res,
         };

--- a/src/commons/crypto/signing/dispatch/signerrouter.rs
+++ b/src/commons/crypto/signing/dispatch/signerrouter.rs
@@ -210,7 +210,7 @@ impl SignerRouter {
         })
     }
 
-    #[cfg(not(feature = "hsm-tests"))]
+    #[cfg(not(any(feature = "hsm-tests-kmip", feature = "hsm-tests-pkcs11")))]
     fn build_signers(work_dir: &Path, signer_mapper: Arc<SignerMapper>) -> KrillResult<SignerRoleAssignments> {
         // When the HSM feature is activated and we are not in test mode:
         //   - Use the HSM for key creation, signing, deletion, except for one-off keys.
@@ -235,7 +235,7 @@ impl SignerRouter {
     }
 
     // TODO: Delete me once setup from Krill configuration is supported.
-    #[cfg(feature = "hsm-tests")]
+    #[cfg(feature = "hsm-tests-kmip")]
     fn build_signers(work_dir: &Path, signer_mapper: Arc<SignerMapper>) -> KrillResult<SignerRoleAssignments> {
         // When the HSM feature is activated AND test mode is activated:
         //   - Use the HSM for as much as possible to depend on it as broadly as possible in the Krill test suite..

--- a/src/commons/crypto/signing/signers/error.rs
+++ b/src/commons/crypto/signing/signers/error.rs
@@ -13,8 +13,8 @@ pub enum SignerError {
     IoError(KrillIoError),
     KeyNotFound,
     DecodeError,
-    SignerUnavailable,
-    SignerUnusable,
+    TemporarilyUnavailable,
+    PermanentlyUnusable,
     Other(String),
 }
 
@@ -28,8 +28,8 @@ impl fmt::Display for SignerError {
             SignerError::IoError(e) => e.fmt(f),
             SignerError::KeyNotFound => write!(f, "Could not find key"),
             SignerError::DecodeError => write!(f, "Could not decode key"),
-            SignerError::SignerUnavailable => write!(f, "Signer is unavailable"),
-            SignerError::SignerUnusable => write!(f, "Signer is unusable"),
+            SignerError::TemporarilyUnavailable => write!(f, "Signer is unavailable"),
+            SignerError::PermanentlyUnusable => write!(f, "Signer is unusable"),
             SignerError::Other(e) => write!(f, "Signer error: {}", e),
         }
     }

--- a/src/commons/crypto/signing/signers/error.rs
+++ b/src/commons/crypto/signing/signers/error.rs
@@ -6,31 +6,33 @@ use crate::commons::error::KrillIoError;
 
 #[derive(Debug)]
 pub enum SignerError {
-    KmipError(String),
-    OpenSslError(ErrorStack),
-    JsonError(serde_json::Error),
+    DecodeError,
     InvalidWorkDir(PathBuf),
     IoError(KrillIoError),
+    JsonError(serde_json::Error),
     KeyNotFound,
-    DecodeError,
-    TemporarilyUnavailable,
-    PermanentlyUnusable,
+    KmipError(String),
+    OpenSslError(ErrorStack),
     Other(String),
+    PermanentlyUnusable,
+    Pkcs11Error(String),
+    TemporarilyUnavailable,
 }
 
 impl fmt::Display for SignerError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            SignerError::KmipError(e) => write!(f, "KMIP Error: {}", e),
-            SignerError::OpenSslError(e) => write!(f, "OpenSsl Error: {}", e),
-            SignerError::JsonError(e) => write!(f, "Could not decode public key info: {}", e),
+            SignerError::DecodeError => write!(f, "Could not decode key"),
             SignerError::InvalidWorkDir(path) => write!(f, "Invalid base path: {}", path.to_string_lossy()),
             SignerError::IoError(e) => e.fmt(f),
+            SignerError::JsonError(e) => write!(f, "Could not decode public key info: {}", e),
             SignerError::KeyNotFound => write!(f, "Could not find key"),
-            SignerError::DecodeError => write!(f, "Could not decode key"),
-            SignerError::TemporarilyUnavailable => write!(f, "Signer is unavailable"),
-            SignerError::PermanentlyUnusable => write!(f, "Signer is unusable"),
+            SignerError::KmipError(e) => write!(f, "KMIP Error: {}", e),
+            SignerError::OpenSslError(e) => write!(f, "OpenSSL Error: {}", e),
             SignerError::Other(e) => write!(f, "Signer error: {}", e),
+            SignerError::PermanentlyUnusable => write!(f, "Signer is unusable"),
+            SignerError::Pkcs11Error(e) => write!(f, "PKCS#11 Error: {}", e),
+            SignerError::TemporarilyUnavailable => write!(f, "Signer is unavailable"),
         }
     }
 }

--- a/src/commons/crypto/signing/signers/kmip/connpool.rs
+++ b/src/commons/crypto/signing/signers/kmip/connpool.rs
@@ -5,7 +5,7 @@
 ///    in time.
 ///  - Handle loss of connectivity by re-creating the connection when an existing connection is considered to be
 ///    "broken" at the network level.
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use kmip::client::ConnectionSettings;
 
@@ -18,14 +18,14 @@ use crate::commons::crypto::signers::{error::SignerError, kmip::internal::KmipTl
 /// [r2d2]: https://crates.io/crates/r2d2/
 #[derive(Debug)]
 pub struct ConnectionManager {
-    conn_settings: ConnectionSettings,
+    conn_settings: Arc<ConnectionSettings>,
 }
 
 impl ConnectionManager {
     /// Create a pool of up-to N TCP + TLS connections to the KMIP server.
     #[rustfmt::skip]
     pub fn create_connection_pool(
-        conn_settings: ConnectionSettings,
+        conn_settings: Arc<ConnectionSettings>,
         max_size: u32,
     ) -> Result<r2d2::Pool<ConnectionManager>, SignerError> {
         let pool = r2d2::Pool::builder()

--- a/src/commons/crypto/signing/signers/kmip/internal.rs
+++ b/src/commons/crypto/signing/signers/kmip/internal.rs
@@ -262,6 +262,11 @@ impl UsableServerState {
             conn_info,
         }
     }
+
+    pub fn get_connection(&self) -> Result<PooledConnection<ConnectionManager>, SignerError> {
+        let conn = self.pool.get()?;
+        Ok(conn)
+    }
 }
 
 impl KmipSigner {
@@ -432,7 +437,7 @@ impl KmipSigner {
 impl KmipSigner {
     /// Get a connection to the KMIP server from the pool, if the server is usable.
     fn connect(&self) -> Result<PooledConnection<ConnectionManager>, SignerError> {
-        let conn = self.server()?.state().pool.get()?;
+        let conn = self.server()?.state().get_connection()?;
         Ok(conn)
     }
 

--- a/src/commons/crypto/signing/signers/kmip/internal.rs
+++ b/src/commons/crypto/signing/signers/kmip/internal.rs
@@ -614,7 +614,7 @@ impl KmipSigner {
         }
 
         if deactivated {
-            // TODO: This can fail if the key is not in the correct state, e.g. one cause can is if the key is not
+            // TODO: This can fail if the key is not in the correct state, e.g. one cause can be if the key is not
             // revoked. We don't expect this because we assume we know whether we activated or revoked the key or not
             // but if for some reason the key exists, we think it does not require revocation but actually it does,
             // then we would fail here. In such a case we could attempt to revoke and retry, but that assumes we can

--- a/src/commons/crypto/signing/signers/kmip/internal.rs
+++ b/src/commons/crypto/signing/signers/kmip/internal.rs
@@ -517,7 +517,7 @@ impl KmipSigner {
 
         let readable_handle = self.handle.read().unwrap();
         let signer_handle = readable_handle.as_ref().ok_or(SignerError::Other(
-            "Failed to record signer key: Signer handle not set".to_string(),
+            "KMIP: Failed to record signer key: Signer handle not set".to_string(),
         ))?;
         self.mapper
             .add_key(signer_handle, key_id, &internal_key_id)

--- a/src/commons/crypto/signing/signers/kmip/internal.rs
+++ b/src/commons/crypto/signing/signers/kmip/internal.rs
@@ -520,7 +520,7 @@ impl KmipSigner {
     pub(super) fn lookup_kmip_key_ids(
         &self,
         key_id: &KeyIdentifier,
-    ) -> Result<KmipKeyPairIds, KeyError<<KmipSigner as Signer>::Error>> {
+    ) -> Result<KmipKeyPairIds, KeyError<SignerError>> {
         let readable_handle = self.handle.read().unwrap();
         let signer_handle = readable_handle.as_ref().ok_or(KeyError::KeyNotFound)?;
 
@@ -760,7 +760,7 @@ impl KmipSigner {
         Ok(success)
     }
 
-    pub(super) fn get_random_bytes(&self, num_bytes_wanted: usize) -> Result<Vec<u8>, <KmipSigner as Signer>::Error> {
+    pub(super) fn get_random_bytes(&self, num_bytes_wanted: usize) -> Result<Vec<u8>, SignerError> {
         if !self.supports_random() {
             return Err(SignerError::KmipError(
                 "The KMIP server does not support random number generation".to_string(),

--- a/src/commons/crypto/signing/signers/kmip/internal.rs
+++ b/src/commons/crypto/signing/signers/kmip/internal.rs
@@ -48,9 +48,9 @@ const RETRY_REQ_UNTIL_MAX: Duration = Duration::from_secs(30);
 /// The maximum number of concurrent connections to the KMIP server to pool.
 const MAX_CONCURRENT_SERVER_CONNECTIONS: u32 = 5;
 
-/// TODO: Make this a configuration setting. For now set it to false because PyKMIP 0.10.0 says it doesn't support the
+/// TODO: Make this a configuration setting. For now set it to true because PyKMIP 0.10.0 says it doesn't support the
 /// `ModifyAttribute` but sending a modify attribute request succeeds.
-const IGNORE_MISSING_CAPABILITIES: bool = false;
+const IGNORE_MISSING_CAPABILITIES: bool = true;
 
 /// A KMIP client that uses a specific TLS and TCP stream implementation. Currently set to [SslStream] from the
 /// [openssl] crate. This will be a different type if we switch to different TCP and/or TLS implementations or to an
@@ -391,7 +391,7 @@ impl KmipSigner {
             // anyway. For example, PyKMIP 0.10.0 does not include the ModifyAttribute operation in the set of
             // supported operations even though it does support it. Without this flag we would not be able to use
             // PyKMIP with Krill!
-            if IGNORE_MISSING_CAPABILITIES {
+            if !IGNORE_MISSING_CAPABILITIES {
                 *status = ProbingServerConnector::Unusable;
                 return Err(SignerError::SignerUnusable);
             }

--- a/src/commons/crypto/signing/signers/kmip/internal.rs
+++ b/src/commons/crypto/signing/signers/kmip/internal.rs
@@ -123,7 +123,7 @@ impl KmipSigner {
     /// Returns true if the KMIP server supports generation of random numbers, false otherwise.
     pub fn supports_random(&self) -> bool {
         match self.server() {
-            Ok(status) => status.state().supports_rng_retrieve,
+            Ok(status) => status.state().supports_random_number_generation,
             Err(_) => false,
         }
     }
@@ -245,7 +245,7 @@ struct UsableServerState {
     pool: r2d2::Pool<ConnectionManager>,
 
     /// Does the KMIP server support the RNG Retrieve operation (for generating random values)?
-    supports_rng_retrieve: bool,
+    supports_random_number_generation: bool,
 
     conn_info: String,
 }
@@ -253,12 +253,12 @@ struct UsableServerState {
 impl UsableServerState {
     pub fn new(
         pool: r2d2::Pool<ConnectionManager>,
-        supports_rng_retrieve: bool,
+        supports_random_number_generation: bool,
         conn_info: String,
     ) -> UsableServerState {
         UsableServerState {
             pool,
-            supports_rng_retrieve,
+            supports_random_number_generation,
             conn_info,
         }
     }

--- a/src/commons/crypto/signing/signers/kmip/signer.rs
+++ b/src/commons/crypto/signing/signers/kmip/signer.rs
@@ -75,10 +75,10 @@ impl Signer for KmipSigner {
         Ok((signature, key))
     }
 
-    fn rand(&self, data: &mut [u8]) -> Result<(), Self::Error> {
-        let random_bytes = self.get_random_bytes(data.len())?;
+    fn rand(&self, target: &mut [u8]) -> Result<(), Self::Error> {
+        let random_bytes = self.get_random_bytes(target.len())?;
 
-        data.copy_from_slice(&random_bytes);
+        target.copy_from_slice(&random_bytes);
 
         Ok(())
     }

--- a/src/commons/crypto/signing/signers/mocksigner.rs
+++ b/src/commons/crypto/signing/signers/mocksigner.rs
@@ -146,10 +146,10 @@ impl MockSigner {
 // interface expected by SignerProvider
 impl MockSigner {
     pub fn create_registration_key(&self) -> Result<(PublicKey, String), SignerError> {
+        self.inc_fn_call_count(FnIdx::CreateRegistrationKey);
         if let Some(err_cb) = &self.create_registration_key_error_cb {
             return Err((err_cb)());
         }
-        self.inc_fn_call_count(FnIdx::CreateRegistrationKey);
         let (public_key, _, _, internal_id) = self.build_key().unwrap();
         Ok((public_key, internal_id))
     }
@@ -159,10 +159,10 @@ impl MockSigner {
         signer_private_key_id: &str,
         challenge: &D,
     ) -> Result<Signature, SignerError> {
+        self.inc_fn_call_count(FnIdx::SignRegistrationChallenge);
         if let Some(err_cb) = &self.sign_registration_challenge_error_cb {
             return Err((err_cb)());
         }
-        self.inc_fn_call_count(FnIdx::SignRegistrationChallenge);
         let pkey = self.load_key(signer_private_key_id).ok_or(SignerError::KeyNotFound)?;
 
         // sign the given data using the loaded private key

--- a/src/commons/crypto/signing/signers/mocksigner.rs
+++ b/src/commons/crypto/signing/signers/mocksigner.rs
@@ -1,0 +1,271 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use bytes::Bytes;
+use openssl::{
+    hash::MessageDigest,
+    pkey::{PKey, Private},
+    rsa::Rsa,
+};
+use rpki::repository::crypto::{
+    signer::KeyError, KeyIdentifier, PublicKey, PublicKeyFormat, Signature, SignatureAlgorithm, Signer, SigningError,
+};
+
+use crate::commons::{
+    api::Handle,
+    crypto::{dispatch::signerinfo::SignerMapper, SignerError},
+};
+
+pub enum FnIdx {
+    SupportsRandom,
+    CreateRegistrationKey,
+    SignRegistrationChallenge,
+    SetHandle,
+    GetName,
+    GetInfo,
+    CreateKey,
+    GetKeyInfo,
+    DestroyKey,
+    Sign,
+    SignOneOff,
+    Rand,
+    Count,
+}
+
+#[derive(Debug)]
+pub struct MockSignerCallCounts {
+    call_counts: RwLock<Vec<u32>>,
+}
+
+impl MockSignerCallCounts {
+    pub fn new() -> Self {
+        let mut call_counts = Vec::with_capacity(FnIdx::Count as usize);
+        call_counts.resize(FnIdx::Count as usize, 0);
+
+        Self {
+            call_counts: RwLock::new(call_counts),
+        }
+    }
+
+    pub fn get(&self, fn_idx: FnIdx) -> u32 {
+        self.call_counts.read().unwrap()[fn_idx as usize]
+    }
+
+    pub fn inc(&self, fn_idx: FnIdx) {
+        self.call_counts.write().unwrap()[fn_idx as usize] += 1;
+    }
+}
+
+pub type CreateRegistrationKeyErrorCb = fn() -> SignerError;
+pub type SignRegistrationChallengeErrorCb = fn() -> SignerError;
+
+#[derive(Debug)]
+pub struct MockSigner {
+    fn_call_counts: Arc<MockSignerCallCounts>,
+    supports_random: bool,
+    handle: RwLock<Option<Handle>>,
+    signer_mapper: Arc<SignerMapper>,
+    keys: RwLock<HashMap<String, PKey<Private>>>,
+    create_registration_key_error_cb: Option<CreateRegistrationKeyErrorCb>,
+    sign_registration_challenge_error_cb: Option<SignRegistrationChallengeErrorCb>,
+}
+
+// test interface
+impl MockSigner {
+    pub fn new(
+        signer_mapper: Arc<SignerMapper>,
+        supports_random: bool,
+        fn_call_counts: Arc<MockSignerCallCounts>,
+        create_registration_key_error_cb: Option<CreateRegistrationKeyErrorCb>,
+        sign_registration_challenge_error_cb: Option<SignRegistrationChallengeErrorCb>,
+    ) -> Self {
+        Self {
+            fn_call_counts,
+            supports_random,
+            handle: RwLock::new(None),
+            signer_mapper,
+            keys: RwLock::new(HashMap::new()),
+            create_registration_key_error_cb,
+            sign_registration_challenge_error_cb,
+        }
+    }
+
+    fn inc_fn_call_count(&self, fn_idx: FnIdx) {
+        self.fn_call_counts.inc(fn_idx)
+    }
+
+    pub fn supports_random(&self) -> bool {
+        self.inc_fn_call_count(FnIdx::SupportsRandom);
+        self.supports_random
+    }
+
+    fn build_key(&self) -> Result<(PublicKey, PKey<Private>, KeyIdentifier, String), SignerError> {
+        // generate a key pair
+        let rsa = Rsa::generate(2048)?;
+        let pkey = PKey::from_rsa(rsa)?;
+        let public_key = Self::public_key_from_pkey(&pkey).unwrap();
+        let key_identifier = public_key.key_identifier();
+
+        // remember this private key by its "internal id"
+        let internal_id = key_identifier.to_string();
+        self.keys.write().unwrap().insert(internal_id.clone(), pkey.clone());
+
+        // return the key details to the caller
+        Ok((public_key, pkey, key_identifier, internal_id))
+    }
+
+    fn sign_with_key<D: AsRef<[u8]> + ?Sized>(pkey: &PKey<Private>, challenge: &D) -> Result<Signature, SignerError> {
+        let mut signer = ::openssl::sign::Signer::new(MessageDigest::sha256(), &pkey)?;
+        signer.update(challenge.as_ref())?;
+        let signature = Signature::new(SignatureAlgorithm::default(), Bytes::from(signer.sign_to_vec()?));
+        Ok(signature)
+    }
+
+    fn public_key_from_pkey(pkey: &PKey<Private>) -> Result<PublicKey, SignerError> {
+        let mut b = Bytes::from(pkey.rsa().unwrap().public_key_to_der().unwrap());
+        PublicKey::decode(&mut b).map_err(|_| SignerError::DecodeError)
+    }
+
+    fn internal_id_from_key_identifier(&self, key_identifier: &KeyIdentifier) -> Result<String, SignerError> {
+        let lock = self.handle.read().unwrap();
+        let signer_handle = lock.as_ref().unwrap();
+        self.signer_mapper
+            .get_key(signer_handle, key_identifier)
+            .map_err(|_| SignerError::KeyNotFound)
+    }
+
+    fn load_key(&self, internal_id: &str) -> Option<PKey<Private>> {
+        // "load" the private key from storage by its "internal id"
+        let keys = self.keys.read().unwrap();
+        keys.get(internal_id).cloned()
+    }
+}
+
+// interface expected by SignerProvider
+impl MockSigner {
+    pub fn create_registration_key(&self) -> Result<(PublicKey, String), SignerError> {
+        if let Some(err_cb) = &self.create_registration_key_error_cb {
+            return Err((err_cb)());
+        }
+        self.inc_fn_call_count(FnIdx::CreateRegistrationKey);
+        let (public_key, _, _, internal_id) = self.build_key().unwrap();
+        Ok((public_key, internal_id))
+    }
+
+    pub fn sign_registration_challenge<D: AsRef<[u8]> + ?Sized>(
+        &self,
+        signer_private_key_id: &str,
+        challenge: &D,
+    ) -> Result<Signature, SignerError> {
+        if let Some(err_cb) = &self.sign_registration_challenge_error_cb {
+            return Err((err_cb)());
+        }
+        self.inc_fn_call_count(FnIdx::SignRegistrationChallenge);
+        let pkey = self.load_key(signer_private_key_id).ok_or(SignerError::KeyNotFound)?;
+
+        // sign the given data using the loaded private key
+        let signature = Self::sign_with_key(&pkey, challenge)?;
+
+        // return the generated signature to the caller
+        Ok(signature)
+    }
+
+    pub fn set_handle(&self, handle: Handle) {
+        self.inc_fn_call_count(FnIdx::SetHandle);
+        // remember the handle that has been generated for us so that we can use it when registering keys with the
+        // signer mapper
+        self.handle.write().unwrap().replace(handle);
+    }
+
+    pub fn get_name(&self) -> &str {
+        self.inc_fn_call_count(FnIdx::GetName);
+        "mock signer"
+    }
+
+    pub fn get_info(&self) -> Option<String> {
+        self.inc_fn_call_count(FnIdx::GetInfo);
+        None
+    }
+}
+
+impl Signer for MockSigner {
+    type KeyId = KeyIdentifier;
+
+    type Error = SignerError;
+
+    fn create_key(&self, _algorithm: PublicKeyFormat) -> Result<Self::KeyId, Self::Error> {
+        self.inc_fn_call_count(FnIdx::CreateKey);
+        let (_, _, key_identifier, internal_id) = self.build_key().unwrap();
+
+        // tell the signer mapper we own this key identifier which maps to our "internal id"
+        let lock = self.handle.read().unwrap();
+        let signer_handle = lock.as_ref().unwrap();
+        self.signer_mapper
+            .add_key(signer_handle, &key_identifier, &internal_id)
+            .unwrap();
+
+        Ok(key_identifier)
+    }
+
+    fn get_key_info(&self, key_identifier: &Self::KeyId) -> Result<PublicKey, KeyError<Self::Error>> {
+        self.inc_fn_call_count(FnIdx::GetKeyInfo);
+        let internal_id = self.internal_id_from_key_identifier(key_identifier).unwrap();
+        let pkey = self.load_key(&internal_id).ok_or(KeyError::KeyNotFound)?;
+        let public_key = Self::public_key_from_pkey(&pkey).unwrap();
+        Ok(public_key)
+    }
+
+    fn destroy_key(&self, key_identifier: &Self::KeyId) -> Result<(), KeyError<Self::Error>> {
+        self.inc_fn_call_count(FnIdx::DestroyKey);
+        let internal_id = self.internal_id_from_key_identifier(key_identifier).unwrap();
+        let _ = self.keys.write().unwrap().remove(&internal_id);
+
+        // remove the key from the signer mapper as well
+        let lock = self.handle.read().unwrap();
+        let signer_handle = lock.as_ref().unwrap();
+        self.signer_mapper._remove_key(signer_handle, &key_identifier).unwrap();
+
+        Ok(())
+    }
+
+    fn sign<D: AsRef<[u8]> + ?Sized>(
+        &self,
+        key_identifier: &Self::KeyId,
+        _algorithm: SignatureAlgorithm,
+        data: &D,
+    ) -> Result<Signature, SigningError<Self::Error>> {
+        self.inc_fn_call_count(FnIdx::Sign);
+        let internal_id = self.internal_id_from_key_identifier(key_identifier)?;
+        let pkey = self.load_key(&internal_id).ok_or(SignerError::KeyNotFound)?;
+        Self::sign_with_key(&pkey, data).map_err(|err| SigningError::Signer(err))
+    }
+
+    fn sign_one_off<D: AsRef<[u8]> + ?Sized>(
+        &self,
+        _algorithm: SignatureAlgorithm,
+        data: &D,
+    ) -> Result<(Signature, PublicKey), Self::Error> {
+        self.inc_fn_call_count(FnIdx::SignOneOff);
+        let (public_key, pkey, _, internal_id) = self.build_key().unwrap();
+        let signature = Self::sign_with_key(&pkey, data).unwrap();
+        let _ = self.keys.write().unwrap().remove(&internal_id);
+        Ok((signature, public_key))
+    }
+
+    fn rand(&self, target: &mut [u8]) -> Result<(), Self::Error> {
+        self.inc_fn_call_count(FnIdx::Rand);
+
+        // is this a poison pill?
+        if target == b"WIPE_ALL_KEYS" {
+            // wipe out all our keys, including the identity key used by the SignerRouter to verify that we are an
+            // already known signer.
+            self.keys.write().unwrap().clear();
+        } else {
+            // no, don't do anything, just leave the buffer as is
+        }
+
+        Ok(())
+    }
+}

--- a/src/commons/crypto/signing/signers/mod.rs
+++ b/src/commons/crypto/signing/signers/mod.rs
@@ -10,3 +10,6 @@ pub mod softsigner;
 
 #[cfg(feature = "hsm")]
 pub mod util;
+
+#[cfg(feature = "hsm")]
+pub mod probe;

--- a/src/commons/crypto/signing/signers/mod.rs
+++ b/src/commons/crypto/signing/signers/mod.rs
@@ -13,3 +13,6 @@ pub mod util;
 
 #[cfg(feature = "hsm")]
 pub mod probe;
+
+#[cfg(test)]
+pub mod mocksigner;

--- a/src/commons/crypto/signing/signers/mod.rs
+++ b/src/commons/crypto/signing/signers/mod.rs
@@ -14,5 +14,5 @@ pub mod util;
 #[cfg(feature = "hsm")]
 pub mod probe;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "hsm"))]
 pub mod mocksigner;

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -1,3 +1,18 @@
+//! The PKCS#11 "Cryptoki" context.
+//!
+//! The term "context" isn't part of the PKCS#11 specification, it's the name given by the `pkcs11` Rust crate to the
+//! root data structure that represents a loaded PKCS#11 library and gives access to the functions exported by it.
+//!
+//! Each PKCS#11 library must be initialized only once by a single application using it, irrespective of however many
+//! threads there are within the application that use it.
+//!
+//! # Known issues
+//!
+//! There are no timeouts around the calls into the PKCS#11 context and yet we have no idea what the PKCS#11 library
+//! is going to do when invoked. If it uses a TCP/IP connection to a remote service which is itself not that fast even
+//! when operating normally, the invocation could block for quite a while (in computing terms at least). One possible
+//! way to improve this could be to invoke the library in another thread and way a maximum amount of time in the
+//! invoking thread before deciding to give up on the spawned thread that is taking too long.
 use std::{
     collections::HashMap,
     path::Path,
@@ -16,13 +31,6 @@ use pkcs11::{
 
 use crate::commons::crypto::SignerError;
 
-/// The PKCS#11 "Cryptoki" context. This term isn't part of the PKCS#11 specification, it's the name given by the
-/// `pkcs11` Rust crate to the root data structure that represents a loaded PKCS#11 library and gives access to the
-/// functions exported by it.
-///
-/// Each library must be initialized only once by a single application using it, irrespective of however many threads
-/// there are within the application that use it.
-///
 /// To enable use cases such as migrating from one PKCS#11 provider to another we need to support loading more than one
 /// PKCS#11 library at once and so need to distinguish one library from another. Prior to actually initializing the
 /// library the only means we have for differentiating one from another is the file system path which the library is

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -122,9 +122,3 @@ impl std::ops::Deref for Pkcs11Context {
         self.ctx.as_ref().unwrap()
     }
 }
-
-impl std::ops::DerefMut for Pkcs11Context {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.ctx.as_mut().unwrap()
-    }
-}

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -278,4 +278,14 @@ impl Pkcs11Context {
     pub fn find_objects_final(&self, session: CK_SESSION_HANDLE) -> Result<(), pkcs11::errors::Error> {
         self.logged_cryptoki_call("C_FindObjectsFinal", |cryptoki| cryptoki.find_objects_final(session))
     }
+
+    pub fn destroy_object(
+        &self,
+        session: CK_SESSION_HANDLE,
+        object_handle: CK_OBJECT_HANDLE,
+    ) -> Result<(), pkcs11::errors::Error> {
+        self.logged_cryptoki_call("C_DeleteObject", |cryptoki| {
+            cryptoki.destroy_object(session, object_handle)
+        })
+    }
 }

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -109,7 +109,9 @@ impl Pkcs11Context {
             args.LockMutex = None;
             args.UnlockMutex = None;
             args.flags = CKF_OS_LOCKING_OK;
+            // args.pReserved // TODO: permit setting this, e.g. YubiHSM uses it to pass special settings through to the library
 
+            // TODO: add a timeout around the call to initialize?
             if let Err(err) = self.initialize(Some(args)) {
                 error!("Failed to initialize PKCS#11 library '{}': {}", self.lib_file_name, err);
                 return Err(SignerError::PermanentlyUnusable);
@@ -134,6 +136,7 @@ impl Drop for Pkcs11Context {
 
 //------------ Deref with logging (rather than just impl std::ops::Deref) ---------------------------------------------
 
+// TODO: add a timeout around Cryptoki calls?
 impl Pkcs11Context {
     fn logged_cryptoki_call<F, T>(&self, cryptoki_call_name: &'static str, call: F) -> Result<T, pkcs11::errors::Error>
     where

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -1,0 +1,130 @@
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, RwLock},
+};
+
+use once_cell::sync::OnceCell;
+use pkcs11::{
+    types::{CKF_OS_LOCKING_OK, CK_C_INITIALIZE_ARGS},
+    Ctx,
+};
+
+use crate::commons::crypto::SignerError;
+
+/// The PKCS#11 "Cryptoki" context. This term isn't part of the PKCS#11 specification, it's the name given by the
+/// `pkcs11` Rust crate to the root data structure that represents a loaded PKCS#11 library and gives access to the
+/// functions exported by it.
+///
+/// Each library must be initialized only once by a single application using it, irrespective of however many threads
+/// there are within the application that use it.
+///
+/// To enable use cases such as migrating from one PKCS#11 provider to another we need to support loading more than one
+/// PKCS#11 library at once and so need to distinguish one library from another. Prior to actually initializing the
+/// library the only means we have for differentiating one from another is the file system path which the library is
+/// loaded from. This may not actually be unique, it could be two copies of the same library (or two different versions
+/// of the same library), or it could be some sort of symbolic link or duplicate mount or other mechanism for making two
+/// file system paths point to the same underlying file. To avoid attempts to load different versions of the same
+/// library we use the filename as the unique identifier rather than the entire path so that two library files at
+/// different filesystem locations with the same name are not both loaded into the memory of our process at the same
+/// time.
+///
+/// To give access to the same loaded library from a second or subsequent caller without double loading or
+/// initialization of the library we need a means of looking up the library context by filename. We use a simple
+/// RwLock'd HashMap for this.
+static CONTEXTS: OnceCell<Arc<RwLock<HashMap<String, Arc<RwLock<Pkcs11Context>>>>>> = OnceCell::new();
+
+#[derive(Debug)]
+pub(super) struct Pkcs11Context {
+    lib_file_name: String,
+
+    ctx: Option<Ctx>,
+}
+
+impl Pkcs11Context {
+    pub fn get_or_load(lib_path: &Path) -> Result<Arc<RwLock<Self>>, SignerError> {
+        let contexts = CONTEXTS.get_or_try_init(
+            || -> Result<Arc<RwLock<HashMap<String, Arc<RwLock<Pkcs11Context>>>>>, SignerError> {
+                Ok(Arc::new(RwLock::new(HashMap::new())))
+            },
+        )?;
+
+        let lib_file_name = lib_path
+            .file_name()
+            .ok_or(SignerError::Pkcs11Error(format!(
+                "PKCS#11 library path '{:?}' does not point to a file",
+                lib_path
+            )))?
+            .to_string_lossy()
+            .to_string();
+
+        let mut locked_contexts = contexts.write().unwrap();
+
+        let ctx_wrapper = locked_contexts
+            .entry(lib_file_name)
+            .or_insert_with_key(|lib_file_name| {
+                let ctx = match Ctx::new(lib_path) {
+                    Ok(ctx) => Some(ctx),
+                    Err(err) => {
+                        error!("Failed to load PKCS#11 library '{:?}': {}", lib_path, err);
+                        None
+                    }
+                };
+                Arc::new(RwLock::new(Pkcs11Context {
+                    lib_file_name: lib_file_name.clone(),
+                    ctx,
+                }))
+            });
+
+        if ctx_wrapper.read().unwrap().ctx.is_none() {
+            return Err(SignerError::Pkcs11Error(format!(
+                "Failed to load PKCS#11 library '{:?}'",
+                lib_path
+            )));
+        }
+
+        Ok(ctx_wrapper.clone())
+    }
+
+    pub fn get_lib_file_name(&self) -> String {
+        self.lib_file_name.clone()
+    }
+
+    pub fn initialize_if_not_already(&mut self) -> Result<(), SignerError> {
+        let ctx = self.ctx.as_mut().ok_or(SignerError::Pkcs11Error(format!(
+            "Failed to initialize library '{}': Library is not loaded yet",
+            self.lib_file_name
+        )))?;
+
+        if !ctx.is_initialized() {
+            // TODO: are these arg values okay?
+            let mut args = CK_C_INITIALIZE_ARGS::new();
+            args.CreateMutex = None;
+            args.DestroyMutex = None;
+            args.LockMutex = None;
+            args.UnlockMutex = None;
+            args.flags = CKF_OS_LOCKING_OK;
+
+            if let Err(err) = ctx.initialize(Some(args)) {
+                error!("Failed to initialize PKCS#11 library '{}': {}", self.lib_file_name, err);
+                return Err(SignerError::PermanentlyUnusable);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl std::ops::Deref for Pkcs11Context {
+    type Target = Ctx;
+
+    fn deref(&self) -> &Self::Target {
+        self.ctx.as_ref().unwrap()
+    }
+}
+
+impl std::ops::DerefMut for Pkcs11Context {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.ctx.as_mut().unwrap()
+    }
+}

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -300,4 +300,14 @@ impl Pkcs11Context {
             cryptoki.destroy_object(session, object_handle)
         })
     }
+
+    pub fn generate_random(
+        &self,
+        session: CK_SESSION_HANDLE,
+        num_bytes_wanted: CK_ULONG,
+    ) -> Result<Vec<u8>, pkcs11::errors::Error> {
+        self.logged_cryptoki_call("C_GenerateRandom", |cryptoki| {
+            cryptoki.generate_random(session, num_bytes_wanted)
+        })
+    }
 }

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -43,10 +43,10 @@ pub(super) struct Pkcs11Context {
     lib_file_name: String,
 
     /// The Rust `pkcs11` Ctx object which gives access to the loaded library functions.
-    /// 
+    ///
     /// Some(...) means that the library was successfully loaded and passed the initial checks performed by the
     /// `pkcs11` crate (at the time of writing it checks that a lot of function pointers are available as expected).
-    /// 
+    ///
     /// None means that we tried and failed to load the library.
     ctx: Option<Ctx>,
 }

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -194,7 +194,7 @@ impl Pkcs11Context {
         self.logged_cryptoki_call_mut("C_Initialize", |cryptoki| cryptoki.initialize(init_args))
     }
 
-    fn finalize(&mut self) -> Result<(), pkcs11::errors::Error> {
+    pub fn finalize(&mut self) -> Result<(), pkcs11::errors::Error> {
         self.logged_cryptoki_call_mut("C_Finalize", |cryptoki| cryptoki.finalize())
     }
 

--- a/src/commons/crypto/signing/signers/pkcs11/internal.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/internal.rs
@@ -173,7 +173,7 @@ impl Pkcs11Signer {
     }
 
     fn get_test_connection_settings() -> Result<ConnectionSettings, SignerError> {
-        let context = Pkcs11Context::get_or_load(Path::new("/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so"))?;
+        let context = Pkcs11Context::get_or_load(Path::new("/usr/lib/softhsm/libsofthsm2.so"))?;
         let slot_id = Option::<CK_SLOT_ID>::None;
         let slot_label = Some("My token 1".to_string());
         let user_pin = Some("1234".to_string());

--- a/src/commons/crypto/signing/signers/pkcs11/internal.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/internal.rs
@@ -1,11 +1,54 @@
-use std::sync::{Arc, RwLock};
+use std::{
+    path::Path,
+    sync::{Arc, RwLock, RwLockReadGuard},
+    time::{Duration, Instant},
+};
 
-use rpki::repository::crypto::{PublicKey, Signature};
+use backoff::ExponentialBackoff;
+
+use bcder::encode::{PrimitiveContent, Values};
+use bytes::Bytes;
+use pkcs11::types::*;
+use rpki::repository::crypto::{PublicKey, PublicKeyFormat, Signature};
 
 use crate::commons::{
     api::Handle,
-    crypto::{dispatch::signerinfo::SignerMapper, SignerError},
+    crypto::{
+        dispatch::signerinfo::SignerMapper,
+        signers::{
+            pkcs11::{context::Pkcs11Context, session::Pkcs11Session},
+            util,
+        },
+        SignerError,
+    },
 };
+
+//------------ Types and constants ------------------------------------------------------------------------------------
+
+/// The time to wait between attempts to initially connect to the KMIP server to verify our connection settings and the
+/// server capabilities.
+const RETRY_INIT_EVERY: Duration = Duration::from_secs(30);
+
+/// The time to wait between an initial and subsequent attempt at sending a request to the KMIP server.
+const RETRY_REQ_AFTER: Duration = Duration::from_secs(2);
+
+/// How much longer should we wait from one request attempt to the next compared to the previous wait?
+const RETRY_REQ_AFTER_MULTIPLIER: f64 = 1.5;
+
+/// The maximum amount of time to keep retrying a failed request.
+const RETRY_REQ_UNTIL_MAX: Duration = Duration::from_secs(30);
+
+// Placeholder struct
+#[derive(Clone, Debug)]
+struct ConnectionSettings {
+    context: Arc<RwLock<Pkcs11Context>>,
+
+    slot_id: Option<CK_SLOT_ID>,
+
+    slot_label: Option<String>,
+
+    user_pin: String,
+}
 
 #[derive(Debug)]
 pub struct Pkcs11Signer {
@@ -14,26 +57,56 @@ pub struct Pkcs11Signer {
     handle: RwLock<Option<Handle>>,
 
     mapper: Arc<SignerMapper>,
+
+    /// A probe dependent interface to the PKCS#11 server.
+    server: Arc<RwLock<ProbingServerConnector>>,
 }
 
 impl Pkcs11Signer {
     /// Creates a new instance of Pkcs11Signer.
     pub fn build(name: &str, mapper: Arc<SignerMapper>) -> Result<Self, SignerError> {
+        // Signer initialization should not block Krill startup. As such we verify that we are able to load the PKCS#11
+        // library don't we initialize the PKCS#11 interface yet because we don't know what it's code will do. If it
+        // were to block while trying to connect to a remote server it would block Krill from starting up completely.
+        // If the remote server is down and the library has logic to  delay and retry, or lacks appropriate timeouts of
+        // connection attempts, we could get stuck for a while. Instead we defer initialization of the library until
+        // first use. The downside of this approach is that we won't detect any issues until that point. Another reason
+        // not to initialize the PKCS#11 library here is that if there are multiple instances of the Pkcs11Signer only
+        // the first of them should call the PKCS#11 C_Initialize() function as the PKCS#11 v2.20 specification states
+        // that "Note that exactly one call to C_Initialize should be made for each application (as opposed to one call
+        // for every thread, for example)". At least, for the same PKCS#11 library that is. If two instances of
+        // Pkcs11Signer each use a different PKCS#11 library, e.g. one uses the SoftHSMv2 library and the other uses the
+        // AWS CloudHSM library, presumably they both need initlaizing within the same instance of the Krill
+        // "application".
+
+        // TODO: Use the supplied configuration settings instead of hard-coded test settings.
+        let conn_settings = Self::get_test_connection_settings()?;
+
+        let server = Arc::new(RwLock::new(ProbingServerConnector::new(conn_settings)));
+
         let s = Pkcs11Signer {
             name: name.to_string(),
             handle: RwLock::new(None),
             mapper: mapper.clone(),
+            server,
         };
 
         Ok(s)
     }
 
     pub fn supports_random(&self) -> bool {
+        // The PKCS#11 C_SeedRandom() and C_GenerateRandom() functions are allowed to return CKR_RANDOM_NO_RNG to
+        // indicate "that the specified token doesn’t have a random number generator". The C_SeedRandom() function can
+        // also return CKR_RANDOM_SEED_NOT_SUPPORTED. Thus it is not a given that the provider is able to generate
+        // random numbers. In theory the provider can also fail to implement the random functions entirely but the
+        // Rust PKCS11 crate `Ctx::new()` function requires these functions to be supported or else it will fail and
+        // we would never get to this point.
         todo!()
     }
 
     pub fn create_registration_key(&self) -> Result<(PublicKey, String), SignerError> {
-        todo!()
+        let (public_key, _, _, internal_key_id) = self.build_key(PublicKeyFormat::Rsa)?;
+        Ok((public_key, internal_key_id))
     }
 
     pub fn sign_registration_challenge<D: AsRef<[u8]> + ?Sized>(
@@ -41,7 +114,8 @@ impl Pkcs11Signer {
         _signer_private_key_id: &str,
         _challenge: &D,
     ) -> Result<Signature, SignerError> {
-        todo!()
+        // todo!()
+        Err(SignerError::KeyNotFound)
     }
 
     pub fn set_handle(&self, _handle: crate::commons::api::Handle) {
@@ -49,10 +123,721 @@ impl Pkcs11Signer {
     }
 
     pub fn get_name(&self) -> &str {
-        todo!()
+        &self.name
     }
 
     pub fn get_info(&self) -> Option<String> {
         todo!()
+    }
+
+    fn get_test_connection_settings() -> Result<ConnectionSettings, SignerError> {
+        let context = Pkcs11Context::get_or_load(Path::new("/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so"))?;
+        let slot_id = None;
+        let slot_label = Some("My token 1".to_string());
+        let user_pin = "1234".to_string();
+        Ok(ConnectionSettings {
+            context,
+            slot_id,
+            slot_label,
+            user_pin,
+        })
+    }
+}
+
+//------------ Probe based server access ------------------------------------------------------------------------------
+
+/// Probe status based access to the PKCS#11 server.
+///
+/// To avoid blocking Krill startup due to HSM connection timeout or failure we start in a `Pending` status which
+/// signifies that we haven't yet verified that we can connect to the HSM or that it supports the capabilities that we
+/// require.
+///
+/// At some point later once an initial connection has been established the PKCS#11 signer changes status to either
+/// `Usable` or `Unusable` based on what was discovered about the PKCS#11 server.
+#[derive(Debug)]
+enum ProbingServerConnector {
+    /// We haven't yet been able to connect to the HSM. If there was already a failed attempt to connect the timestamp
+    /// of the attempt is remembered so that we can choose to space out connection attempts rather than attempt to
+    /// connect every time Krill tries to use the signer.
+    Probing {
+        // The connection settings are not optional but are stored in an Option so that we can "take" them out when
+        // moving from the Probing status for use in the Usable status.
+        conn_settings: Option<ConnectionSettings>,
+        last_probe_time: Option<Instant>,
+    },
+
+    /// The HSM was successfully probed but found to be lacking required capabilities and is thus unusable by Krill.
+    Unusable,
+
+    /// The HSM was successfully probed and confirmed to have the required capabilities.
+    ///
+    /// Note that this does not mean that the HSM is currently contactable, only that we were able to contact it at
+    /// least once since Krill was started. If the domain name/IP address used to connect to Krill now point to a
+    /// different HSM instance the previously determined conclusion that the HSM is usable may no longer be valid.
+    ///
+    /// In this status we keep state concerning our relationship with the HSM.
+    Usable(UsableServerState),
+}
+
+impl ProbingServerConnector {
+    /// Create a new connector to a server that hasn't been probed yet.
+    pub fn new(conn_settings: ConnectionSettings) -> Self {
+        ProbingServerConnector::Probing {
+            conn_settings: Some(conn_settings),
+            last_probe_time: None,
+        }
+    }
+
+    /// Marks now as the last probe attempt timestamp.
+    ///
+    /// Calling this function while not in the Probing state will result in a panic.
+    pub fn mark(&self) -> Result<(), SignerError> {
+        match self {
+            #[rustfmt::skip]
+            ProbingServerConnector::Probing { mut last_probe_time, .. } => {
+                last_probe_time.replace(Instant::now());
+                Ok(())
+            }
+            _ => Err(SignerError::KmipError(
+                "Internal error: cannot mark last probe time as probing has already finished.".into(),
+            )),
+        }
+    }
+
+    pub fn conn_settings(&self) -> &ConnectionSettings {
+        match &self {
+            ProbingServerConnector::Probing { conn_settings, .. } => conn_settings.as_ref().unwrap(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn take_conn_settings(&mut self) -> ConnectionSettings {
+        match self {
+            ProbingServerConnector::Probing { conn_settings, .. } => conn_settings.take().unwrap(),
+            _ => unreachable!(),
+        }
+    }
+
+    /// Helper function to retrieve the state associated with status Usable. Only called when in status `Usable`.
+    /// Calling this function while in another state will result in a panic.
+    pub fn state(&self) -> &UsableServerState {
+        match self {
+            ProbingServerConnector::Usable(state) => state,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// The details needed to interact with a usable KMIP server.
+#[derive(Debug)]
+struct UsableServerState {
+    context: Arc<RwLock<Pkcs11Context>>,
+
+    /// Does the server support generation of random numbers?
+    supports_random_number_generation: bool,
+
+    conn_info: String,
+
+    slot_id: CK_SLOT_ID,
+}
+
+impl UsableServerState {
+    pub fn new(
+        supports_random_number_generation: bool,
+        context: Arc<RwLock<Pkcs11Context>>,
+        conn_info: String,
+        slot_id: CK_SLOT_ID,
+    ) -> UsableServerState {
+        UsableServerState {
+            context,
+            supports_random_number_generation,
+            conn_info,
+            slot_id,
+        }
+    }
+
+    pub fn get_connection(&self) -> Result<Pkcs11Session, pkcs11::errors::Error> {
+        Pkcs11Session::new(self.context.clone(), self.slot_id)
+    }
+}
+
+impl Pkcs11Signer {
+    /// Get a read lock on the Usable server status, if the server is usable.
+    ///
+    /// Returns `Ok` with the status read lock if the server is usable, otherwise returns an `Err` because the
+    /// server is unusable or we haven't yet been able to establish if it is usable or not.
+    ///
+    /// Will try probing again if we didn't already manage to connect to the server and the delay period between probes
+    /// has elapsed.
+    fn server(&self) -> Result<RwLockReadGuard<ProbingServerConnector>, SignerError> {
+        fn get_server_if_usable(
+            status: RwLockReadGuard<ProbingServerConnector>,
+        ) -> Option<Result<RwLockReadGuard<ProbingServerConnector>, SignerError>> {
+            // Check the status through the unlocked read lock
+            match &*status {
+                ProbingServerConnector::Usable(_) => {
+                    // The server has been confirmed as usable, return the read-lock granting access to the current
+                    // status and via it the current state of our relationship with the server.
+                    Some(Ok(status))
+                }
+
+                ProbingServerConnector::Unusable => {
+                    // The server has been confirmed as unusable, fail.
+                    Some(Err(SignerError::PermanentlyUnusable))
+                }
+
+                ProbingServerConnector::Probing { last_probe_time, .. } => {
+                    // We haven't yet established whether the  server is usable or not. If we haven't yet checked or we
+                    // haven't tried checking again for a while, then try contacting it again. If we can't establish
+                    // whether or not the server is usable, return an error.
+                    if !is_time_to_check(RETRY_INIT_EVERY, *last_probe_time) {
+                        Some(Err(SignerError::TemporarilyUnavailable))
+                    } else {
+                        None
+                    }
+                }
+            }
+        }
+
+        // Return the current status or attempt to set it by probing the server
+        let status = self.server.read().unwrap();
+        get_server_if_usable(status).unwrap_or_else(|| {
+            self.probe_server()
+                .and_then(|_| Ok(self.server.read().unwrap()))
+                .map_err(|_| SignerError::TemporarilyUnavailable)
+        })
+    }
+
+    /// Verify if the configured server is contactable and supports the required capabilities.
+    fn probe_server(&self) -> Result<(), SignerError> {
+        // Hold a write lock for the duration of our attempt to verify the server so that no other attempt occurs
+        // at the same time. Bail out if another thread is performing a probe and has the lock. This is the same result
+        // as when attempting to use the server between probe retries.
+        let mut status = self.server.try_write().map_err(|_| SignerError::TemporarilyUnavailable)?;
+
+        // Update the timestamp of our last attempt to contact the server. This is used above to know when we have
+        // waited long enough before attempting to contact the server again. This also guards against attempts to probe
+        // when probing has already finished as mark() will fail in that case.
+        status.mark()?;
+
+        let (res, lib_name) = {
+            let conn_settings = status.conn_settings();
+            let mut writable_ctx = conn_settings.context.write().unwrap();
+            let lib_name = writable_ctx.get_lib_file_name();
+
+            debug!("Probing server using library '{}'", lib_name);
+            let res = writable_ctx.initialize_if_not_already();
+
+            (res, lib_name)
+        };
+
+        if let Err(err) = res {
+            if matches!(err, SignerError::PermanentlyUnusable) {
+                error!("Unable to initialize PKCS#11 info for library '{}': {}", lib_name, err);
+                *status = ProbingServerConnector::Unusable;
+            }
+            return Err(err);
+        }
+
+        // Note: We don't need to check for supported functions because the `pkcs11` Rust crate `fn new()` already
+        // requires that all of the functions that we need are supported. In fact it checks for so many functions I
+        // wonder if it might not fail on some customer deployments, but perhaps it checks only for functions required
+        // by the PKCS#11 specification...?
+
+        let (cryptoki_info, slot_id, slot_info, token_info, user_pin) = {
+            let conn_settings = status.conn_settings();
+            let readable_ctx = conn_settings.context.read().unwrap();
+
+            let cryptoki_info = readable_ctx.get_info().map_err(|err| {
+                error!("Unable to read PKCS#11 info for library '{}': {}", lib_name, err);
+                SignerError::PermanentlyUnusable
+            })?;
+
+            let slot_id = if let Some(slot_id) = conn_settings.slot_id {
+                slot_id
+            } else if let Some(slot_label) = &conn_settings.slot_label {
+                fn has_token_label(
+                    ctx: &RwLockReadGuard<Pkcs11Context>,
+                    slot_id: CK_SLOT_ID,
+                    slot_label: &str,
+                ) -> bool {
+                    match ctx.get_token_info(slot_id) {
+                        Ok(info) => info.label.to_string() == slot_label,
+                        Err(err) => {
+                            warn!("Failed to obtain token info for PKCS#11 slot id '{}': {}", slot_id, err);
+                            false
+                        }
+                    }
+                }
+
+                let slot_id = readable_ctx
+                    .get_slot_list(true)
+                    .map_err(|err| {
+                        error!("Failed to enumerate PKCS#11 slots for library '{}': {}", lib_name, err);
+                        SignerError::PermanentlyUnusable
+                    })?
+                    .into_iter()
+                    .find(|&slot_id| has_token_label(&readable_ctx, slot_id, &slot_label));
+
+                match slot_id {
+                    Some(slot_id) => slot_id,
+                    None => {
+                        error!(
+                            "No PKCS#11 slot found for library '{}' with label '{}'",
+                            lib_name, slot_label
+                        );
+                        return Err(SignerError::PermanentlyUnusable);
+                    }
+                }
+            } else {
+                error!("No PKCS#11 slot id or label specified for library '{}'", lib_name);
+                return Err(SignerError::PermanentlyUnusable);
+            };
+
+            let slot_info = readable_ctx.get_slot_info(slot_id).map_err(|err| {
+                error!(
+                    "Unable to read PKCS#11 slot info for library '{}' slot {}: {}",
+                    lib_name, slot_id, err
+                );
+                SignerError::PermanentlyUnusable
+            })?;
+
+            let token_info = readable_ctx.get_token_info(slot_id).map_err(|err| {
+                error!(
+                    "Unable to read PKCS#11 token info for library '{}' slot {}: {}",
+                    lib_name, slot_id, err
+                );
+                SignerError::PermanentlyUnusable
+            })?;
+
+            let user_pin = conn_settings.user_pin.clone();
+
+            (cryptoki_info, slot_id, slot_info, token_info, user_pin)
+        };
+
+        // TODO: check for RSA key pair support?
+
+        let mut login_session = Pkcs11Session::new(status.conn_settings().context.clone(), slot_id).map_err(|err| {
+            error!(
+                "Unable to open PKCS#11 session for library '{}' slot {}: {}",
+                lib_name, slot_id, err
+            );
+            SignerError::PermanentlyUnusable
+        })?;
+        // TODO: make user pin optional?
+        login_session.login(CKU_USER, Some(&user_pin)).map_err(|err| {
+            error!(
+                "Unable to login to PKCS#11 session for library '{}' slot {}: {}",
+                lib_name, slot_id, err
+            );
+            SignerError::PermanentlyUnusable
+        })?;
+
+        // Switch from probing the server to using it.
+        // -------------------------------------------
+
+        // let server_identification = server_properties.vendor_identification.unwrap_or("Unknown".into());
+
+        // Take the ConnectionSettings out of the Probing status so that we can move it to the Usable status. (we
+        // could clone it but it potentially contains a lot of certificate and key byte data and is about to get
+        // dropped when we change status which is silly when we still need it, instead take it with us to the new
+        // status)
+
+        // // Success! We can use this server. Announce it and switch our status to KmipSignerStatus::Usable.
+        // info!(
+        //     "Using KMIP server '{}' at {}:{}",
+        //     server_identification, conn_settings.host, conn_settings.port
+        // );
+
+        // let supports_rng_retrieve = supported_operations.contains(&Operation::RNGRetrieve);
+        // let conn_info = format!(
+        //     "KMIP Signer [vendor: {}, host: {}, port: {}]",
+        //     server_identification, conn_settings.host, conn_settings.port
+        // );
+        // let pool = ConnectionManager::create_connection_pool(conn_settings, MAX_CONCURRENT_SERVER_CONNECTIONS)?;
+
+        let conn_settings = status.conn_settings();
+        let supports_random_number_generation = false;
+        let context = conn_settings.context.clone();
+        let server_info = "Some server info".to_string();
+        let state = UsableServerState::new(supports_random_number_generation, context, server_info, slot_id);
+
+        *status = ProbingServerConnector::Usable(state);
+
+        Ok(())
+    }
+}
+
+//------------ Connection related functions ---------------------------------------------------------------------------
+
+impl Pkcs11Signer {
+    /// Get a connection to the server, if the server is usable.
+    fn connect(&self) -> Result<Pkcs11Session, SignerError> {
+        let conn = self.server()?.state().get_connection()?;
+        Ok(conn)
+    }
+
+    /// Perform some operation using a KMIP server pool connection.
+    ///
+    /// Fails if the KMIP server is not [KmipSignerStatus::Usable]. If the operation fails due to a transient
+    /// connection error, retry with backoff upto a defined retry limit.
+    fn with_conn<T, F>(&self, desc: &str, do_something_with_conn: F) -> Result<T, SignerError>
+    where
+        F: FnOnce(&Pkcs11Session) -> Result<T, pkcs11::errors::Error> + Copy,
+    {
+        // Define the backoff policy to use
+        let backoff_policy = ExponentialBackoff {
+            initial_interval: RETRY_REQ_AFTER,
+            multiplier: RETRY_REQ_AFTER_MULTIPLIER,
+            max_elapsed_time: Some(RETRY_REQ_UNTIL_MAX),
+            ..Default::default()
+        };
+
+        // Define a notify callback to customize messages written to the logger
+        let notify = |err, next: Duration| {
+            warn!("{} failed, retrying in {} seconds: {}", desc, next.as_secs(), err);
+        };
+
+        // Define an operation to (re)try
+        let op = || {
+            // First get a (possibly already existing) connection from the pool
+            let conn = self.connect().map_err(retry_on_transient_signer_error)?;
+
+            // Next, try to execute the callers operation using the connection. If it fails, examine the cause of
+            // failure to determine if it should be a hard-fail (no more retries) or if we should try again.
+            Ok((do_something_with_conn)(&conn).map_err(retry_on_transient_pkcs11_error)?)
+        };
+
+        // Don't even bother going round the retry loop if we haven't yet successfully connected to the KMIP server
+        // and verified its capabilities:
+        let _ = self.server()?;
+
+        // Try (and retry if needed) the requested operation.
+        let res = backoff::retry_notify(backoff_policy, op, notify).or_else(|err| {
+            error!("{} failed, retries exhausted: {}", desc, err);
+            Err(err)
+        })?;
+
+        Ok(res)
+    }
+}
+
+//------------ High level helper functions for use by the public Signer interface implementation ----------------------
+
+impl Pkcs11Signer {
+    pub(super) fn remember_key_id(
+        &self,
+        key_id: &rpki::repository::crypto::KeyIdentifier,
+        internal_key_id: String,
+    ) -> Result<(), SignerError> {
+        let readable_handle = self.handle.read().unwrap();
+        let signer_handle = readable_handle.as_ref().ok_or(SignerError::Other(
+            "PKCS#11: Failed to record signer key: Signer handle not set".to_string(),
+        ))?;
+        self.mapper
+            .add_key(signer_handle, key_id, &internal_key_id)
+            .map_err(|err| SignerError::Pkcs11Error(format!("Failed to record signer key: {}", err)))?;
+
+        Ok(())
+    }
+
+    // pub(super) fn lookup_key_id(&self, key_id: &KeyIdentifier) -> Result<CKA_ID, KeyError<SignerError>> {
+    //     let readable_handle = self.handle.read().unwrap();
+    //     let signer_handle = readable_handle.as_ref().ok_or(KeyError::KeyNotFound)?;
+
+    //     let internal_key_id = self
+    //         .mapper
+    //         .get_key(signer_handle, key_id)
+    //         .map_err(|_| KeyError::KeyNotFound)?;
+
+    //     Ok(internal_key_id)
+    // }
+
+    pub(super) fn get_random_bytes(&self, _num_bytes_wanted: usize) -> Result<Vec<u8>, SignerError> {
+        if !self.supports_random() {
+            return Err(SignerError::Pkcs11Error(
+                "The PKCS#11 provider does not support random number generation".to_string(),
+            ));
+        }
+        todo!()
+    }
+
+    pub(super) fn build_key(
+        &self,
+        algorithm: PublicKeyFormat,
+    ) -> Result<(PublicKey, CK_OBJECT_HANDLE, CK_OBJECT_HANDLE, String), SignerError> {
+        // https://tools.ietf.org/html/rfc6485#section-3: Asymmetric Key Pair Formats
+        //   "The RSA key pairs used to compute the signatures MUST have a 2048-bit
+        //    modulus and a public exponent (e) of 65,537."
+
+        if !matches!(algorithm, PublicKeyFormat::Rsa) {
+            return Err(SignerError::Pkcs11Error(format!(
+                "Algorithm {:?} not supported while creating key",
+                &algorithm
+            )));
+        }
+
+        let mech = CK_MECHANISM {
+            mechanism: CKM_RSA_PKCS_KEY_PAIR_GEN,
+            pParameter: std::ptr::null_mut(),
+            ulParameterLen: 0,
+        };
+
+        let mut cka_id: [u8; 20] = [0; 20];
+        openssl::rand::rand_bytes(&mut cka_id)
+            .map_err(|_| SignerError::Pkcs11Error("Internal error while generating a random number".to_string()))?;
+
+        let mut pub_template: Vec<CK_ATTRIBUTE> = Vec::new();
+        pub_template.push(CK_ATTRIBUTE::new(CKA_ID).with_bytes(&cka_id));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_VERIFY).with_bool(&CK_TRUE));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_ENCRYPT).with_bool(&CK_FALSE));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_WRAP).with_bool(&CK_FALSE));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_TOKEN).with_bool(&CK_TRUE));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_PRIVATE).with_bool(&CK_TRUE));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_MODULUS_BITS).with_ck_ulong(&2048));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_PUBLIC_EXPONENT).with_bytes(&[0x01, 0x00, 0x01]));
+        pub_template.push(CK_ATTRIBUTE::new(CKA_LABEL).with_string("Krill"));
+
+        let mut priv_template: Vec<CK_ATTRIBUTE> = Vec::new();
+        priv_template.push(CK_ATTRIBUTE::new(CKA_ID).with_bytes(&cka_id));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_SIGN).with_bool(&CK_TRUE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_DECRYPT).with_bool(&CK_FALSE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_UNWRAP).with_bool(&CK_FALSE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_SENSITIVE).with_bool(&CK_TRUE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_TOKEN).with_bool(&CK_TRUE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_PRIVATE).with_bool(&CK_TRUE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_EXTRACTABLE).with_bool(&CK_FALSE));
+        priv_template.push(CK_ATTRIBUTE::new(CKA_LABEL).with_string("Krill"));
+
+        let (pub_handle, priv_handle) = self.with_conn("build key", |conn| {
+            conn.generate_key_pair(&mech, &pub_template, &priv_template)
+        })?;
+
+        let public_key = self.get_public_key_from_handle(pub_handle)?;
+        // let key_identifier = public_key.key_identifier();
+
+        Ok((public_key, pub_handle, priv_handle, hex::encode(cka_id)))
+    }
+
+    fn get_rsa_public_key_bytes(&self, pub_handle: u64) -> Result<Bytes, SignerError> {
+        let (modulus_len, pub_exponent_len) = self.with_conn("get key pair part lengths", |conn| {
+            let mut pub_template: Vec<CK_ATTRIBUTE> = Vec::new();
+            pub_template.push(CK_ATTRIBUTE::new(CKA_MODULUS));
+            pub_template.push(CK_ATTRIBUTE::new(CKA_PUBLIC_EXPONENT));
+            let (_, res_vec) = conn.get_attribute_value(pub_handle, &mut pub_template)?;
+            Ok((res_vec[0].ulValueLen as usize, res_vec[1].ulValueLen as usize))
+        })?;
+
+        let (modulus, pub_exponent) = self.with_conn("get key pair parts", |conn| {
+            let mut modulus = Vec::with_capacity(modulus_len);
+            let mut pub_exponent = Vec::with_capacity(pub_exponent_len);
+            modulus.resize(modulus_len, 0);
+            pub_exponent.resize(pub_exponent_len, 0);
+            let mut pub_template: Vec<CK_ATTRIBUTE> = Vec::new();
+            pub_template.push(CK_ATTRIBUTE::new(CKA_MODULUS).with_bytes(modulus.as_mut_slice()));
+            pub_template.push(CK_ATTRIBUTE::new(CKA_PUBLIC_EXPONENT).with_bytes(pub_exponent.as_mut_slice()));
+            conn.get_attribute_value(pub_handle, &mut pub_template)?;
+            Ok((modulus, pub_exponent))
+        })?;
+
+        util::rsa_public_key_bytes_from_parts(&modulus, &pub_exponent)
+    }
+
+    // TODO: This is almost identical to the equivalent fn in KmipSigner. Factor out the common code.
+    pub(super) fn get_public_key_from_handle(&self, pub_handle: u64) -> Result<PublicKey, SignerError> {
+        let rsa_public_key_bytes = self.get_rsa_public_key_bytes(pub_handle)?;
+
+        let subject_public_key = bcder::BitString::new(0, rsa_public_key_bytes);
+
+        let subject_public_key_info =
+            bcder::encode::sequence((PublicKeyFormat::Rsa.encode(), subject_public_key.encode()));
+
+        let mut subject_public_key_info_source: Vec<u8> = Vec::new();
+        subject_public_key_info
+            .write_encoded(bcder::Mode::Der, &mut subject_public_key_info_source)
+            .map_err(|err| {
+                SignerError::KmipError(format!(
+                    "Failed to create DER encoded SubjectPublicKeyInfo from constituent parts: {}",
+                    err
+                ))
+            })?;
+
+        let public_key = PublicKey::decode(subject_public_key_info_source.as_slice()).map_err(|err| {
+            SignerError::KmipError(format!(
+                "Failed to create public key from the DER encoded SubjectPublicKeyInfo: {}",
+                err
+            ))
+        })?;
+
+        Ok(public_key)
+    }
+}
+
+// TODO: Refactor duplicate code out of here and kmip/internal.rs:
+fn is_time_to_check(time_between_checks: Duration, possible_lack_check_time: Option<Instant>) -> bool {
+    match possible_lack_check_time {
+        None => true,
+        Some(instant) => Instant::now().saturating_duration_since(instant) > time_between_checks,
+    }
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+// Retry with backoff related helper impls/fns:
+// --------------------------------------------------------------------------------------------------------------------
+
+fn retry_on_transient_pkcs11_error(err: pkcs11::errors::Error) -> backoff::Error<SignerError> {
+    if is_transient_error(&err) {
+        backoff::Error::Transient(err.into())
+    } else {
+        backoff::Error::Permanent(err.into())
+    }
+}
+
+fn retry_on_transient_signer_error(err: SignerError) -> backoff::Error<SignerError> {
+    match err {
+        SignerError::TemporarilyUnavailable => backoff::Error::Transient(err),
+        _ => backoff::Error::Permanent(err),
+    }
+}
+
+fn is_transient_error(err: &pkcs11::errors::Error) -> bool {
+    match err {
+        pkcs11::errors::Error::Io(_) => {
+            // The Rust `pkcs11` crate encountered an I/O error. I assume this can only occur when trying and
+            // failing to open the PKCS#11 library file that we asked it to use.
+            false
+        }
+        pkcs11::errors::Error::Module(_) => {
+            // The Rust `pkcs11` crate had a serious problem such as the loaded library not exporting a required
+            // function or that it was asked to initialize an already initialized library.
+            false
+        }
+        pkcs11::errors::Error::InvalidInput(_) => {
+            // The Rust `pkcs11` crate was unable to use an input it was given, e.g. a PIN contained a nul byte
+            // or was not set or unset as expected.
+            false
+        }
+        pkcs11::errors::Error::Pkcs11(err) => {
+            // Error codes were taken from the `types` module of the Rust `pkcs11` crate.
+            // See section 11.1 of the PKCS#11 v2.20 specification for an explanation of each value.
+            // Return true only for errors which might succeed very soon after they failed. Errors which are solvable
+            // by an operator changing data or configuration in the HSM are not treated as transient errors as they
+            // are unlikely to be solved in the immediate future and thus there is no value in retrying.
+            match *err {
+                // PKCS#11 v2.20
+                CKR_OK => false, // unreachable!() ?
+                CKR_CANCEL => false,
+                CKR_HOST_MEMORY => true,
+                CKR_SLOT_ID_INVALID => true, // maybe we tried accessing the slot just before it is created?
+                CKR_GENERAL_ERROR => true,
+                CKR_FUNCTION_FAILED => true, // the spec says the situation is not necessarily totally hopeless
+                CKR_ARGUMENTS_BAD => false,  // resubmitting the same bad arguments will just fail again
+                CKR_NO_EVENT => false,
+                CKR_NEED_TO_CREATE_THREADS => false,
+                CKR_CANT_LOCK => false,
+                CKR_ATTRIBUTE_READ_ONLY => false, // for attributes that are always read only retrying will not succeed
+                CKR_ATTRIBUTE_SENSITIVE => false,
+                CKR_ATTRIBUTE_TYPE_INVALID => false,
+                CKR_ATTRIBUTE_VALUE_INVALID => false,
+                CKR_ACTION_PROHIBITED => false,
+                CKR_DATA_INVALID => false,
+                CKR_DATA_LEN_RANGE => false,
+                CKR_DEVICE_ERROR => true, // some error but we don't know what so could be transient
+                CKR_DEVICE_MEMORY => true, // maybe the token frees up some memory such that a retry succeeds?
+                CKR_DEVICE_REMOVED => true, // not present at the time the function was executed but might be later
+                CKR_ENCRYPTED_DATA_INVALID => false,
+                CKR_ENCRYPTED_DATA_LEN_RANGE => false,
+                CKR_FUNCTION_CANCELED => false,
+                CKR_FUNCTION_NOT_PARALLEL => false,
+                CKR_FUNCTION_NOT_SUPPORTED => false,
+                CKR_KEY_HANDLE_INVALID => false,
+                CKR_KEY_SIZE_RANGE => false,
+                CKR_KEY_TYPE_INCONSISTENT => false,
+                CKR_KEY_NOT_NEEDED => false,
+                CKR_KEY_CHANGED => false,
+                CKR_KEY_NEEDED => false,
+                CKR_KEY_INDIGESTIBLE => false,
+                CKR_KEY_FUNCTION_NOT_PERMITTED => false,
+                CKR_KEY_NOT_WRAPPABLE => false,
+                CKR_KEY_UNEXTRACTABLE => false,
+                CKR_MECHANISM_INVALID => false,
+                CKR_MECHANISM_PARAM_INVALID => false,
+                CKR_OBJECT_HANDLE_INVALID => false,
+                CKR_OPERATION_ACTIVE => true, // the active operation might finish thereby permitting a retry to succeed
+                CKR_OPERATION_NOT_INITIALIZED => false,
+                CKR_PIN_INCORRECT => false,
+                CKR_PIN_INVALID => false,
+                CKR_PIN_LEN_RANGE => false,
+                CKR_PIN_EXPIRED => false,
+                CKR_PIN_LOCKED => false,
+                CKR_SESSION_CLOSED => true, // maybe on retry we open a new session and succeed?
+                CKR_SESSION_COUNT => true, // if a session closes it might be possible on retry for a session open to succeed
+                CKR_SESSION_HANDLE_INVALID => false,
+                CKR_SESSION_PARALLEL_NOT_SUPPORTED => false,
+                CKR_SESSION_READ_ONLY => false,
+                CKR_SESSION_EXISTS => false,
+                CKR_SESSION_READ_ONLY_EXISTS => true, // will succeed on retry if the conflicting SO session logs out
+                CKR_SESSION_READ_WRITE_SO_EXISTS => true, // will succeed on retry if the conflicting SO session logs out
+                CKR_SIGNATURE_INVALID => false,
+                CKR_SIGNATURE_LEN_RANGE => false,
+                CKR_TEMPLATE_INCOMPLETE => false,
+                CKR_TEMPLATE_INCONSISTENT => false,
+                CKR_TOKEN_NOT_PRESENT => true, // not present at the time the function was executed but might be later
+                CKR_TOKEN_NOT_RECOGNIZED => false,
+                CKR_TOKEN_WRITE_PROTECTED => true, // maybe the right protection is a transient condition?
+                CKR_UNWRAPPING_KEY_HANDLE_INVALID => false,
+                CKR_UNWRAPPING_KEY_SIZE_RANGE => false,
+                CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT => false,
+                CKR_USER_ALREADY_LOGGED_IN => true, // maybe another client was is busy logging out so try again?
+                CKR_USER_NOT_LOGGED_IN => false,
+                CKR_USER_PIN_NOT_INITIALIZED => false,
+                CKR_USER_TYPE_INVALID => false,
+                CKR_USER_ANOTHER_ALREADY_LOGGED_IN => true,
+                CKR_USER_TOO_MANY_TYPES => true, // maybe some sessions are terminated while retrying permitting us to succeed?
+                CKR_WRAPPED_KEY_INVALID => false,
+                CKR_WRAPPED_KEY_LEN_RANGE => false,
+                CKR_WRAPPING_KEY_HANDLE_INVALID => false,
+                CKR_WRAPPING_KEY_SIZE_RANGE => false,
+                CKR_WRAPPING_KEY_TYPE_INCONSISTENT => false,
+                CKR_RANDOM_SEED_NOT_SUPPORTED => false,
+                CKR_RANDOM_NO_RNG => false,
+                CKR_DOMAIN_PARAMS_INVALID => false,
+                CKR_CURVE_NOT_SUPPORTED => false,
+                CKR_BUFFER_TOO_SMALL => false,
+                CKR_SAVED_STATE_INVALID => false,
+                CKR_INFORMATION_SENSITIVE => false,
+                CKR_STATE_UNSAVEABLE => true, // the spec doesn't seem to rule out this being a temporary condition
+                CKR_CRYPTOKI_NOT_INITIALIZED => false,
+                CKR_CRYPTOKI_ALREADY_INITIALIZED => false,
+                CKR_MUTEX_BAD => false,        // should never happen so consider it fatal?
+                CKR_MUTEX_NOT_LOCKED => false, // should never happen so consider it fatal?
+
+                // PKCS#11 v2.40
+                CKR_NEW_PIN_MODE => false,
+                CKR_NEXT_OTP => false,
+                CKR_EXCEEDED_MAX_ITERATIONS => false,
+                CKR_FIPS_SELF_TEST_FAILED => false,
+                CKR_LIBRARY_LOAD_FAILED => false,
+                CKR_PIN_TOO_WEAK => false,
+                CKR_PUBLIC_KEY_INVALID => false,
+                CKR_FUNCTION_REJECTED => false,
+                CKR_VENDOR_DEFINED => false,
+
+                // Unknown
+                _ => false,
+            }
+        }
+        pkcs11::errors::Error::UnavailableInformation => false,
+    }
+}
+
+impl From<pkcs11::errors::Error> for SignerError {
+    fn from(err: pkcs11::errors::Error) -> Self {
+        if is_transient_error(&err) {
+            error!("PKCS#11 signer unavailable: {}", err);
+            SignerError::TemporarilyUnavailable
+        } else {
+            SignerError::Pkcs11Error(err.to_string())
+        }
     }
 }

--- a/src/commons/crypto/signing/signers/pkcs11/internal.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/internal.rs
@@ -289,7 +289,7 @@ struct UsableServerState {
     login_mode: LoginMode,
 
     /// When login_mode is NOT LoginMode::LoginRequired this will be None.
-    /// 
+    ///
     /// Section 11.6 "Session management functions" of the PKCS#11 v2.20 specification says:
     ///   "Call C_Login to log the user into the token. Since all sessions an application has with a token have a
     ///    shared login state, C_Login only needs to be called for one of the sessions."
@@ -514,7 +514,7 @@ impl Pkcs11Signer {
                 );
                 SignerError::PermanentlyUnusable
             })?;
-            
+
             login_session.login(CKU_USER, user_pin.as_deref()).map_err(|err| {
                 error!(
                     "[{}] Unable to login to PKCS#11 session for library '{}' slot {}: {}",
@@ -522,14 +522,14 @@ impl Pkcs11Signer {
                 );
                 SignerError::PermanentlyUnusable
             })?;
-            
+
             trace!(
                 "[{}] Logged in to PKCS#11 session for library '{}' slot {}",
                 signer_name,
                 lib_name,
                 slot_id,
             );
-            
+
             Some(login_session)
         } else {
             None

--- a/src/commons/crypto/signing/signers/pkcs11/internal.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/internal.rs
@@ -765,7 +765,7 @@ impl Pkcs11Signer {
     }
 
     // TODO: This is almost identical to the equivalent fn in KmipSigner. Factor out the common code.
-    pub(super) fn get_public_key_from_handle(&self, pub_handle: u64) -> Result<PublicKey, SignerError> {
+    pub(super) fn get_public_key_from_handle(&self, pub_handle: CK_OBJECT_HANDLE) -> Result<PublicKey, SignerError> {
         let rsa_public_key_bytes = self.get_rsa_public_key_bytes(pub_handle)?;
 
         let subject_public_key = bcder::BitString::new(0, rsa_public_key_bytes);
@@ -860,6 +860,11 @@ impl Pkcs11Signer {
                 &human_key_class, cka_id_hex_str
             )))),
         }
+    }
+
+    pub(super) fn destroy_key_by_handle(&self, key_handle: CK_OBJECT_HANDLE) -> Result<(), SignerError> {
+        trace!("PKCS#11: Destroying key with PKCS#11 handle {}", key_handle);
+        self.with_conn("destroy", |conn| conn.destroy_object(key_handle))
     }
 }
 

--- a/src/commons/crypto/signing/signers/pkcs11/mod.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/mod.rs
@@ -1,3 +1,4 @@
+pub mod context;
 /// # Thread safety
 ///
 /// From section 6.7.6 "Capabilities of sessions":
@@ -19,7 +20,7 @@
 /// logical reader that potentially contains a token". However, rather than refer to "tokens" we instead here refer to
 /// the PKCS#11 server. This is because Krill uses the term token to refer to the token used to authenticate with the
 /// Krill API.
-/// 
+///
 /// By using "server" the code is more consistent with the KmipSigner code, we avoid the overlap with the Krill meaning
 /// of "token" and, while it may at first seem misleading because for example the SoftHSMv2 PKCS#11 library communicates
 /// with a local process and not a remote server, this is no worse than the KMIP scenario when the "server" is actually
@@ -27,8 +28,7 @@
 /// representative of the remote cloud server or server cluster nature of the backend being communicated with by the
 /// PKCS#11 library.
 pub mod internal;
-pub mod signer;
-pub mod context;
 pub mod session;
+pub mod signer;
 
 pub use internal::Pkcs11Signer;

--- a/src/commons/crypto/signing/signers/pkcs11/mod.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/mod.rs
@@ -1,3 +1,31 @@
+/// # Thread safety
+///
+/// From section 6.7.6 "Capabilities of sessions":
+///
+///   "A consequence of the fact that a single session can, in general, perform only one operation at a time is that an
+///    application should never make multiple simultaneous function calls to Cryptoki which use a common session.  If
+///    multiple threads of an application attempt to use a common session concurrently in this fashion, Cryptoki does
+///    not define what happens. This means that if multiple threads of an application all need to use Cryptoki to access
+///    a particular token, it might be appropriate for each thread to have its own session with the token, unless the
+///    application can ensure by some other means (e.g., by some locking mechanism) that no sessions are ever used by
+///    multiple threads simultaneously.  This is true regardless of whether or not the Cryptoki library was initialized
+///    in a fashion which permits safe multi-threaded access to it. Even if it is safe to access the library from
+///    multiple threads simultaneously, it is still not necessarily safe to use a particular session from multiple
+///    threads simultaneously.""
+///
+/// # Terminology
+///
+/// The PKCS#11 specification defines the term token as a "logical view of a cryptographic device" and slot as "a
+/// logical reader that potentially contains a token". However, rather than refer to "tokens" we instead here refer to
+/// the PKCS#11 server. This is because Krill uses the term token to refer to the token used to authenticate with the
+/// Krill API.
+/// 
+/// By using "server" the code is more consistent with the KmipSigner code, we avoid the overlap with the Krill meaning
+/// of "token" and, while it may at first seem misleading because for example the SoftHSMv2 PKCS#11 library communicates
+/// with a local process and not a remote server, this is no worse than the KMIP scenario when the "server" is actually
+/// a locally running PyKMIP Python process, and in cases such as the AWS CloudHSM PKCS#11 library is actually
+/// representative of the remote cloud server or server cluster nature of the backend being communicated with by the
+/// PKCS#11 library.
 pub mod internal;
 pub mod signer;
 pub mod context;

--- a/src/commons/crypto/signing/signers/pkcs11/session.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/session.rs
@@ -120,4 +120,11 @@ impl Pkcs11Session {
             .unwrap()
             .destroy_object(self.session_handle, object_handle)
     }
+
+    pub fn generate_random(&self, num_bytes_wanted: CK_ULONG) -> Result<Vec<u8>, pkcs11::errors::Error> {
+        self.context
+            .read()
+            .unwrap()
+            .generate_random(self.session_handle, num_bytes_wanted)
+    }
 }

--- a/src/commons/crypto/signing/signers/pkcs11/session.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/session.rs
@@ -1,0 +1,54 @@
+use std::sync::{Arc, RwLock};
+
+use pkcs11::types::{
+    CKF_RW_SESSION, CKF_SERIAL_SESSION, CK_ATTRIBUTE, CK_MECHANISM, CK_RV, CK_SESSION_HANDLE, CK_SLOT_ID, CK_USER_TYPE,
+};
+
+use crate::commons::crypto::signers::pkcs11::context::Pkcs11Context;
+
+#[derive(Debug)]
+pub(super) struct Pkcs11Session {
+    context: Arc<RwLock<Pkcs11Context>>,
+
+    handle: CK_SESSION_HANDLE,
+}
+
+impl Pkcs11Session {
+    pub(super) fn new(
+        context: Arc<RwLock<Pkcs11Context>>,
+        slot_id: CK_SLOT_ID,
+    ) -> Result<Pkcs11Session, pkcs11::errors::Error> {
+        let handle = context
+            .read()
+            .unwrap()
+            .open_session(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION, None, None)?;
+        Ok(Pkcs11Session { context, handle })
+    }
+
+    pub(super) fn generate_key_pair(
+        &self,
+        mechanism: &CK_MECHANISM,
+        pub_template: &[CK_ATTRIBUTE],
+        priv_template: &[CK_ATTRIBUTE],
+    ) -> Result<(u64, u64), pkcs11::errors::Error> {
+        self.context
+            .read()
+            .unwrap()
+            .generate_key_pair(self.handle, mechanism, pub_template, priv_template)
+    }
+
+    pub(super) fn get_attribute_value<'a>(
+        &self,
+        pub_handle: u64,
+        pub_template: &'a mut Vec<CK_ATTRIBUTE>,
+    ) -> Result<(CK_RV, &'a Vec<CK_ATTRIBUTE>), pkcs11::errors::Error> {
+        self.context
+            .read()
+            .unwrap()
+            .get_attribute_value(self.handle, pub_handle, pub_template)
+    }
+
+    pub(super) fn login(&self, user_type: CK_USER_TYPE, user_pin: Option<&str>) -> Result<(), pkcs11::errors::Error> {
+        self.context.read().unwrap().login(self.handle, user_type, user_pin)
+    }
+}

--- a/src/commons/crypto/signing/signers/pkcs11/session.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/session.rs
@@ -1,7 +1,8 @@
 use std::sync::{Arc, RwLock};
 
 use pkcs11::types::{
-    CKF_RW_SESSION, CKF_SERIAL_SESSION, CK_ATTRIBUTE, CK_MECHANISM, CK_RV, CK_SESSION_HANDLE, CK_SLOT_ID, CK_USER_TYPE,
+    CKF_RW_SESSION, CKF_SERIAL_SESSION, CK_ATTRIBUTE, CK_BYTE, CK_MECHANISM, CK_OBJECT_HANDLE, CK_RV,
+    CK_SESSION_HANDLE, CK_SLOT_ID, CK_ULONG, CK_USER_TYPE,
 };
 
 use crate::commons::crypto::signers::pkcs11::context::Pkcs11Context;
@@ -14,18 +15,40 @@ pub(super) struct Pkcs11Session {
 }
 
 impl Pkcs11Session {
-    pub(super) fn new(
+    pub fn new(
         context: Arc<RwLock<Pkcs11Context>>,
         slot_id: CK_SLOT_ID,
     ) -> Result<Pkcs11Session, pkcs11::errors::Error> {
+        // Section 11.6 "Session management functions" under "C_OpenSession" says:
+        //    "For legacy reasons, the CKF_SERIAL_SESSION bit must always be set; if a call to C_OpenSession does not
+        //     have this bit set, the call should return unsuccessfully with the error code
+        //     CKR_PARALLEL_NOT_SUPPORTED."
+        //
+        // Note that we don't track whether or not the session logs in so that we can later logout because the spec
+        // we invoke C_CloseSession on drop and the spec for C_CloseSession says:
+        //    "If this function is successful and it closes the last session between the application and the token, the
+        //    login state of the token for the application returns to public sessions. Any new sessions to the token
+        //    opened by the application will be either R/O Public or R/W Public sessions."
+        //
+        // In the spirit of not doing anything we don't have to do, we can keep the code simpler by not calling
+        // C_Logout because we don't have to.
         let handle = context
             .read()
             .unwrap()
             .open_session(slot_id, CKF_SERIAL_SESSION | CKF_RW_SESSION, None, None)?;
         Ok(Pkcs11Session { context, handle })
     }
+}
 
-    pub(super) fn generate_key_pair(
+// TODO: Is this ever actually called, or does Krill do an immediate unclean shutdown if terminated?
+impl Drop for Pkcs11Session {
+    fn drop(&mut self) {
+        let _ = self.context.read().unwrap().close_session(self.handle);
+    }
+}
+
+impl Pkcs11Session {
+    pub fn generate_key_pair(
         &self,
         mechanism: &CK_MECHANISM,
         pub_template: &[CK_ATTRIBUTE],
@@ -37,7 +60,7 @@ impl Pkcs11Session {
             .generate_key_pair(self.handle, mechanism, pub_template, priv_template)
     }
 
-    pub(super) fn get_attribute_value<'a>(
+    pub fn get_attribute_value<'a>(
         &self,
         pub_handle: u64,
         pub_template: &'a mut Vec<CK_ATTRIBUTE>,
@@ -48,7 +71,27 @@ impl Pkcs11Session {
             .get_attribute_value(self.handle, pub_handle, pub_template)
     }
 
-    pub(super) fn login(&self, user_type: CK_USER_TYPE, user_pin: Option<&str>) -> Result<(), pkcs11::errors::Error> {
+    pub fn login(&self, user_type: CK_USER_TYPE, user_pin: Option<&str>) -> Result<(), pkcs11::errors::Error> {
         self.context.read().unwrap().login(self.handle, user_type, user_pin)
+    }
+
+    pub fn sign_init(&self, mechanism: &CK_MECHANISM, key: CK_OBJECT_HANDLE) -> Result<(), pkcs11::errors::Error> {
+        self.context.read().unwrap().sign_init(self.handle, mechanism, key)
+    }
+
+    pub fn sign(&self, data: &[CK_BYTE]) -> Result<Vec<CK_BYTE>, pkcs11::errors::Error> {
+        self.context.read().unwrap().sign(self.handle, data)
+    }
+
+    pub fn find_objects_init(&self, template: &[CK_ATTRIBUTE]) -> Result<(), pkcs11::errors::Error> {
+        self.context.read().unwrap().find_objects_init(self.handle, template)
+    }
+
+    pub fn find_objects(&self, max_object_count: CK_ULONG) -> Result<Vec<CK_OBJECT_HANDLE>, pkcs11::errors::Error> {
+        self.context.read().unwrap().find_objects(self.handle, max_object_count)
+    }
+
+    pub fn find_objects_final(&self) -> Result<(), pkcs11::errors::Error> {
+        self.context.read().unwrap().find_objects_final(self.handle)
     }
 }

--- a/src/commons/crypto/signing/signers/pkcs11/session.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/session.rs
@@ -114,5 +114,10 @@ impl Pkcs11Session {
         self.context.read().unwrap().find_objects_final(self.session_handle)
     }
 
+    pub fn destroy_object(&self, object_handle: CK_OBJECT_HANDLE) -> Result<(), pkcs11::errors::Error> {
+        self.context
+            .read()
+            .unwrap()
+            .destroy_object(self.session_handle, object_handle)
     }
 }

--- a/src/commons/crypto/signing/signers/pkcs11/session.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/session.rs
@@ -75,6 +75,9 @@ impl Pkcs11Session {
         self.context.read().unwrap().login(self.handle, user_type, user_pin)
     }
 
+    // Note: Cryptographic operations can fail if the key has CKA_ALWAYS_AUTHENTICATE set as that requires that we call
+    // C_Login immediately prior to calling C_SignInit, and we don't support that yet (would it ever make sense as this
+    // could for example require an operator to enter a pin code in a key pad on every signing moment?).
     pub fn sign_init(&self, mechanism: &CK_MECHANISM, key: CK_OBJECT_HANDLE) -> Result<(), pkcs11::errors::Error> {
         self.context.read().unwrap().sign_init(self.handle, mechanism, key)
     }

--- a/src/commons/crypto/signing/signers/pkcs11/signer.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/signer.rs
@@ -1,3 +1,4 @@
+use pkcs11::types::{CKO_PRIVATE_KEY, CKO_PUBLIC_KEY};
 use rpki::repository::crypto::{
     signer::KeyError, KeyIdentifier, PublicKey, PublicKeyFormat, Signature, SignatureAlgorithm, Signer, SigningError,
 };
@@ -16,29 +17,51 @@ impl Signer for Pkcs11Signer {
         Ok(key_id)
     }
 
-    fn get_key_info(&self, _key_id: &Self::KeyId) -> Result<PublicKey, KeyError<Self::Error>> {
-        todo!()
+    fn get_key_info(&self, key_id: &Self::KeyId) -> Result<PublicKey, KeyError<Self::Error>> {
+        let internal_key_id = self.lookup_key_id(key_id)?;
+        let pub_handle = self.find_key(&internal_key_id, CKO_PUBLIC_KEY)?;
+        self.get_public_key_from_handle(pub_handle)
+            .map_err(|err| KeyError::Signer(err))
     }
 
     fn destroy_key(&self, _key: &Self::KeyId) -> Result<(), KeyError<Self::Error>> {
-        todo!()
+        Ok(()) //TODO
     }
 
     fn sign<D: AsRef<[u8]> + ?Sized>(
         &self,
-        _key: &Self::KeyId,
-        _algorithm: SignatureAlgorithm,
-        _data: &D,
+        key_id: &Self::KeyId,
+        algorithm: SignatureAlgorithm,
+        data: &D,
     ) -> Result<Signature, SigningError<Self::Error>> {
-        todo!()
+        let internal_key_id = self.lookup_key_id(key_id)?;
+        let priv_handle = self
+            .find_key(&internal_key_id, CKO_PRIVATE_KEY)
+            .map_err(|err| match err {
+                KeyError::KeyNotFound => SigningError::KeyNotFound,
+                KeyError::Signer(err) => SigningError::Signer(err),
+            })?;
+
+        self.sign_with_key(priv_handle, algorithm, data.as_ref())
+            .map_err(|err| SigningError::Signer(err))
     }
 
     fn sign_one_off<D: AsRef<[u8]> + ?Sized>(
         &self,
-        _algorithm: SignatureAlgorithm,
-        _data: &D,
+        algorithm: SignatureAlgorithm,
+        data: &D,
     ) -> Result<(Signature, PublicKey), Self::Error> {
-        todo!()
+        let (key, _, priv_handle, _) = self.build_key(PublicKeyFormat::Rsa)?;
+
+        let signature_res = self
+            .sign_with_key(priv_handle, algorithm, data.as_ref())
+            .map_err(|err| SignerError::Pkcs11Error(format!("One-off signing of data failed: {}", err)));
+
+        // let _ = self.destroy_key_pair(&kmip_key_pair_ids, KeyStatus::Active);
+
+        let signature = signature_res?;
+
+        Ok((signature, key))
     }
 
     fn rand(&self, target: &mut [u8]) -> Result<(), Self::Error> {

--- a/src/commons/crypto/signing/signers/pkcs11/signer.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/signer.rs
@@ -9,11 +9,14 @@ impl Signer for Pkcs11Signer {
 
     type Error = SignerError;
 
-    fn create_key(&self, _algorithm: PublicKeyFormat) -> Result<Self::KeyId, Self::Error> {
-        todo!()
+    fn create_key(&self, algorithm: PublicKeyFormat) -> Result<Self::KeyId, Self::Error> {
+        let (key, _, _, internal_key_id) = self.build_key(algorithm)?;
+        let key_id = key.key_identifier();
+        self.remember_key_id(&key_id, internal_key_id)?;
+        Ok(key_id)
     }
 
-    fn get_key_info(&self, _key: &Self::KeyId) -> Result<PublicKey, KeyError<Self::Error>> {
+    fn get_key_info(&self, _key_id: &Self::KeyId) -> Result<PublicKey, KeyError<Self::Error>> {
         todo!()
     }
 
@@ -38,7 +41,11 @@ impl Signer for Pkcs11Signer {
         todo!()
     }
 
-    fn rand(&self, _target: &mut [u8]) -> Result<(), Self::Error> {
-        todo!()
+    fn rand(&self, target: &mut [u8]) -> Result<(), Self::Error> {
+        let random_bytes = self.get_random_bytes(target.len())?;
+
+        target.copy_from_slice(&random_bytes);
+
+        Ok(())
     }
 }

--- a/src/commons/crypto/signing/signers/probe.rs
+++ b/src/commons/crypto/signing/signers/probe.rs
@@ -1,0 +1,336 @@
+use std::{
+    marker::PhantomData,
+    sync::{Arc, RwLock, RwLockReadGuard},
+    time::{Duration, Instant},
+};
+
+#[derive(Debug)]
+pub enum ProbeError<E> {
+    WrongState,
+    AwaitingNextProbe,
+    CompletedUnusable,
+    CallbackFailed(E),
+}
+
+/// Probe status based access to the PKCS#11 server.
+///
+/// To avoid blocking Krill startup due to HSM connection timeout or failure we start in a `AwaitingNextProbe` status which
+/// signifies that we haven't yet verified that we can connect to the HSM or that it supports the capabilities that we
+/// require.
+///
+/// At some point later once an initial connection has been established the PKCS#11 signer changes status to either
+/// `Usable` or `Unusable` based on what was discovered about the PKCS#11 server.
+#[derive(Debug)]
+pub struct StatefulProbe<C, E, S> {
+    status: RwLock<ProbeStatus<C, E, S>>,
+
+    probe_interval: Duration,
+}
+
+pub enum ProbeStatus<C, E, S> {
+    /// We haven't yet been able to connect to the HSM. If there was already a failed attempt to connect the timestamp
+    /// of the attempt is remembered so that we can choose to space out connection attempts rather than attempt to
+    /// connect every time Krill tries to use the signer.
+    Probing {
+        config: Arc<C>,
+        last_probe_time: Option<Instant>,
+        phantom: PhantomData<E>,
+    },
+
+    /// The HSM was successfully probed but found to be lacking required capabilities and is thus unusable by Krill.
+    Unusable,
+
+    /// The HSM was successfully probed and confirmed to have the required capabilities.
+    ///
+    /// Note that this does not mean that the HSM is currently contactable, only that we were able to contact it at
+    /// least once since Krill was started. If the domain name/IP address used to connect to Krill now point to a
+    /// different HSM instance the previously determined conclusion that the HSM is usable may no longer be valid.
+    ///
+    /// In this status we keep state concerning our relationship with the HSM.
+    Usable(S),
+}
+
+impl<C, E, S> std::fmt::Debug for ProbeStatus<C, E, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Probing { .. } => write!(f, "Probing"),
+            Self::Unusable => write!(f, "Unusable"),
+            Self::Usable(_) => write!(f, "Usable"),
+        }
+    }
+}
+
+impl<C, E, S> ProbeStatus<C, E, S> {
+    /// Marks now as the last probe attempt timestamp.
+    ///
+    /// Calling this function while not in the Probing state will result in a panic.
+    pub fn mark(&mut self) -> Result<(), ProbeError<E>> {
+        match self {
+            #[rustfmt::skip]
+            ProbeStatus::Probing { last_probe_time, .. } => {
+                last_probe_time.replace(Instant::now());
+                Ok(())
+            }
+            _ => Err(ProbeError::WrongState),
+        }
+    }
+
+    pub fn config(&self) -> Result<Arc<C>, ProbeError<E>> {
+        match self {
+            ProbeStatus::Probing { config, .. } => Ok(config.clone()),
+            _ => Err(ProbeError::WrongState),
+        }
+    }
+
+    pub fn last_probe_time(&self) -> Result<Option<Instant>, ProbeError<E>> {
+        match self {
+            ProbeStatus::Probing { last_probe_time, .. } => Ok(last_probe_time.clone()),
+            _ => Err(ProbeError::WrongState),
+        }
+    }
+
+    /// Helper function to retrieve the state associated with status Usable. Only callable when in status `Usable`.
+    /// Calling this function while in another state will result in a panic.
+    pub fn state(&self) -> Result<&S, ProbeError<E>> {
+        match self {
+            ProbeStatus::Usable(state) => Ok(&state),
+            _ => Err(ProbeError::WrongState),
+        }
+    }
+}
+
+impl<C, E, S> StatefulProbe<C, E, S> {
+    /// Create a new connector to a server that hasn't been probed yet.
+    pub fn new(config: Arc<C>, probe_interval: Duration) -> Self {
+        let status = RwLock::new(ProbeStatus::Probing {
+            config,
+            last_probe_time: None,
+            phantom: PhantomData,
+        });
+        StatefulProbe { status, probe_interval }
+    }
+
+    pub fn last_probe_time(&self) -> Result<Option<Instant>, ProbeError<E>> {
+        self.status.read().unwrap().last_probe_time()
+    }
+
+    /// Get a read lock on the Usable server status, if the server is usable.
+    ///
+    /// Returns `Ok` with the status read lock if the server is usable, otherwise returns an `Err` because the
+    /// server is unusable or we haven't yet been able to establish if it is usable or not.
+    ///
+    /// Will try probing again if we didn't already manage to connect to the server and the delay period between probes
+    /// has elapsed.
+    pub fn status<F>(&self, probe: F) -> Result<RwLockReadGuard<ProbeStatus<C, E, S>>, ProbeError<E>>
+    where
+        F: Fn(&ProbeStatus<C, E, S>) -> Result<S, ProbeError<E>>,
+    {
+        fn is_time_to_check(time_between_probes: Duration, last_probe_time: Option<Instant>) -> bool {
+            match last_probe_time {
+                None => true,
+                Some(instant) => Instant::now().saturating_duration_since(instant) > time_between_probes,
+            }
+        }
+
+        fn get_if_usable<C, E, S>(
+            status: RwLockReadGuard<ProbeStatus<C, E, S>>,
+            retry_interval: Duration,
+        ) -> Option<Result<RwLockReadGuard<ProbeStatus<C, E, S>>, ProbeError<E>>> {
+            // Check the status through the unlocked read lock
+            match &*status {
+                ProbeStatus::Usable(_) => {
+                    // The server has been confirmed as usable, return the read-lock granting access to the current
+                    // status and via it the current state of our relationship with the server.
+                    Some(Ok(status))
+                }
+
+                ProbeStatus::Unusable => {
+                    // The server has been confirmed as unusable, fail.
+                    Some(Err(ProbeError::CompletedUnusable))
+                }
+
+                ProbeStatus::Probing { last_probe_time, .. } => {
+                    // We haven't yet established whether the  server is usable or not. If we haven't yet checked or we
+                    // haven't tried checking again for a while, then try contacting it again. If we can't establish
+                    // whether or not the server is usable, return an error.
+                    if !is_time_to_check(retry_interval, *last_probe_time) {
+                        Some(Err(ProbeError::AwaitingNextProbe))
+                    } else {
+                        None
+                    }
+                }
+            }
+        }
+
+        /// Verify if the configured server is contactable and supports the required capabilities.
+        fn send_probe<C, E, F, S>(probe: &StatefulProbe<C, E, S>, probe_cb: F) -> Result<(), ProbeError<E>>
+        where
+            F: Fn(&ProbeStatus<C, E, S>) -> Result<S, ProbeError<E>>,
+        {
+            // Hold a write lock for the duration of our attempt to verify the server so that no other attempt occurs
+            // at the same time. Bail out if another thread is performing a probe and has the lock. This is the same result
+            // as when attempting to use the server between probe retries.
+            let mut status = probe.status.try_write().map_err(|_| ProbeError::AwaitingNextProbe)?;
+
+            // Update the timestamp of our last attempt to contact the server. This is used above to know when we have
+            // waited long enough before attempting to contact the server again. This also guards against attempts to probe
+            // when probing has already finished as mark() will fail in that case.
+            status.mark()?;
+
+            match (probe_cb)(&*status) {
+                Ok(usable_state) => {
+                    *status = ProbeStatus::Usable(usable_state);
+                    Ok(())
+                }
+                Err(err) => {
+                    if matches!(err, ProbeError::CompletedUnusable) {
+                        *status = ProbeStatus::Unusable;
+                    }
+                    Err(err)
+                }
+            }
+        }
+
+        // Return the current status or attempt to set it by probing the server
+        let status = self.status.read().unwrap();
+        get_if_usable(status, self.probe_interval).unwrap_or_else(|| {
+            send_probe(self, probe)
+                .and_then(|_| Ok(self.status.read().unwrap()))
+                .map_err(|err| match err {
+                    ProbeError::CompletedUnusable => err,
+                    _ => ProbeError::AwaitingNextProbe,
+                })
+        })
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct Config {
+        hostname: String,
+
+        port: u64,
+    }
+
+    #[derive(Copy, Clone, Debug, Default)]
+    struct State {
+        some_state: u8,
+    }
+
+    impl State {
+        fn some_func(&self) -> u8 {
+            self.some_state
+        }
+    }
+
+    #[derive(Debug)]
+    enum SomeError {
+        SomeErrorCode,
+    }
+
+    fn probe_func(_status: &ProbeStatus<Config, SomeError, State>) -> Result<State, ProbeError<SomeError>> {
+        Err(ProbeError::CompletedUnusable)
+    }
+
+    #[test]
+    fn probe_should_be_permanently_unavailable_with_closure() {
+        let config = Arc::new(Config::default());
+        let conn = StatefulProbe::<_, SomeError, State>::new(config, Duration::from_secs(0));
+        let res = conn.status(|_| Err(ProbeError::CompletedUnusable));
+        match res {
+            Err(ProbeError::CompletedUnusable) => {}
+            other => panic!("Expected Err(ProbeError::PermanentlyUnusable) but got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn probe_should_be_permanently_unavailable_with_fn() {
+        let config = Arc::new(Config::default());
+        let conn = StatefulProbe::<_, SomeError, State>::new(config, Duration::from_secs(0));
+        let res = conn.status(probe_func);
+        match res {
+            Err(ProbeError::CompletedUnusable) => {}
+            other => panic!("Expected Err(ProbeError::PermanentlyUnusable) but got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn probe_should_be_permanently_unavailable() {
+        let config = Arc::new(Config::default());
+        let conn = StatefulProbe::<_, SomeError, State>::new(config, Duration::from_secs(0));
+        let res = conn.status(|_| Err(ProbeError::CompletedUnusable));
+        match res {
+            Err(ProbeError::CompletedUnusable) => {}
+            other => panic!("Expected Err(ProbeError::PermanentlyUnusable) but got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn probe_should_be_temporarily_unavailable() {
+        let config = Arc::new(Config::default());
+        let conn = StatefulProbe::<_, SomeError, State>::new(config, Duration::from_secs(0));
+        let res = conn.status(|_| Err(ProbeError::AwaitingNextProbe));
+        match res {
+            Err(ProbeError::AwaitingNextProbe) => {}
+            other => panic!("Expected Err(ProbeError::AwaitingNextProbe) but got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn probe_should_be_temporarily_unavailable_on_custom_error() {
+        let config = Arc::new(Config::default());
+        let conn = StatefulProbe::<_, SomeError, State>::new(config, Duration::from_secs(0));
+        let res = conn.status(|_| Err(ProbeError::CallbackFailed(SomeError::SomeErrorCode)));
+        match res {
+            Err(ProbeError::AwaitingNextProbe) => {}
+            other => panic!("Expected Err(ProbeError::AwaitingNextProbe) but got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn last_probe_time_should_advance() -> Result<(), ProbeError<SomeError>> {
+        let config = Arc::new(Config::default());
+
+        // Probing is only done when .get() is called
+        let conn = StatefulProbe::<_, SomeError, State>::new(config, Duration::from_millis(100));
+        assert_eq!(None, conn.last_probe_time()?);
+
+        // The first call to .get() should trigger a probe
+        let _ = conn.status(|_| Err(ProbeError::AwaitingNextProbe));
+        let t1 = conn.last_probe_time()?;
+        assert!(t1.is_some());
+
+        // A call to .get() before the next probe interval should NOT result in an updated last probe time
+        std::thread::sleep(Duration::from_millis(10));
+        let _ = conn.status(|_| Err(ProbeError::AwaitingNextProbe));
+        let t2 = conn.last_probe_time()?;
+        assert!(t2 == t1);
+
+        // A call to .get() after the next probe interval SHOULD result in an updated last probe time
+        std::thread::sleep(Duration::from_millis(200));
+        let _ = conn.status(|_| Err(ProbeError::AwaitingNextProbe));
+        let t3 = conn.last_probe_time()?;
+        assert!(t3 > t1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn probe_should_change_state_when_usable() -> Result<(), ProbeError<SomeError>> {
+        let config = Arc::new(Config::default());
+        let new_state = State { some_state: 1 };
+
+        // Probing only happens when .get() is called
+        let conn = StatefulProbe::<_, SomeError, State>::new(config, Duration::from_millis(0));
+        let new_status = conn.status(|_| Ok(new_state))?;
+        assert_eq!(1, new_status.state()?.some_state);
+        assert_eq!(1, new_status.state()?.some_func());
+
+        Ok(())
+    }
+}

--- a/src/commons/crypto/signing/signers/probe.rs
+++ b/src/commons/crypto/signing/signers/probe.rs
@@ -156,10 +156,16 @@ impl<C, E, S> StatefulProbe<C, E, S> {
                     if !is_time_to_check(retry_interval, *last_probe_time) {
                         if let Some(instant) = last_probe_time {
                             let until = retry_interval.saturating_sub(instant.elapsed());
-                            info!("Signer availability checking is cooling off: {:?}s remaining", until.as_secs());
+                            info!(
+                                "Signer availability checking is cooling off: {:?}s remaining",
+                                until.as_secs()
+                            );
                         } else {
                             // This should be unreachable
-                            info!("Signer availability checking is cooling off for {:?}s", retry_interval.as_secs());
+                            info!(
+                                "Signer availability checking is cooling off for {:?}s",
+                                retry_interval.as_secs()
+                            );
                         }
                         Some(Err(ProbeError::AwaitingNextProbe))
                     } else {

--- a/src/commons/crypto/signing/signers/probe.rs
+++ b/src/commons/crypto/signing/signers/probe.rs
@@ -155,7 +155,7 @@ impl<C, E, S> StatefulProbe<C, E, S> {
                     // whether or not the server is usable, return an error.
                     if !is_time_to_check(retry_interval, *last_probe_time) {
                         if let Some(instant) = last_probe_time {
-                            let until = retry_interval.saturating_sub(instant.elapsed());
+                            let until = retry_interval.checked_sub(instant.elapsed()).unwrap(); // TODO
                             info!(
                                 "Signer availability checking is cooling off: {:?}s remaining",
                                 until.as_secs()

--- a/src/commons/crypto/signing/signers/probe.rs
+++ b/src/commons/crypto/signing/signers/probe.rs
@@ -154,6 +154,13 @@ impl<C, E, S> StatefulProbe<C, E, S> {
                     // haven't tried checking again for a while, then try contacting it again. If we can't establish
                     // whether or not the server is usable, return an error.
                     if !is_time_to_check(retry_interval, *last_probe_time) {
+                        if let Some(instant) = last_probe_time {
+                            let until = retry_interval.saturating_sub(instant.elapsed());
+                            info!("Signer availability checking is cooling off: {:?}s remaining", until.as_secs());
+                        } else {
+                            // This should be unreachable
+                            info!("Signer availability checking is cooling off for {:?}s", retry_interval.as_secs());
+                        }
                         Some(Err(ProbeError::AwaitingNextProbe))
                     } else {
                         None

--- a/src/commons/crypto/signing/signers/softsigner.rs
+++ b/src/commons/crypto/signing/signers/softsigner.rs
@@ -221,7 +221,7 @@ impl OpenSslSigner {
         if let Some(mapper) = &self.mapper {
             let readable_handle = self.handle.read().unwrap();
             let signer_handle = readable_handle.as_ref().ok_or(SignerError::Other(
-                "Failed to record signer key: Signer handle not set".to_string(),
+                "OpenSSL: Failed to record signer key: Signer handle not set".to_string(),
             ))?;
             mapper
                 .add_key(signer_handle, key_id, &format!("{}", key_id))

--- a/src/commons/crypto/signing/signers/softsigner.rs
+++ b/src/commons/crypto/signing/signers/softsigner.rs
@@ -5,6 +5,7 @@ use std::{
     fs::File,
     io::Write,
     path::{Path, PathBuf},
+    str::FromStr,
     sync::Arc,
 };
 

--- a/src/commons/crypto/signing/signers/softsigner.rs
+++ b/src/commons/crypto/signing/signers/softsigner.rs
@@ -85,12 +85,10 @@ impl OpenSslSigner {
         Ok(s)
     }
 
-    #[cfg(feature = "hsm")]
     pub fn get_name(&self) -> &str {
         &self.name
     }
 
-    #[cfg(feature = "hsm")]
     pub fn set_handle(&self, handle: Handle) {
         let mut writable_handle = self.handle.write().unwrap();
         if writable_handle.is_some() {
@@ -99,21 +97,10 @@ impl OpenSslSigner {
         *writable_handle = Some(handle);
     }
 
-    #[cfg(feature = "hsm")]
-    pub fn sign_registration_challenge<D: AsRef<[u8]> + ?Sized>(
-        &self,
-        signer_private_key_id: &str,
-        challenge: &D,
-    ) -> Result<Signature, SignerError> {
-        use std::str::FromStr;
-
-        let key_id = KeyIdentifier::from_str(signer_private_key_id).map_err(|_| SignerError::KeyNotFound)?;
-        let key_pair = self.load_key(&key_id)?;
-        let signature = Self::sign_with_key(key_pair.pkey.as_ref(), challenge)?;
-        Ok(signature)
+    pub fn get_info(&self) -> Option<String> {
+        self.info.clone()
     }
 
-    #[cfg(feature = "hsm")]
     pub fn create_registration_key(&self) -> Result<(PublicKey, String), SignerError> {
         // For the OpenSslSigner we use the KeyIdentifier as the internal key id so the two are the same.
         let key_id = self.build_key()?;
@@ -123,9 +110,15 @@ impl OpenSslSigner {
         Ok((public_key, internal_key_id))
     }
 
-    #[cfg(feature = "hsm")]
-    pub fn get_info(&self) -> Option<String> {
-        self.info.clone()
+    pub fn sign_registration_challenge<D: AsRef<[u8]> + ?Sized>(
+        &self,
+        signer_private_key_id: &str,
+        challenge: &D,
+    ) -> Result<Signature, SignerError> {
+        let key_id = KeyIdentifier::from_str(signer_private_key_id).map_err(|_| SignerError::KeyNotFound)?;
+        let key_pair = self.load_key(&key_id)?;
+        let signature = Self::sign_with_key(key_pair.pkey.as_ref(), challenge)?;
+        Ok(signature)
     }
 }
 

--- a/src/daemon/ca/certauth.rs
+++ b/src/daemon/ca/certauth.rs
@@ -1941,7 +1941,7 @@ mod tests {
     #[test]
     fn generate_id_cert() {
         test::test_under_tmp(|d| {
-            let signer = KrillSigner::build(&d).unwrap();
+            let signer = KrillSigner::build(&d, false).unwrap();
             let id = Rfc8183Id::generate(&signer).unwrap();
             id.cert.validate_ta().unwrap();
         });

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -101,7 +101,7 @@ impl KrillServer {
         let mut repo_dir = work_dir.clone();
         repo_dir.push("repo");
 
-        let signer = Arc::new(KrillSigner::build(work_dir)?);
+        let signer = Arc::new(KrillSigner::build(work_dir, false)?);
 
         #[cfg(feature = "multi-user")]
         let login_session_cache = Arc::new(LoginSessionCache::new());

--- a/src/pubd/manager.rs
+++ b/src/pubd/manager.rs
@@ -224,7 +224,7 @@ mod tests {
     };
 
     fn publisher_alice(work_dir: &Path) -> Publisher {
-        let signer = KrillSigner::build(work_dir).unwrap();
+        let signer = KrillSigner::build(work_dir, true).unwrap();
 
         let key = signer.create_key().unwrap();
         let id_cert = IdCertBuilder::new_ta_id_cert(&key, &signer).unwrap();
@@ -244,7 +244,7 @@ mod tests {
         let config = Arc::new(Config::test(work_dir, true, false, false));
         init_config(&config);
 
-        let signer = KrillSigner::build(work_dir).unwrap();
+        let signer = KrillSigner::build(work_dir, false).unwrap();
         let signer = Arc::new(signer);
 
         let repository_manager = RepositoryManager::build(config, signer).unwrap();

--- a/src/upgrades/mod.rs
+++ b/src/upgrades/mod.rs
@@ -186,7 +186,7 @@ fn upgrade_0_9_0(config: Arc<Config>) -> Result<(), UpgradeError> {
     }
 
     if needs_v0_9_0_upgrade(work_dir, "cas") {
-        let signer = Arc::new(KrillSigner::build(work_dir)?);
+        let signer = Arc::new(KrillSigner::build(work_dir, false)?);
         let repo_manager = RepositoryManager::build(config.clone(), signer)?;
 
         CaObjectsMigration::migrate(config, repo_manager)?;

--- a/src/upgrades/v0_9_0/ca_objects_migration.rs
+++ b/src/upgrades/v0_9_0/ca_objects_migration.rs
@@ -42,7 +42,7 @@ impl CaObjectsMigration {
         let store = KeyValueStore::disk(&config.data_dir, CASERVER_DIR)?;
         let ca_store = AggregateStore::<ca::CertAuth>::disk(&config.data_dir, CASERVER_DIR)?;
 
-        let signer = Arc::new(KrillSigner::build(&config.data_dir)?);
+        let signer = Arc::new(KrillSigner::build(&config.data_dir, false)?);
 
         if store.version_is_before(KrillVersion::release(0, 6, 0))? {
             Err(UpgradeError::custom("Cannot upgrade Krill installations from before version 0.6.0. Please upgrade to any version ranging from 0.6.0 to 0.8.1 first, and then upgrade to this version."))

--- a/tests/migrate_repository.rs
+++ b/tests/migrate_repository.rs
@@ -13,6 +13,7 @@ use krill::{
 };
 
 #[tokio::test]
+#[cfg(not(feature = "hsm-tests-pkcs11"))]
 async fn migrate_repository() {
     init_logging();
 


### PR DESCRIPTION
This PR builds on PR #688 "Use new de-mut'd rpki-rs Signer trait" and implements a working PKCS#11 signer including a GH Actions job to run the Krill test suite using the new signer against an installed instance of SoftHSMv2.

## Known issues

- A general lack of tests.
- Comments in code need review/removing/adding/updating.
- This PR still doesn't introduce configuration file based selection & configuration of signers, so it uses hard-coded feature gated creation and configuration of of signers instead.
- Warnings from `cargo build` about unused code, These are due to the current hard-coded signer setup.

## Readme first

I updated the [`doc/development/hsm/architecture.md`](/NLnetLabs/krill/blob/issue-547-pkcs11-walking-skeleton/doc/development/hsm/architecture.md) file, I suggest reading it first. There's still lots more I could probably mention and explain and maybe some of it should be removed or moved to some sort of appendix.

## A note about Cargo.toml and the pkcs11 crate

I hit a strange problem where in release builds the `pkcs11` crate seems to end up with a key NULL ptr being optimized out such that SoftHSMv2 complains with `CKR_ARGUMENTS_NAD` and in the logs says that `pReserved` must be NULL. In debug builds this doesn't happen. So in `Cargo.toml` there's currently a workaround for this that disables compiler optimizations only for the pkcs11 crate in release mode. That seems to have "solved" the problem for now but this should be raised with the `pkcs11` crate owners, there are no issues relating to this in their GitHub project that I can see.

I have raised https://github.com/mheese/rust-pkcs11/issues/49 for this.

## Changes that are quick to review
First, let's mention changes that are separate and easy to review and will knock down dramatically the count of files left to review:

- `.github/workflows/ci.yml`: An updated GitHub Actions CI workflow that adds testing Krill in PKCS#11 mode against SoftHSMv2 installed in the runner machine.

- `Cargo.lock` and `Cargo.toml`: Additional crate dependencies and Cargo features relating to the new PKCS#11 code.

- `src/commons/crypto/cert.rs`, `src/commons/crypto/cms.rs`, `src/commons/crypto/signing/dispatch/krillsigner.rs`, `src/daemon/ca/certauth.rs`, `src/daemon/krillserver.rs`, `src/pubd/manager.rs`, `src/upgrades/mod.rs`, `src/upgrades/v0_9_0`, `/ca_objects_migration.rs`: Modified calls to `KrillSigner::build()` to pass an additional `alternate_config` boolean flag. This should be `false` in most cases, it is for use by a subset of the tests that create a second instance of Krill or KrillSigner within the same process and then try and use PKCS#11 signer with SoftHSMv2, as SoftHSMv2 doesn't support multiple users or concurrent login by the same user so when `true` the second `KrillSigner` instance (e.g. for "Alice") will use OpenSSL instead of PKCS#11 based signing. The need for this flag will disappear when signers can be configured as tests can then configure the signing setup as needed without this hard-coded workaround.

- `tests/migrate_repository.rs`: The `migrate_repository` test has been disabled when using PKCS#11 testing mode as it fails, I believe relating to the use of SoftHSMv2 as mentioned above, but in this case I have not yet narrowed down the exact failure.

- `src/commons/crypto/signing/signers/error.rs`: Multiple files including this one were touched by a `SignerError` variant rename to make it immediately clear whether this issue is worth retrying or not, something that was confusing me on a regular basis. The variants were also sorted into alphabetical order.
  - `SignerError::SignerUnavailable` is renamed to `SignerError::TemporarilyUnavilable`.
  - `SignerError::SignerUnusable` is renamed to `SignerError::PermanentlyUnusable`

- `src/commons/crypto/signing/dispatch/signerprovider.rs`: The enum based dispatch has been extended by copy-pasting a line in each match block and editing it to refer to the new `SignerProvider::Pkcs11` variant. I also then extended it again to support a `SignerProvider::Mock` variant for testing purposes.

- `src/commons/crypto/signing/signers/kmip/connpool.rs`: An `Arc` was introduced around the `ConnectionSettings` as it fitted better into the code I wrote for the PKCS#11 signer and to support, maybe, referencing part of the Krill configuration PR directly in a later PR rather than cloning what could be a lot of configuration data.

- `src/commons/crypto/signing/signers/kmip/signer.rs`: The `data` argument of `fn rand()` was renamed to `target` to better reflect what it is for and to be more consistent with existing code elsewhere.

- `src/commons/crypto/signing/signers/mod.rs`: `pub mod XXX` for the new `pkcs11` and `probe` modules (`probe` is a factoring out of code from the KMIP signer to be used also by the PKCS11 signer).

- `src/commons/crypto/signing/signers/pkcs11/mod.rs`: `pub mod XXX` for the new `pkcs11/xxx.rs` modules.

- `src/commons/crypto/signing/dispatch/signerrouter.rs`: Extended to create a PKCS#11 signer if the `hsm-tests-pkcs11` feature flag is enabled. Added some initial happy flow tests based around the new mock signer.

- `src/commons/crypto/signing/signers/softsigner.rs`: Very minor changes including re-ordering of some functions for consistency across signer implementations, and prefixing of some error messages with "OpenSSL".

## Intermediate changes

- `src/commons/crypto/signing/dispatch/signerinfo.rs`: Removed an unused function and updated it to generate the signer handle as a UUID and to store the signer backend identity details (public key and private key internal id) more explicitly, not combined and encoded together as a signer handle.

- `src/commons/crypto/signing/signers/kmip/internal.rs`:
  - Server probing functionality has been extracted into a new `probe.rs` module. The new `probe_server()` function contains the KMIP specific bits that remain from before.
  - A stupid inverted flag mistake was fixed (see `IGNORE_MISSING_CAPABILITIES`).
  - Some function ordering was changed to make comparison between signer modules easier. 
  - The `supports_rng_retrieve` flag was renamed to a non-KMIP-specific name  `supports_random_number_generation` term so that the same naming can be used in the PKCS#11 signer as well for consistency.
  - The `.pool.get()` call was abstracted into `.get_connection()` so that the same pattern could be used in the PKCS#11 signer (for which we do no need to obtain a connection but not from a pool).
  - Some minor changes made along the way (added comments, prefixing some error messages with "KMIP" but I think error messages will need to be reviewed and tweaked again later so I'd ignore this for now).

New modules:

- `src/commons/crypto/signing/signers/mocksigner.rs`:

  Initial version of a mock signer. Should perhaps be updated to use hard-coded values instead of actually doing key generation and signing using OpenSSL.

- `src/commons/crypto/signing/signers/probe.rs`:

  Functionality extracted from the KMIP signer for use also by the PKCS#11 signer. I added some tests as well while I was refactoring.

  **Explanation:** In the KMIP signer while not yet initialized we try periodically (but not on every operation) to connect to the signer backend and to then verify that the KMIP server meets our requirements. We need to do the same for the PKCS#11 signer as well as in the case of something like a PKCS#11 library communicating with a remote AWS CloudHSM server it may fail initially if the server is not yet reachable and so we will have to keep trying. I verified this support with the YubiHSM USB key that I have because if the background `yubihsm-connector` daemon isn't running then the library can be loaded but can't connect with the backend yet.

  **Functional changes:** The signer specific behaviour is now passed in as a callback function. I did it this way as the alternative was enum based dispatch which seemed like overkill or using a trait which we try and avoid as Rust with traits is more complicated (e.g. lack of official async support if we want to use `async` later for signers).

- `src/commons/crypto/signing/signers/pkcs11/context.rs`

  This new module provides the `Pkcs11Context` struct which encapsulates
  - Loading of PKCS#11 libraries.
  - Iinvoking `C_Initialize()` once and only once per process.
  - Delaying the call to `C_Initialize()` to avoid blocking Krill startup (e.g. if the backend is a remote AWS CloudHSM instance that we're having trouble connecting to and maybe the PKCS#11 library even tries multiple times with some largish timeout).
  - Calling `C_Finalize()` when all references to the context are dropped.
  - Logging all dispatches to the underlying PKCS#11 interface and any errors that occur.

  **Known issues:**
  - I'm not sure that the `Option` in `ctx: Option<Ctx>` is actually needed, need to review that.

- `src/commons/crypto/signing/signers/pkcs11/session.rs`

  This new module provides the `Pkcs11Session` struct which is a thin wrapper around calls to `Pkcs11Context` ensuring that a new PKCS#11 session is opened and closed around the call (which I'm not sure is super wise or necessary but I had it in the prototype and haven't been revisited that design yet) and passing the created session handle to the `Pkcs11Context` when dispatching to the PKCS#11 `C_XXX()` function. It takes a lock (read or write as appopriate) on calls into the context because some of the functions exposed by the underlying `pkcs11` crate are `&mut self`.

- `src/commons/crypto/signing/signers/pkcs11/signer.rs`

  A thin wrapper that implements the `rpki` crate `Signer` interface by delegating into the functions in `pkcs11/internal.rs`, very similar to what is done for the KMIP signer in `kmip/signer.rs`.

## The biggest part: the core of the new PKCS#11 signer

### The `pkcs11` dependency

First, we should consider whether the Rust [`pkcs11`](https://crates.io/crates/pkcs11) is an acceptable crate to use. It uses the Apache 2.0 license which many of the Krill dependencies use. There are [a few packages using it](https://crates.io/crates/pkcs11/reverse_dependencies), it's been around for several years and has [continued to receive updates in that time](https://crates.io/crates/pkcs11/versions), it has [multiple contributors though primarily just one](https://github.com/mheese/rust-pkcs11/graphs/contributors), it has lots of forks though whether that means it is good to build on or people have found issues with it I do not know, from its description it appears to have been well tested and no issues have been seen with it so far with either SoftHSMv2, YubiHSM or AWS CloudHSM. Lastly, it has by far [the most downloads, and the most recent downloads](https://crates.io/keywords/pkcs11) of the `pkcs11` and `cryptoki` labelled crates on Crates.io.

### The new Krill code

The structure tries to be consistent with that of `kmip/internal.rs`. It feels like there is more common functionality that can be extracted across the signer implementations but there are subtle differences so perhaps not, or not without more pain than gain.

The `build()`, `get_name()`, `set_handle()`, `get_info()`, `create_registration_key()` and `sign_registration_challenge()` functions are used by initial creation of the signer and registering/binding from `SignerRouter`, same as with the KMIP signer.

`get_test_connection_settings()` is a hard-coded placeholder until configuration from config file is supported.

To use a PKCS#11 signer we need to know which path to load the library from, which slot id to use (or slot label to lookup to determine the slot ID) and any optional user PIN to authenticate with. The PKCS#11 specification allows for PKCS#11 implementations that do not require login, those that require login but do not require a PIN and those the require login with a PIN.

The `probe_server()` function should probably be split into smaller chunks by extracting helper functions to make the logic clearer and to make the fn smaller. Essentially it just tries to access the library, determine the slot ID if needed, query information about the library. check that we can establish a session and login if needed, and determine whether or not the signer is capable of generating random numbers or not.

The primary differences to the KMIP signer are in the functions that support the `Signer` trait, e.g. `build_key()`, `sign_with_key()`, `find_key()`, etc.

In `build_key()` we assign a random ID to the key to create so as we can't change it afterwards (because at least AWS CloudHSM doesn't support `C_SetAttribute()`) and we need some stable identifier for looking up the key later . This could be a more deterministic value, e.g. with some fixed set of prefix bytes, and doesn't need to use OpenSSL rand (I see that @timbru just added a dependency on the `rand` crate in a different change so that could be used instead) or something else. After the key is created we attempt to obtain its key material or RSA modulus and public exponent so that we can determine the Krill `KeyIdentifier` value for the key.

Key IDs are CKA_ID byte values. To pass them back to the `SignerMapper` we convert them to strings by hex encoding them.

Lastly, there's a big mapping at the bottom of the module to decide whether a given error is retryable or not.