### PR TITLE
Do not skip migration of pubd 0.9.0 (fix: 928)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ it would result in the child CA rejecting the parent response, log an error, and
 try synchronising again, but it would not result in any changes to the CA certificate
 issued by the parent to the child.
 
+Furthermore, this release fixes an issue where the data for a Publication Server
+(if configured) would not be migrated if the previous Krill version was 0.9.0.
+See issue #928.
+
 ## 0.10.1 'Slash'
 
 Krill 0.10.0, or rather rpki-rs 0.15.4 became quite strict in its validation of

--- a/src/upgrades/pre_0_10_0/pubd_migration.rs
+++ b/src/upgrades/pre_0_10_0/pubd_migration.rs
@@ -52,7 +52,7 @@ impl UpgradeStore for PublicationServerMigration {
         if !self.current_kv_store.has_scope("0".to_string())? {
             Ok(false)
         } else {
-            Ok(self.current_kv_store.version_is_after(KrillVersion::release(0, 9, 0))?
+            Ok(self.current_kv_store.version()? >= KrillVersion::release(0, 9, 0)
                 && self
                     .current_kv_store
                     .version_is_before(KrillVersion::candidate(0, 10, 0, 1))?)


### PR DESCRIPTION
Note: testing this is quite awkward because of the complicated way that is used to determine what migrations are needed.

A better fix would be to simplify that logic. I believe that the proper change would be too involved for a quick bug fix release, so this current change is just a quick fix. I created issue #929 so that we can do this properly for release 0.11.0.