### PR TITLE
Bump cargo-deb and cargo-generate-rpm.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -68,8 +68,8 @@ jobs:
           - image: 'centos:7'
             extra_build_args: '--features static-openssl'
     env:
-      CARGO_DEB_VER: 1.28.0
-      CARGO_GENERATE_RPM_VER: 0.4.0
+      CARGO_DEB_VER: 1.34.1
+      CARGO_GENERATE_RPM_VER: 0.6.0
       # A Krill version of the form 'x.y.z-bis' denotes a dev build that is newer than the released x.y.z version but is
       # not yet a new release.
       NEXT_VER_LABEL: bis
@@ -161,7 +161,7 @@ jobs:
       run: |
         case ${OS_NAME} in
           debian|ubuntu)
-            cargo install cargo-deb --version ${CARGO_DEB_VER}
+            cargo install cargo-deb --version ${CARGO_DEB_VER} --locked
             ;;
         esac
 
@@ -170,9 +170,7 @@ jobs:
       run: |
         case ${OS_NAME} in
           centos)
-            # Temporary workaround for https://github.com/cat-in-136/cargo-generate-rpm/issues/21
-            rustup toolchain install 1.52.0
-            cargo +1.52.0 install cargo-generate-rpm --version ${CARGO_GENERATE_RPM_VER} --locked
+            cargo install cargo-generate-rpm --version ${CARGO_GENERATE_RPM_VER} --locked
             ;;
         esac
 


### PR DESCRIPTION
Mainly to drop the workaround for the now fixed issue https://github.com/cat-in-136/cargo-generate-rpm/issues/21.