### PR TITLE
Attribute the DEB changelog entry to RPKI team

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -219,18 +219,7 @@ jobs:
 
         case ${OS_NAME} in
           debian|ubuntu)
-            case ${{ github.event_name }} in
-              pull_request | workflow_dispatch)
-                MAINTAINER="${{ github.event.sender.login }} <pkg@nlnetlabs.nl>"
-                ;;
-              push)
-                MAINTAINER="${{ github.event.pusher.name }} <${{ github.event.pusher.email }}>"
-                ;;
-              *)
-                echo 2>&1 "ERROR: Unexpected GitHub Actions event"
-                exit 1
-                ;;
-            esac
+            MAINTAINER="The NLnet Labs RPKI Team <rpki@nlnetlabs.nl>"
 
             # Generate the RFC 5322 format date by hand instead of using date --rfc-email because that option doesn't exist
             # on Ubuntu 16.04 and Debian 9


### PR DESCRIPTION
Make the same change as was made for Routinator. See: https://github.com/NLnetLabs/routinator/pull/688/commits

The packaging workflow has been triggered manually against this PR branch. The output of the run can be seen [here](https://github.com/NLnetLabs/krill/actions/runs/1791494894). This won't work until PR https://github.com/NLnetLabs/krill/pull/767 has first been merged and this PR branch then synced with main.