### PR TITLE
PKCS#11 HSM support should compile out-of-the-box on FreeBSD.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "cryptoki-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec220169d3b1705b54bce57e459873828e5c3bf0e25b96e5f2142acbbb71dda"
+checksum = "1e4895bb04269df9a14f2692c6499dc2769e9a93caa33ef37c4df134f76956d2"
 dependencies = [
  "libloading",
  "target-lexicon",

--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ For more information please refer to the [documentation](https://krill.docs.nlne
 
 # Changelog
 
-## 0.10.0 RC2 'Hush'
+## 0.10.0 RC3 'Hush'
 
-This second release candidate fixes the following issues identified
-in RC1:
+This third release candidate fixes the following issues identified
+in RC1 and RC2:
 - Using a jitter of 0 results in a panic #859
 - Make krill.lock file optional and opt-in #856
 - BGPSec Router Certificate should NOT contain SIA extension #854
 - Manifest of 0.10.0-rc1 includes CRL, but nothing else #853
+- HSM support in v0.10.0-rc2 doesn't compile on FreeBSD 13.1 #861
 
-In this release candidate we introduce the following major features:
+In this release we introduce the following major features:
 - BGPSec Router Certificate Signing
 - Support the use of Hardware Security Modules (HSMs) for key operations
 


### PR DESCRIPTION
This PR updates the `cryptoki-sys` crate to v0.1.4 which includes PKCS#11 bindings for the x86_64-unknown-freebsd Rust target, to address issue #861.

This is a DRAFT PR as the v0.1.4 release of `cryptoki-sys` is not available yet, but is expected soon. See https://github.com/parallaxsecond/rust-cryptoki/pull/96.