### PR TITLE
Silence multi-user related dead code warnings.

### DIFF
--- a/src/commons/actor.rs
+++ b/src/commons/actor.rs
@@ -117,7 +117,11 @@ pub struct Actor {
     is_user: bool,
     attributes: Attributes,
     new_auth: Option<Auth>,
+
+    #[cfg_attr(not(feature = "multi-user"), allow(dead_code))]
     policy: Option<AuthPolicy>,
+
+    #[cfg_attr(not(feature = "multi-user"), allow(dead_code))]
     auth_error: Option<ApiAuthError>,
 }
 


### PR DESCRIPTION
Silence multi-user related dead code warnings about fields that are written to but not read unless the multi-user feature is enabled. 

This typically occurs when disabling default features while developing to speed up compilation and then you get these annoying warnings. We don't exclude the fields entirely from the compilation because that would add more conditional compilation guards which makes the code harder to read.