### PR TITLE
Allow plain HTTP for --server in krillc. #913

### DIFF
--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -2,7 +2,7 @@ use std::{env, fmt};
 
 use serde::{de::DeserializeOwned, Serialize};
 
-use rpki::{ca::idexchange, uri};
+use rpki::ca::idexchange;
 
 use crate::{
     cli::{
@@ -29,25 +29,30 @@ use crate::{
     constants::{PW_HASH_LOG_N, PW_HASH_P, PW_HASH_R},
 };
 
-fn resolve_uri(server: &uri::Https, path: &str) -> String {
+fn resolve_uri(server: &idexchange::ServiceUri, path: &str) -> String {
     format!("{}{}", server, path)
 }
 
-async fn get_json<T: DeserializeOwned>(server: &uri::Https, token: &Token, path: &str) -> Result<T, Error> {
+async fn get_json<T: DeserializeOwned>(server: &idexchange::ServiceUri, token: &Token, path: &str) -> Result<T, Error> {
     let uri = resolve_uri(server, path);
     httpclient::get_json(&uri, Some(token))
         .await
         .map_err(Error::HttpClientError)
 }
 
-async fn post_empty(server: &uri::Https, token: &Token, path: &str) -> Result<(), Error> {
+async fn post_empty(server: &idexchange::ServiceUri, token: &Token, path: &str) -> Result<(), Error> {
     let uri = resolve_uri(server, path);
     httpclient::post_empty(&uri, Some(token))
         .await
         .map_err(Error::HttpClientError)
 }
 
-async fn post_json(server: &uri::Https, token: &Token, path: &str, data: impl Serialize) -> Result<(), Error> {
+async fn post_json(
+    server: &idexchange::ServiceUri,
+    token: &Token,
+    path: &str,
+    data: impl Serialize,
+) -> Result<(), Error> {
     let uri = resolve_uri(server, path);
     httpclient::post_json(&uri, data, Some(token))
         .await
@@ -55,7 +60,7 @@ async fn post_json(server: &uri::Https, token: &Token, path: &str, data: impl Se
 }
 
 async fn post_json_with_response<T: DeserializeOwned>(
-    server: &uri::Https,
+    server: &idexchange::ServiceUri,
     token: &Token,
     path: &str,
     data: impl Serialize,
@@ -67,7 +72,7 @@ async fn post_json_with_response<T: DeserializeOwned>(
 }
 
 async fn post_json_with_opt_response<T: DeserializeOwned>(
-    server: &uri::Https,
+    server: &idexchange::ServiceUri,
     token: &Token,
     uri: &str,
     data: impl Serialize,
@@ -78,7 +83,7 @@ async fn post_json_with_opt_response<T: DeserializeOwned>(
         .map_err(Error::HttpClientError)
 }
 
-async fn delete(server: &uri::Https, token: &Token, uri: &str) -> Result<(), Error> {
+async fn delete(server: &idexchange::ServiceUri, token: &Token, uri: &str) -> Result<(), Error> {
     let uri = resolve_uri(server, uri);
     httpclient::delete(&uri, Some(token))
         .await
@@ -87,7 +92,7 @@ async fn delete(server: &uri::Https, token: &Token, uri: &str) -> Result<(), Err
 
 /// Command line tool for Krill admin tasks
 pub struct KrillClient {
-    server: uri::Https,
+    server: idexchange::ServiceUri,
     token: Token,
 }
 
@@ -714,7 +719,7 @@ mod tests {
         details.with_log_file("/var/log/krill/krill.log");
 
         let client = KrillClient {
-            server: test::https("https://localhost:3001/"),
+            server: test::service_uri("https://localhost:3001/"),
             token: Token::from("secret"),
         };
 
@@ -738,7 +743,7 @@ mod tests {
         details.with_log_file("/var/log/krill/krill.log");
 
         let client = KrillClient {
-            server: test::https("https://localhost:3001/"),
+            server: test::service_uri("https://localhost:3001/"),
             token: Token::from("secret"),
         };
 

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -2,7 +2,6 @@
 use std::collections::HashMap;
 
 use std::{
-    convert::TryFrom,
     path::PathBuf,
     str::{from_utf8_unchecked, FromStr},
     {env, fmt},
@@ -54,7 +53,7 @@ impl GeneralArgs {
     fn from_matches(matches: &ArgMatches) -> Result<Self, Error> {
         let server = {
             let mut server = match env::var(KRILL_CLI_SERVER_ENV) {
-                Ok(server_str) => Some(idexchange::ServiceUri::try_from(server_str)?),
+                Ok(server_str) => Some(idexchange::ServiceUri::from_str(&server_str)?),
                 Err(_) => None,
             };
 

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -44,7 +44,7 @@ use crate::{
 };
 
 struct GeneralArgs {
-    server: uri::Https,
+    server: idexchange::ServiceUri,
     token: Token,
     format: ReportFormat,
     api: bool,
@@ -54,15 +54,15 @@ impl GeneralArgs {
     fn from_matches(matches: &ArgMatches) -> Result<Self, Error> {
         let server = {
             let mut server = match env::var(KRILL_CLI_SERVER_ENV) {
-                Ok(server_str) => Some(uri::Https::try_from(server_str)?),
+                Ok(server_str) => Some(idexchange::ServiceUri::try_from(server_str)?),
                 Err(_) => None,
             };
 
             if let Some(server_str) = matches.value_of(KRILL_CLI_SERVER_ARG) {
-                server = Some(uri::Https::from_str(server_str)?);
+                server = Some(idexchange::ServiceUri::from_str(server_str)?);
             }
 
-            server.unwrap_or_else(|| uri::Https::from_str(KRILL_CLI_SERVER_DFLT).unwrap())
+            server.unwrap_or_else(|| idexchange::ServiceUri::from_str(KRILL_CLI_SERVER_DFLT).unwrap())
         };
 
         let token = {
@@ -102,7 +102,7 @@ impl GeneralArgs {
 impl Default for GeneralArgs {
     fn default() -> Self {
         GeneralArgs {
-            server: uri::Https::from_str(KRILL_CLI_SERVER_DFLT).unwrap(),
+            server: idexchange::ServiceUri::from_str(KRILL_CLI_SERVER_DFLT).unwrap(),
             token: Token::from(""),
             format: ReportFormat::Text,
             api: false,
@@ -113,7 +113,7 @@ impl Default for GeneralArgs {
 /// This type holds all the necessary data to connect to a Krill daemon, and
 /// authenticate, and perform a specific action.
 pub struct Options {
-    pub server: uri::Https,
+    pub server: idexchange::ServiceUri,
     pub token: Token,
     pub format: ReportFormat,
     pub api: bool,
@@ -136,7 +136,7 @@ impl Options {
     }
 
     /// Creates a new Options explicitly (useful for testing)
-    pub fn new(server: uri::Https, token: &str, format: ReportFormat, command: Command) -> Self {
+    pub fn new(server: idexchange::ServiceUri, token: &str, format: ReportFormat, command: Command) -> Self {
         Options {
             server,
             token: Token::from(token),

--- a/src/test.rs
+++ b/src/test.rs
@@ -187,7 +187,7 @@ pub async fn start_krill_pubd() -> PathBuf {
 }
 
 pub async fn krill_admin(command: Command) -> ApiResponse {
-    let krillc_opts = Options::new(https(KRILL_SERVER_URI), "secret", ReportFormat::Json, command);
+    let krillc_opts = Options::new(service_uri(KRILL_SERVER_URI), "secret", ReportFormat::Json, command);
     match KrillClient::process(krillc_opts).await {
         Ok(res) => res, // ok
         Err(e) => panic!("{}", e),
@@ -200,7 +200,7 @@ pub async fn krill_embedded_pubd_admin(command: PubServerCommand) -> ApiResponse
 
 pub async fn krill_dedicated_pubd_admin(command: PubServerCommand) -> ApiResponse {
     let options = Options::new(
-        https(KRILL_PUBD_SERVER_URI),
+        service_uri(KRILL_PUBD_SERVER_URI),
         "secret",
         ReportFormat::Json,
         Command::PubServer(command),
@@ -212,7 +212,7 @@ pub async fn krill_dedicated_pubd_admin(command: PubServerCommand) -> ApiRespons
 }
 
 pub async fn krill_admin_expect_error(command: Command) -> Error {
-    let krillc_opts = Options::new(https(KRILL_SERVER_URI), "secret", ReportFormat::Json, command);
+    let krillc_opts = Options::new(service_uri(KRILL_SERVER_URI), "secret", ReportFormat::Json, command);
     match KrillClient::process(krillc_opts).await {
         Ok(_res) => panic!("Expected error"),
         Err(e) => e,
@@ -656,6 +656,10 @@ pub fn rsync(s: &str) -> uri::Rsync {
 
 pub fn https(s: &str) -> uri::Https {
     uri::Https::from_str(s).unwrap()
+}
+
+pub fn service_uri(s: &str) -> idexchange::ServiceUri {
+    idexchange::ServiceUri::from_str(s).unwrap()
 }
 
 pub fn ca_handle(s: &str) -> CaHandle {


### PR DESCRIPTION
Essentially this is just replacing `uri::Https` with `idexchange::ServiceUri` (both from `rpki-rs) as the latter allows both http and https.