### PR TITLE
We use `-dev` as the next version label now, not `-bis`.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -68,9 +68,9 @@ jobs:
     env:
       CARGO_DEB_VER: 1.34.2
       CARGO_GENERATE_RPM_VER: 0.6.0
-      # A Krill version of the form 'x.y.z-bis' denotes a dev build that is newer than the released x.y.z version but is
+      # A Krill version of the form 'x.y.z-dev' denotes a dev build that is newer than the released x.y.z version but is
       # not yet a new release.
-      NEXT_VER_LABEL: bis
+      NEXT_VER_LABEL: dev
     name: pkg
     runs-on: ubuntu-latest
     # Build on the oldest platform we are targeting in order to avoid https://github.com/rust-lang/rust/issues/57497.


### PR DESCRIPTION
As requested by @timbru.