### PR TITLE
Upgrade KMIP dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "kmip-protocol"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c232c81ccbf10282ec2830fbd81f7f002e2548e4c169aada86c6b444bcfa89e3"
+checksum = "396744d490b405f4ff293057bae5625e03dcf8be70fd4ba8c6346a54e78fd837"
 dependencies = [
  "cfg-if",
  "enum-display-derive",
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "kmip-ttlv"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f11aebbf4a381db6ea786b4148d6e03285c0e58bd778d5f407b4b5ef8b57c2"
+checksum = "1aa943fd7166db2cc2deaea17bd5c2862ccf68eef9ce15576bcee9e4b494685c"
 dependencies = [
  "cfg-if",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ hex                   = "^0.4"
 hyper                 = { version = "^0.14", features = ["server"] }
 intervaltree          = "0.2.6"
 jmespatch             = { version = "^0.3", features = ["sync"], optional = true }
-kmip                  = { version = "0.4.1", package = "kmip-protocol", features = ["tls-with-openssl"], optional = true }
+kmip                  = { version = "0.4.2", package = "kmip-protocol", features = ["tls-with-openssl"], optional = true }
 libflate              = "^1"
 log                   = "^0.4"
 once_cell             = { version = "^1.7.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ For more information please refer to the [documentation](https://krill.docs.nlne
 
 # Changelog
 
-## 0.10.0 RC2 'Hush'
+## 0.10.0 RC3 'Hush'
 
-This second release candidate fixes the following issues identified
-in RC1:
+This third release candidate fixes the following issues identified
+in RC1 and RC2:
 - Using a jitter of 0 results in a panic #859
 - Make krill.lock file optional and opt-in #856
 - BGPSec Router Certificate should NOT contain SIA extension #854
 - Manifest of 0.10.0-rc1 includes CRL, but nothing else #853
+- Security fixes in KMIP dependencies.
 
-In this release candidate we introduce the following major features:
+In this release we introduce the following major features:
 - BGPSec Router Certificate Signing
 - Support the use of Hardware Security Modules (HSMs) for key operations
 


### PR DESCRIPTION
No new functionality, only security fixes in upstream dependencies of the crate which were detected by GitHub Dependabot.