### PR TITLE
Minor useful KMIP tweaks

### DIFF
--- a/defaults/krill-hsm.conf
+++ b/defaults/krill-hsm.conf
@@ -219,11 +219,11 @@
 # insecure   boolean      false            No     If true, do not verify the servers
 #                                                 TLS certificate.
 # deficient  boolean      false            No     If true, ignore server claims that
-#                                                 lacks functionality that we require.
-#                                                 For example PyKMIP 0.10.0 says it
-#                                                 doesn't support the ModifyAttribute
-#                                                 but sending a modify attribute
-#                                                 request succeeds.
+#                                                 it lacks functionality that we
+#                                                 require. For example PyKMIP 0.10.0
+#                                                 says it doesn't support the
+#                                                 ModifyAttribute but sending a
+#                                                 modify attribute request succeeds.
 # server_cert_path                                File system paths to certificate
 #            string       None             No     files (in PEM format) for verifying
 # server_ca_cert_path                             the identity of the server.

--- a/defaults/krill-hsm.conf
+++ b/defaults/krill-hsm.conf
@@ -218,6 +218,12 @@
 # port       integer      5696             Yes    The port number to connect to.
 # insecure   boolean      false            No     If true, do not verify the servers
 #                                                 TLS certificate.
+# deficient  boolean      false            No     If true, ignore server claims that
+#                                                 lacks functionality that we require.
+#                                                 For example PyKMIP 0.10.0 says it
+#                                                 doesn't support the ModifyAttribute
+#                                                 but sending a modify attribute
+#                                                 request succeeds.
 # server_cert_path                                File system paths to certificate
 #            string       None             No     files (in PEM format) for verifying
 # server_ca_cert_path                             the identity of the server.

--- a/src/commons/crypto/signing/signers/kmip/internal.rs
+++ b/src/commons/crypto/signing/signers/kmip/internal.rs
@@ -172,7 +172,11 @@ impl KmipSigner {
         // Signer initialization should not block Krill startup. As such we delaying contacting the KMIP server until
         // first use. The downside of this approach is that we won't detect any issues until that point.
 
-        let server = Arc::new(StatefulProbe::new(Arc::new(conf.try_into()?), Duration::from_secs(30)));
+        let server = Arc::new(StatefulProbe::new(
+            name.to_string(),
+            Arc::new(conf.try_into()?),
+            Duration::from_secs(30),
+        ));
 
         let s = KmipSigner {
             name: name.to_string(),
@@ -266,6 +270,7 @@ impl UsableServerState {
 impl KmipSigner {
     /// Verify if the configured KMIP server is contactable and supports the required capabilities.
     fn probe_server(
+        _name: String,
         status: &ProbeStatus<ConnectionSettings, SignerError, UsableServerState>,
     ) -> Result<UsableServerState, ProbeError<SignerError>> {
         let conn_settings = status.config()?;

--- a/src/commons/crypto/signing/signers/pkcs11/internal.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/internal.rs
@@ -75,7 +75,6 @@ pub enum LoginMode {
     LoginRequired,
 }
 
-// Placeholder struct
 #[derive(Clone, Debug)]
 struct ConnectionSettings {
     context: ThreadSafePkcs11Context,


### PR DESCRIPTION
- Make the `deficient` flag configurable.
- Output the current signer name in log messages to be more helpful and also more consistent with the PKCS#11 signer code.