### PR TITLE
Fix compilation on armv7-unknown-linux-gnueabihf by supplying missing Serde impls. (#751)

### DIFF
--- a/src/commons/util/ext_serde.rs
+++ b/src/commons/util/ext_serde.rs
@@ -1,5 +1,5 @@
 //! Defines helper methods for Serializing and Deserializing external types.
-use std::str::FromStr;
+use std::{str::FromStr, sync::atomic::{AtomicU64, Ordering}};
 
 use bytes::Bytes;
 use log::LevelFilter;
@@ -161,4 +161,23 @@ where
 {
     let string = String::deserialize(d)?;
     Facility::from_str(&string).map_err(|_| de::Error::custom(format!("Unsupported syslog_facility: \"{}\"", string)))
+}
+
+//------------- AtomicU64 -----------------------------------------------------
+// Implemented automatically by Serde derive but only for x86_64 architectures,
+// for other architectures (such as armv7 for the Raspberry Pi 4b) it has to be
+// implemented manually.
+
+pub fn de_atomicu64<'de, D>(d: D) -> Result<AtomicU64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(AtomicU64::new(u64::deserialize(d)?))
+}
+
+pub fn ser_atomicu64<S>(v: &AtomicU64, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    s.serialize_u64(v.load(Ordering::SeqCst))
 }

--- a/src/daemon/auth/common/crypt.rs
+++ b/src/daemon/auth/common/crypt.rs
@@ -38,10 +38,61 @@ const POLY1305_TAG_BYTE_LEN: usize = POLY1305_TAG_BIT_LEN / 8;
 const CLEARTEXT_PREFIX_LEN: usize = CHACHA20_NONCE_BYTE_LEN + POLY1305_TAG_BYTE_LEN;
 const UNUSED_AAD: [u8; 0] = [0; 0];
 
+//------------ CrossPlatformDeserializableAtomicU64 -------------------------------------------------------------------
+
+/// This type provides Serde (de)serialization irrespective of target platform, as the Serde crate provided derive
+/// impls only appear to produce code when compiled on x86_64. See: https://github.com/NLnetLabs/krill/issues/751
+#[derive(Debug)]
+struct CrossPlatformDeserializableAtomicU64(AtomicU64);
+
+impl std::ops::Deref for CrossPlatformDeserializableAtomicU64 {
+    type Target = AtomicU64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CrossPlatformDeserializableAtomicU64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct DeserializableAtomicU64Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for DeserializableAtomicU64Visitor {
+            type Value = CrossPlatformDeserializableAtomicU64;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("an unsigned integer in the range 0..=2^64-1")
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error, {
+                Ok(CrossPlatformDeserializableAtomicU64(AtomicU64::new(v)))
+            }
+        }
+
+        deserializer.deserialize_u64(DeserializableAtomicU64Visitor)
+    }
+}
+
+impl serde::Serialize for CrossPlatformDeserializableAtomicU64 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u64(self.0.load(Ordering::SeqCst))
+    }
+}
+
+//------------ NonceState ---------------------------------------------------------------------------------------------
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NonceState {
-    sender_unique: [u8; 4], //   32 bits
-    counter: AtomicU64,     // + 64 bits = 96 bits = CHACHA20_NONCE_BIT_LEN
+    sender_unique: [u8; 4],           //   32 bits
+    counter: CrossPlatformDeserializableAtomicU64, // + 64 bits = 96 bits = CHACHA20_NONCE_BIT_LEN
 }
 
 impl NonceState {
@@ -52,7 +103,7 @@ impl NonceState {
 
         Ok(NonceState {
             sender_unique,
-            counter: AtomicU64::new(0),
+            counter: CrossPlatformDeserializableAtomicU64(AtomicU64::new(0)),
         })
     }
 
@@ -68,6 +119,8 @@ impl NonceState {
         nonce
     }
 }
+
+//------------ CryptState ---------------------------------------------------------------------------------------------
 
 pub struct CryptState {
     pub key: [u8; CHACHA20_KEY_BYTE_LEN],

--- a/src/daemon/auth/common/crypt.rs
+++ b/src/daemon/auth/common/crypt.rs
@@ -27,6 +27,7 @@ use std::{
 use crate::commons::{
     error::{Error, KrillIoError},
     KrillResult,
+    util::ext_serde,
 };
 
 const CHACHA20_KEY_BIT_LEN: usize = 256;
@@ -41,6 +42,11 @@ const UNUSED_AAD: [u8; 0] = [0; 0];
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NonceState {
     sender_unique: [u8; 4], //   32 bits
+
+    #[serde(
+        deserialize_with = "ext_serde::de_atomicu64",
+        serialize_with = "ext_serde::ser_atomicu64"
+    )]
     counter: AtomicU64,     // + 64 bits = 96 bits = CHACHA20_NONCE_BIT_LEN
 }
 


### PR DESCRIPTION
Fixes #751.

I'm not sure if this is the _right_ way to fix this, but it seems to work.

Tested on my Raspberry Pi 4b by cross compiling on my x86_64 laptop host then running the produced binary with config-file users on the Pi:

```
$ cargo install cross
$ rustup target add armv7-unknown-linux-gnueabihf
$ cross build --target armv7-unknown-linux-gnueabihf --features static-openssl --release
$ scp target/release/krill pi@192.168.0.18:
$ scp target/release/krillc pi@192.168.0.18:
$ ssh pi@192.168.0.18
$ ./krillc config user --id x18
Enter the password to hash: 
***

[auth_users]
"x18" = { attributes={ role="admin" }, password_hash="********", salt="********" }
$ grep -Ev '^#' krill.conf | sed '/^\s*$/d'
log_level = "trace"
log_type = "stderr"
admin_token = "********"
service_uri = "https://localhost:3000/"
auth_type = "config-file"

[auth_users]
"x18" = { attributes={ role="admin" }, password_hash="********", salt="********" }
$ ./krill -c ./krill.conf
```

I then visited the Krill login page in my browser and checked that an incorrect password was correctly rejected and a valid password was accepted.

Unfortunately GitHub Actions doesn't seem to provide ARMv7 architecture runners, only x86_64 ones, so we can't do automated testing on ARMv7 without using a self-hosted runner or some other service.

If needed I can provide access to my Pi ;-)