### PR TITLE
Add Ubuntu 22.04 packaging support.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -371,11 +371,16 @@ jobs:
         # test for that O/S (remember to change debian:bullseye to the correct
         # O/S name!):
         #
-        #
         # exclude:
         #   - image: 'debian:bullseye'
         #     mode: 'upgrade-from-published'
         exclude:
+          - pkg: 'krill'
+            mode: 'upgrade-from-published'
+            image: 'ubuntu:jammy'    # ubuntu/22.04 - not yet published
+        
+        # Exclude all krillup packages from upgrade testing as no krillup package
+        # has yet been published.
           - pkg: 'krillup'
             mode: 'upgrade-from-published'
             image: 'ubuntu:xenial'   # ubuntu/16.04

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -50,6 +50,7 @@ jobs:
           - 'ubuntu:xenial'   # ubuntu/16.04
           - 'ubuntu:bionic'   # ubuntu/18.04
           - 'ubuntu:focal'    # ubuntu/20.04
+          - 'ubuntu:jammy'    # ubuntu/22.04
           - 'debian:stretch'  # debian/9
           - 'debian:buster'   # debian/10
           - 'debian:bullseye' # debian/11
@@ -355,6 +356,7 @@ jobs:
           - 'ubuntu:xenial'   # ubuntu/16.04
           - 'ubuntu:bionic'   # ubuntu/18.04
           - 'ubuntu:focal'    # ubuntu/20.04
+          - 'ubuntu:jammy'    # ubuntu/22.04
           - 'debian:stretch'  # debian/9
           - 'debian:buster'   # debian/10
           - 'debian:bullseye' # debian/11
@@ -383,6 +385,9 @@ jobs:
           - pkg: 'krillup'
             mode: 'upgrade-from-published'
             image: 'ubuntu:focal'    # ubuntu/20.04
+          - pkg: 'krillup'
+            mode: 'upgrade-from-published'
+            image: 'ubuntu:jammy'    # ubuntu/22.04
           - pkg: 'krillup'
             mode: 'upgrade-from-published'
             image: 'debian:stretch'  # debian/9

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ depends = "$auto, passwd"
 [package.metadata.deb.variants.ubuntu-focal]
 
 [package.metadata.deb.variants.ubuntu-jammy]
+depends = "$auto, passwd, libssl3"
 
 [package.metadata.deb.variants.debian-stretch]
 features = [ "static-openssl" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,8 @@ depends = "$auto, passwd"
 
 [package.metadata.deb.variants.ubuntu-focal]
 
+[package.metadata.deb.variants.ubuntu-jammy]
+
 [package.metadata.deb.variants.debian-stretch]
 features = [ "static-openssl" ]
 depends = "$auto, passwd"

--- a/pkg/common/krill-ubuntu-jammy.krill.service
+++ b/pkg/common/krill-ubuntu-jammy.krill.service
@@ -1,0 +1,1 @@
+krill-ubuntu-focal.krill.service


### PR DESCRIPTION
Add support for packaging for Ubuntu 22.04 Jammy Jellyfish, due for release on April 21, 2022.