### PR TITLE
Fix `docker build` for normal (aka non-CI) users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,4 +171,3 @@ EXPOSE 3000/tcp
 # activating Tini, but cannot be enabled from inside the Docker image).
 ENTRYPOINT ["/sbin/tini", "--", "/opt/entrypoint.sh"]
 CMD ["krill", "-c", "/var/krill/data/krill.conf"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,9 +116,7 @@ RUN CARGO_HTTP_MULTIPLEXING=false cargo install \
 # 'build' stage and so that the magic $TARGETPLATFORM ARG will be set for us.
 FROM ${BASE_IMG} AS copy
 ARG TARGETPLATFORM
-WORKDIR /tmp/out/bin/
-COPY dockerbin/$TARGETPLATFORM .
-RUN chmod +x ./*
+ONBUILD COPY dockerbin/$TARGETPLATFORM /tmp/out/bin/
 
 
 # -----------------------------------------------------------------------------
@@ -173,3 +171,4 @@ EXPOSE 3000/tcp
 # activating Tini, but cannot be enabled from inside the Docker image).
 ENTRYPOINT ["/sbin/tini", "--", "/opt/entrypoint.sh"]
 CMD ["krill", "-c", "/var/krill/data/krill.conf"]
+


### PR DESCRIPTION
Since PR #773 was merged 10 days ago to `main` the `Dockerfile` can only be built using the [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) mode of Docker (i.e. running `DOCKER_BUILDKIT=1 docker build` instead of plain `docker build`. This is a regression that was introduced some time during the development of PR #773 and clearly a plain `docker build` test was not done using the resulting `Dockerfile` which was my mistake.

The `MODE` and support for BuildKit were added for use by the GitHub Actions `pkg` workflow to support cross compilation and building of multiple Docker images in parallel, some with externally pre-cross compiled binaries to be copied into the image, others building the binaries within the image building process. The copy `MODE` is not something normal users are expected to use.

The issue that arises is that with BuildKit the `copy` stage is skipped when the `MODE` build arg is set to `build` (the default) but without BuildKit, i.e. with Docker in its normal (legacy) mode of operation, the `copy` stage is executed (because plain Docker is not clever enough to realize it is not needed) and fails when the `COPY` command is unable to find the files to copy in to the image (because we ran the build in `build` mode not `copy` mode and so didn't place any files ready for Docker to find).

This PR defers the `COPY` command from the `build` stage until a stage that actually uses it via the [`ONBUILD`](https://docs.docker.com/engine/reference/builder/#onbuild) `Dockerfile` instruction. The case which currently fails then no longer fails because the deferred command is never used and thus cannot fail.

The change in behaviour is described below:

| BuildKit enabled? | `MODE` | Old behaviour | New behaviour |
| --- | --- | --- | --- |
| no | `build` | the `copy` stage `COPY` command **fails** due to missing binaries to copy in to the image | the `copy` stage defers the  `COPY` command to the next stage but the next stage uses the `build` stage as input and thus the `copy` stage is not actually used and so the deferred `COPY` command is not run (and thus cannot fail) |
| yes | `build` | the `copy` stage is skipped so cannot fail | unchanged |
| no | `copy` | the `build` stage is run and discarded _(which is inefficient but normal users are not expected to use this mode anyway)_ then the `copy` stage copies the provided files in | the `build` stage is run and discarded _(which is inefficient but normal users are not expected to use this mode anyway)_ then the `copy` stage defers copying the files in until the next stage when they are copied into the image at the expected location |
| yes | `copy` | the `copy` stage `COPY` command copies the files into the image at the expected location | the `copy` stage defers copying the files in until the next stage when they are copied into the image at the expected location |

I also removed a redundant `chmod` command because any executables copied in will keep their executable flag and keeping the `chmod` command would complicate the use of `ONBUILD`.