### PR TITLE
Initial support for AARCH64 on Debian 10 Buster

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -60,6 +60,7 @@ jobs:
       matrix:
         target:
           - 'armv7-unknown-linux-gnueabihf'
+          - 'aarch64-unknown-linux-gnu'
     name: cross
     runs-on: ubuntu-latest
     steps:
@@ -110,10 +111,16 @@ jobs:
           # custom build arguments instead.
           - image: 'centos:7'
             extra_build_args: '--features static-openssl'
+
           # package for the Raspberry Pi 4b as an ARMv7 cross compiled variant of the Debian Bullseye upon which
           # Raspbian 11 is based. Disable the multi-user default feature until #751 is fixed.
           - image: 'debian:bullseye'                # Raspbian 11 is based on Debian Bullseye
             target: 'armv7-unknown-linux-gnueabihf' # the Raspberry Pi 4b is armv7
+
+          # package for the ROCK64 as an AARCH64 cross compiled variant of Debian Buster upon which
+          # Armbian 21 is based. Disable the multi-user default feature until #751 is fixed.
+          - image: 'debian:bullseye'                # Raspbian 11 is based on Debian Bullseye
+            target: 'aarch64-unknown-linux-gnu'     # the Raspberry Pi 4b is armv7
     env:
       CARGO_DEB_VER: 1.28.0
       CARGO_GENERATE_RPM_VER: 0.4.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,9 @@ depends = "$auto, passwd"
 
 [package.metadata.deb.variants.debian-buster]
 
+[package.metadata.deb.variants.debian-buster-aarch64-unknown-linux-gnu]
+depends = "adduser, passwd, libssl1.1"
+
 [package.metadata.deb.variants.debian-bullseye]
 
 [package.metadata.deb.variants.debian-bullseye-armv7-unknown-linux-gnueabihf]

--- a/pkg/common/krill-debian-buster-aarch64-unknown-linux-gnu.krill.service
+++ b/pkg/common/krill-debian-buster-aarch64-unknown-linux-gnu.krill.service
@@ -1,0 +1,1 @@
+krill-debian-buster.krill.service


### PR DESCRIPTION
Passed basic sanity tests on a ROCK64 AARCH64 device running Debian Buster.
Builds on the previous PR adding ARMv7 on Debian 11 support.
Merge #755 first then this PR will update to target the `main` branch and the packaging action will then run.