### PR TITLE
Reduce the Docker image size by a couple of MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ARG RUN_USER=krill
 ARG RUN_USER_UID=1012
 ARG RUN_USER_GID=1012
 
-RUN apk add bash libgcc openssl tzdata util-linux
+RUN apk --no-cache add bash libgcc openssl tzdata util-linux
 
 RUN addgroup -g ${RUN_USER_GID} ${RUN_USER} && \
     adduser -D -u ${RUN_USER_UID} -G ${RUN_USER} ${RUN_USER}


### PR DESCRIPTION
I noticed that the `Dockerfile` uses `apk add --no-cache tiny` but doesn't use `--no-cache` in other `apk add` invocations.

Using it consistently in a quick local test showed a couple of MB reduction in the final image size:

```
$ docker images ximon
REPOSITORY   TAG                   IMAGE ID       CREATED          SIZE
ximon        krillwithnocache      5a73b949eef9   3 minutes ago    61.4MB
ximon        krillwithoutnocache   f5b835b664d8   24 minutes ago   63.2MB
```

There's no reason to keep the APK indexes in the built image.