### PR TITLE
Package Krill for Ubuntu 22.04 Jammy Jellyfish

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -458,6 +458,9 @@ jobs:
         #   - image: 'debian:bullseye'
         #     mode: 'upgrade-from-published'
         exclude:
+          - pkg: 'krill'
+            mode: 'upgrade-from-published'
+            image: 'ubuntu:jammy'
           - pkg: 'krillup'
             mode: 'upgrade-from-published'
             image: 'ubuntu:xenial'   # ubuntu/16.04

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -307,10 +307,18 @@ jobs:
             echo "  * See: https://github.com/NLnetLabs/krill/releases/tag/v${KRILL_NEW_VER}" >>target/debian/changelog
             echo " -- maintainer ${MAINTAINER}  ${RFC5322_TS}" >>target/debian/changelog
 
+            if [[ "${CROSS_TARGET}" == "x86_64" ]]; then
+              EXTRA_CARGO_DEB_ARGS=
+              VARIANT="${OS_NAME}-${OS_REL}"
+            else
+              EXTRA_CARGO_DEB_ARGS="--no-build --no-strip --target ${CROSS_TARGET} --output target/debian"
+              VARIANT="${OS_NAME}-${OS_REL}-${CROSS_TARGET}"
+            fi
+
             if [ "${MATRIX_PKG}" == "krillup" ]; then
-                # Ugly hack to use an alternate Cargo Deb configuration for krillup.
-                sed -i -e 's/^\[package\.metadata\.deb\]/[package.metadata.moved-deb]/' \
-                       -e 's/^\[package\.metadata\.krillup-deb/[package.metadata.deb/' Cargo.toml
+              # Ugly hack to use an alternate Cargo Deb configuration for krillup.
+              sed -i -e 's/^\[package\.metadata\.deb\]/[package.metadata.moved-deb]/' \
+                     -e 's/^\[package\.metadata\.krillup-deb/[package.metadata.deb/' Cargo.toml
             fi
 
             DEB_VER="${PKG_KRILL_VER}-1${OS_REL}"
@@ -391,7 +399,7 @@ jobs:
     - name: Upload package
       uses: actions/upload-artifact@v2
       with:
-        name: ${{ matrix.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}
+        name: ${{ matrix.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
         path: |
           target/debian/*.deb
           target/generate-rpm/*.rpm
@@ -506,7 +514,7 @@ jobs:
     - name: Download package
       uses: actions/download-artifact@v2
       with:
-        name: ${{ matrix.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}
+        name: ${{ matrix.pkg }}_${{ env.OS_NAME }}_${{ env.OS_REL }}_${{ matrix.target }}
 
     - name: Add current user to LXD group
       run: |

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -502,8 +502,6 @@ jobs:
             echo "LXC_IMAGE=images:${OS_NAME}/${OS_REL}/cloud" >> $GITHUB_ENV
             ;;
         esac
-      env:
-        MATRIX_IMAGE: ${{ matrix.image }}
 
     - name: Download package
       uses: actions/download-artifact@v2

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -132,6 +132,7 @@ jobs:
       shell: bash
       env:
         MATRIX_IMAGE: ${{ matrix.image }}
+        MATRIX_OS: ${{ matrix.os }}
       run: |
         # Get the operating system and release name (e.g. ubuntu and xenial) from the image name (e.g. ubuntu:xenial) by
         # extracting only the parts before and after but not including the colon:
@@ -141,9 +142,6 @@ jobs:
         fi
         echo "OS_NAME=${IMAGE%:*}" >> $GITHUB_ENV
         echo "OS_REL=${IMAGE#*:}" >> $GITHUB_ENV
-      env:
-        MATRIX_IMAGE: ${{ matrix.image }}
-        MATRIX_OS: ${{ matrix.os }}
 
     # Git clone the Krill code in the branch we were invoked on.
     - name: Checkout repository

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -90,6 +90,7 @@ jobs:
           - 'ubuntu:xenial'   # ubuntu/16.04
           - 'ubuntu:bionic'   # ubuntu/18.04
           - 'ubuntu:focal'    # ubuntu/20.04
+          - 'ubuntu:jammy'    # ubuntu/22.04
           - 'debian:stretch'  # debian/9
           - 'debian:buster'   # debian/10
           - 'debian:bullseye' # debian/11
@@ -427,6 +428,7 @@ jobs:
           - 'ubuntu:xenial'   # ubuntu/16.04
           - 'ubuntu:bionic'   # ubuntu/18.04
           - 'ubuntu:focal'    # ubuntu/20.04
+          - 'ubuntu:jammy'    # ubuntu/22.04
           - 'debian:stretch'  # debian/9
           - 'debian:buster'   # debian/10
           - 'debian:bullseye' # debian/11
@@ -457,6 +459,9 @@ jobs:
           - pkg: 'krillup'
             mode: 'upgrade-from-published'
             image: 'ubuntu:focal'    # ubuntu/20.04
+          - pkg: 'krillup'
+            mode: 'upgrade-from-published'
+            image: 'ubuntu:jammy'    # ubuntu/22.04
           - pkg: 'krillup'
             mode: 'upgrade-from-published'
             image: 'debian:stretch'  # debian/9

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -96,6 +96,8 @@ jobs:
           - 'debian:bullseye' # debian/11
           - 'centos:7'
           - 'rockylinux:8'    # compatible with EOL centos:8
+        target:
+          - 'x86_64'
         include:
           # For CentOS 7 we want to statically link with OpenSSL, but `cargo generate-rpm` doesn't build the code for
           # unlike `cargo deb` so we have to control the feature set used for building ourselves rather than in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ depends = "$auto, passwd"
 [package.metadata.deb.variants.ubuntu-focal]
 
 [package.metadata.deb.variants.ubuntu-jammy]
+depends = "$auto, passwd, libssl3"
 
 [package.metadata.deb.variants.debian-stretch]
 features = [ "static-openssl" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,8 @@ depends = "$auto, passwd"
 
 [package.metadata.deb.variants.ubuntu-focal]
 
+[package.metadata.deb.variants.ubuntu-jammy]
+
 [package.metadata.deb.variants.debian-stretch]
 features = [ "static-openssl" ]
 depends = "$auto, passwd"

--- a/pkg/common/krill-ubuntu-jammy.krill.service
+++ b/pkg/common/krill-ubuntu-jammy.krill.service
@@ -1,0 +1,1 @@
+krill-ubuntu-focal.krill.service


### PR DESCRIPTION
As the 20.04 .deb doesn't work on 22.04 due to a libssl mismatch.