### PR TITLE
Support ASPAs with an explicit empty provider as set.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,9 +1537,8 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee4c0626a16c808bb6b557298def266e8cd1078515b5ea07b382f2a0b75375c"
+version = "0.13.1-dev"
+source = "git+https://github.com/NLnetLabs/rpki-rs/?branch=aspa-empty-providers#209c335f7b91a1eb1836ba43603f8e9daa2fff53"
 dependencies = [
  "base64 0.13.0",
  "bcder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,8 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.13.1-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs/#03174d8c7c18d3f8cc23cc58a856f4148efee171"
+version = "0.13.1-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c07c6977a509b11d01aae0d9dcf6e30f0dcfe46f9c3fcb4f47f7789a356e35"
 dependencies = [
  "base64 0.13.0",
  "bcder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.13.1-dev"
-source = "git+https://github.com/NLnetLabs/rpki-rs/?branch=aspa-empty-providers#209c335f7b91a1eb1836ba43603f8e9daa2fff53"
+source = "git+https://github.com/NLnetLabs/rpki-rs/#03174d8c7c18d3f8cc23cc58a856f4148efee171"
 dependencies = [
  "base64 0.13.0",
  "bcder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ rand                  = "^0.8"
 regex                 = { version = "^1.4", optional = true, default_features = false, features = ["std"] }
 reqwest               = { version = "0.11", features = ["json"] }
 rpassword             = { version = "^5.0", optional = true }
-#rpki                  = { version = "0.13.0", features = [ "repository", "rrdp", "serde" ] }
-rpki                  = { version = "0.13.1-dev", git = "https://github.com/NLnetLabs/rpki-rs/", features = [ "repository", "rrdp", "serde" ] }
+rpki                  = { version = "0.13.1-rc1", features = [ "repository", "rrdp", "serde" ] }
+# rpki                  = { version = "0.13.1-rc1", git = "https://github.com/NLnetLabs/rpki-rs/", features = [ "repository", "rrdp", "serde" ] }
 scrypt                = { version = "^0.6", optional = true, default-features = false }
 serde                 = { version = "^1.0", features = ["derive"] }
 serde_json            = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,8 @@ rand                  = "^0.8"
 regex                 = { version = "^1.4", optional = true, default_features = false, features = ["std"] }
 reqwest               = { version = "0.11", features = ["json"] }
 rpassword             = { version = "^5.0", optional = true }
-rpki                  = { version = "0.13.0", features = [ "repository", "rrdp", "serde" ] }
+#rpki                  = { version = "0.13.0", features = [ "repository", "rrdp", "serde" ] }
+rpki                  = { version = "0.13.1-dev", git = "https://github.com/NLnetLabs/rpki-rs/", branch = "aspa-empty-providers", features = [ "repository", "rrdp", "serde" ] }
 scrypt                = { version = "^0.6", optional = true, default-features = false }
 serde                 = { version = "^1.0", features = ["derive"] }
 serde_json            = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ regex                 = { version = "^1.4", optional = true, default_features = 
 reqwest               = { version = "0.11", features = ["json"] }
 rpassword             = { version = "^5.0", optional = true }
 #rpki                  = { version = "0.13.0", features = [ "repository", "rrdp", "serde" ] }
-rpki                  = { version = "0.13.1-dev", git = "https://github.com/NLnetLabs/rpki-rs/", branch = "aspa-empty-providers", features = [ "repository", "rrdp", "serde" ] }
+rpki                  = { version = "0.13.1-dev", git = "https://github.com/NLnetLabs/rpki-rs/", features = [ "repository", "rrdp", "serde" ] }
 scrypt                = { version = "^0.6", optional = true, default-features = false }
 serde                 = { version = "^1.0", features = ["derive"] }
 serde_json            = "^1.0"

--- a/src/commons/api/aspa.rs
+++ b/src/commons/api/aspa.rs
@@ -184,14 +184,11 @@ impl FromStr for AspaDefinition {
             // Ensure that the providers are sorted,  and there are no duplicates
             providers.sort_by_key(|p| p.provider());
 
-            if providers.len() > 1 {
-                let mut last_seen = providers.first().unwrap();
-                for i in 1..providers.len() {
-                    let next = providers.get(i).unwrap(); // safe i max == .len() - 1
-                    if next.provider() == last_seen.provider() {
-                        return Err(AspaDefinitionFormatError::ProviderAsDuplicate(*last_seen, *next));
-                    }
-                    last_seen = next;
+            for adjacent_pair in providers.windows(2) {
+                let left = adjacent_pair[0];
+                let right = adjacent_pair[1];
+                if left.provider() == right.provider() {
+                    return Err(AspaDefinitionFormatError::ProviderAsDuplicate(left, right));
                 }
             }
 

--- a/src/commons/api/aspa.rs
+++ b/src/commons/api/aspa.rs
@@ -184,15 +184,13 @@ impl FromStr for AspaDefinition {
             // Ensure that the providers are sorted,  and there are no duplicates
             providers.sort_by_key(|p| p.provider());
 
-            for adjacent_pair in providers.windows(2) {
-                let left = adjacent_pair[0];
-                let right = adjacent_pair[1];
-                if left.provider() == right.provider() {
-                    return Err(AspaDefinitionFormatError::ProviderAsDuplicate(left, right));
-                }
+            match providers
+                .windows(2)
+                .find(|pair| pair[0].provider() == pair[1].provider())
+            {
+                Some(dup) => Err(AspaDefinitionFormatError::ProviderAsDuplicate(dup[0], dup[1])),
+                None => Ok(AspaDefinition::new(customer, providers)),
             }
-
-            Ok(AspaDefinition::new(customer, providers))
         }
     }
 }

--- a/src/commons/util/dummysigner.rs
+++ b/src/commons/util/dummysigner.rs
@@ -10,7 +10,7 @@ impl Signer for DummySigner {
     type KeyId = KeyIdentifier;
     type Error = SignerError;
 
-    fn create_key(&mut self, _: PublicKeyFormat) -> Result<Self::KeyId, Self::Error> {
+    fn create_key(&self, _: PublicKeyFormat) -> Result<Self::KeyId, Self::Error> {
         unreachable!()
     }
 
@@ -21,7 +21,7 @@ impl Signer for DummySigner {
         unreachable!()
     }
 
-    fn destroy_key(&mut self, _: &Self::KeyId) -> Result<(), rpki::repository::crypto::signer::KeyError<Self::Error>> {
+    fn destroy_key(&self, _: &Self::KeyId) -> Result<(), rpki::repository::crypto::signer::KeyError<Self::Error>> {
         unreachable!()
     }
 

--- a/src/daemon/ca/events.rs
+++ b/src/daemon/ca/events.rs
@@ -374,10 +374,10 @@ impl fmt::Display for RoaUpdates {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AspaObjectsUpdates {
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     updated: Vec<AspaInfo>,
 
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     removed: Vec<AspaCustomer>,
 }
 

--- a/tests/functional.rs
+++ b/tests/functional.rs
@@ -480,6 +480,29 @@ async fn functional() {
         ca_aspas_expect(&ca4, AspaDefinitionList::new(vec![updated_aspa])).await;
     }
 
+    {
+        info("##################################################################");
+        info("#                                                                #");
+        info("# Update ASPA to have no providers (explicit empty list)         #");
+        info("#                                                                #");
+        info("##################################################################");
+
+        let customer = AspaCustomer::from_str("AS65000").unwrap();
+        let aspa_update = AspaProvidersUpdate::new(
+            vec![],
+            vec![
+                ProviderAs::from_str("AS65003(v4)").unwrap(),
+                ProviderAs::from_str("AS65005(v6)").unwrap(),
+                ProviderAs::from_str("AS65006").unwrap(),
+            ],
+        );
+
+        ca_aspas_update(&ca4, customer, aspa_update).await;
+
+        let updated_aspa = AspaDefinition::from_str("AS65000 => <none>").unwrap();
+        ca_aspas_expect(&ca4, AspaDefinitionList::new(vec![updated_aspa])).await;
+    }
+
     //------------------------------------------------------------------------------------------
     // Test shrinking / growing resources
     //------------------------------------------------------------------------------------------
@@ -550,7 +573,7 @@ async fn functional() {
 
         // Expect that the ASPA object is withdrawn
         expect_objects_for_ca4(
-            "CA4 should now de-aggregate ROAS",
+            "CA4 should now remove ASPA",
             &[route_resource_set_10_0_0_0_def_1, route_resource_set_10_1_0_0_def_1],
             &[],
         )


### PR DESCRIPTION
This updates the logic to allow for an empty provider AS set (as per sidrops discussion). Tests were added, and an issue was found in the encoding of empty provider as sets, which was fixed in this PR for rpki-rs:

https://github.com/NLnetLabs/rpki-rs/pull/171

