### PR TITLE
Add SSLKEYLOGFILE support (#615)

### DIFF
--- a/src/daemon/http/tls.rs
+++ b/src/daemon/http/tls.rs
@@ -179,6 +179,7 @@ impl TlsConfigBuilder {
         config.set_single_cert(cert, key).map_err(TlsConfigError::InvalidKey)?;
         config.set_protocols(&["h2".into(), "http/1.1".into()]);
 
+        # See: https://wiki.wireshark.org/TLS#tls-decryption
         if std::env::var(SSLKEYLOGFILE_ENV_VAR_NAME).is_ok() {
             config.key_log = Arc::new(KeyLogFile::new());
         }

--- a/src/daemon/http/tls.rs
+++ b/src/daemon/http/tls.rs
@@ -27,12 +27,14 @@ use std::{
 
 use futures::ready;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_rustls::rustls::{NoClientAuth, ServerConfig, TLSError};
+use tokio_rustls::rustls::{NoClientAuth, ServerConfig, TLSError, KeyLogFile};
 
 use hyper::server::{
     accept::Accept,
     conn::{AddrIncoming, AddrStream},
 };
+
+const SSLKEYLOGFILE_ENV_VAR_NAME: &'static str = "SSLKEYLOGFILE";
 
 pub trait Transport: AsyncRead + AsyncWrite {
     fn remote_addr(&self) -> Option<SocketAddr>;
@@ -176,6 +178,11 @@ impl TlsConfigBuilder {
         let mut config = ServerConfig::new(NoClientAuth::new());
         config.set_single_cert(cert, key).map_err(TlsConfigError::InvalidKey)?;
         config.set_protocols(&["h2".into(), "http/1.1".into()]);
+
+        if std::env::var(SSLKEYLOGFILE_ENV_VAR_NAME).is_ok() {
+            config.key_log = Arc::new(KeyLogFile::new());
+        }
+
         Ok(config)
     }
 }


### PR DESCRIPTION
Per https://github.com/NLnetLabs/krill/issues/615 this PR adds support for SSLKEYLOGFILE env var triggered logging of TLS session keys to disk for use in later decrypting HTTPS sessions for diagnostic purposes.

For more information see https://wiki.wireshark.org/TLS#tls-decryption