### PR TITLE
Handle more PKCS#11 transient failure scenarios. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ in RC1 and RC2:
 - Make krill.lock file optional and opt-in #856
 - BGPSec Router Certificate should NOT contain SIA extension #854
 - Manifest of 0.10.0-rc1 includes CRL, but nothing else #853
-- Security fixes in KMIP dependencies.
+- Security fixes in KMIP dependencies (HSM support).
+- Handle more PKCS#11 transient failure scenarios (HSM support).
 
 In this release we introduce the following major features:
 - BGPSec Router Certificate Signing

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -28,7 +28,6 @@ use cryptoki::{
     session::{Session, SessionFlags, UserType},
     slot::{Slot, SlotInfo, TokenInfo},
 };
-use futures::TryFutureExt;
 use once_cell::sync::OnceCell;
 
 use crate::commons::crypto::SignerError;

--- a/src/commons/crypto/signing/signers/pkcs11/context.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/context.rs
@@ -187,7 +187,8 @@ impl Pkcs11Context {
     }
 
     pub fn finalize(&mut self) -> Result<(), Pkcs11Error> {
-        self.logged_cryptoki_call_take("Finalize", |cryptoki| {
+        // ignore the result because we want to continue even if the call fails.
+        let _ = self.logged_cryptoki_call_take("Finalize", |cryptoki| {
             cryptoki.finalize();
             Ok(())
         });

--- a/src/commons/crypto/signing/signers/pkcs11/signer.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/signer.rs
@@ -3,7 +3,7 @@ use std::{
     marker::PhantomData,
     path::Path,
     sync::{Arc, RwLock, RwLockReadGuard},
-    time::Duration, ops::Deref,
+    time::Duration,
 };
 
 use backoff::ExponentialBackoff;

--- a/src/commons/crypto/signing/signers/pkcs11/signer.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/signer.rs
@@ -1096,9 +1096,9 @@ fn is_transient_error(err: &Pkcs11Error) -> bool {
                 cryptoki::error::RvError::UserAlreadyLoggedIn => true, // maybe another client was is busy logging out so try again?
                 cryptoki::error::RvError::UserAnotherAlreadyLoggedIn => true,
                 cryptoki::error::RvError::UserNotLoggedIn => false,
-                cryptoki::error::RvError::UserPinNotInitialized => false, // maybe the operator will initialize the PIN 
+                cryptoki::error::RvError::UserPinNotInitialized => true, // maybe the operator will initialize the PIN 
                 cryptoki::error::RvError::UserTooManyTypes => true, // maybe some sessions are terminated while retrying permitting us to succeed?
-                cryptoki::error::RvError::UserTypeInvalid => false, // maybe the operator will fix the users type
+                cryptoki::error::RvError::UserTypeInvalid => true, // maybe the operator will fix the users type
                 cryptoki::error::RvError::VendorDefined => true, // we have no way of knowing what this kind of failure is, maybe it is transient
                 cryptoki::error::RvError::WrappedKeyInvalid => false,
                 cryptoki::error::RvError::WrappedKeyLenRange => false,


### PR DESCRIPTION
This PR modifies Krill to be able to connect to and use the HSM in certain transient failure scenarios without a restart of Krill as is currently required.

Firstly, we re-initialize the PKCS#11 context in order to "flush" the cache of some PKCS#11 libraries so that they notice an unavailable token becoming available without needing to restart Krill. (see: https://github.com/parallaxsecond/rust-cryptoki/issues/75). This was previously implemented when the `pkcs11` crate was used but was temporarily removed as it didn't work as was once we switched to the `cryptoki` crate. The `cryptoki` crate since added the required functionality so that we can now re-implement this.

This PR also changed some of the error codes considered to be permanent failures to instead be considered transient failures. This was done for errors that might be resolvable by an operator while Krill is running, e.g. if a token name or user password were set incorrectly these might not require reconfiguration or restart of Krill but just fixing of the tokens own configuration.

There are no tests for this at the moment, but it has been tested manually. The test configured Krill to use a SoftHSMv2 PKCS#11 slot that was not yet initialized. Without this PR, if the slot is initialized (by calling `softhsm2-init`) while Krill is running then Krill is not able to use the slot until Krill is restarted. The SoftHSMv2 PKCS#11 library seems to "cache" the absence of the slot. Re-initializing the library however causes it to "notice" that the slot is now available and so Krill is then able to use it without needing to be restarted.

It was also tested with a YubiHSM 2. When the YubiHSM 2 connector is not running the token is not found by the PKCS#11 library and this error is cached by the library so that even if the connector is subsequently (re)started then Krill will still be unable to use it. Re-initializing the PKCS#11 library however causes it to be able to connect to the now running connector and work as expected.