### PR TITLE
Show repo init settings

### DIFF
--- a/src/pubd/repository.rs
+++ b/src/pubd/repository.rs
@@ -1328,11 +1328,14 @@ impl RepoStats {
 
 impl fmt::Display for RepoStats {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "RSYNC BASE:        {}", self.sia_base)?;
+        writeln!(f, "RRDP NOTIFICATION: {}", self.rrdp_notification_uri)?;
+        writeln!(f)?;
         if let Some(update) = self.last_update() {
-            writeln!(f, "RRDP updated: {}", update.to_rfc3339())?;
+            writeln!(f, "RRDP updated:      {}", update.to_rfc3339())?;
         }
-        writeln!(f, "RRDP session: {}", self.session())?;
-        writeln!(f, "RRDP serial:  {}", self.serial())?;
+        writeln!(f, "RRDP session:      {}", self.session())?;
+        writeln!(f, "RRDP serial:       {}", self.serial())?;
         writeln!(f)?;
         writeln!(f, "Publisher, Objects, Size, Last Updated")?;
         for (publisher, stats) in self.get_publishers() {

--- a/src/pubd/repository.rs
+++ b/src/pubd/repository.rs
@@ -363,7 +363,17 @@ impl RepositoryContent {
         let serial = self.rrdp.serial;
         let last_update = Some(self.rrdp.notification().time());
 
-        RepoStats::new(publishers, session, serial, last_update)
+        let rrdp_notification_uri = self.rrdp.notification_uri();
+        let sia_base = self.rsync.base_uri.clone();
+
+        RepoStats::new(
+            publishers,
+            session,
+            serial,
+            last_update,
+            sia_base,
+            rrdp_notification_uri,
+        )
     }
 
     /// Returns the stats for all current publishers
@@ -1229,12 +1239,14 @@ impl RepositoryAccess {
 
 //------------ RepoStats -----------------------------------------------------
 
-#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RepoStats {
     publishers: HashMap<PublisherHandle, PublisherStats>,
     session: RrdpSession,
     serial: u64,
     last_update: Option<Time>,
+    sia_base: uri::Rsync,
+    rrdp_notification_uri: uri::Https,
 }
 
 impl RepoStats {
@@ -1243,21 +1255,16 @@ impl RepoStats {
         session: RrdpSession,
         serial: u64,
         last_update: Option<Time>,
+        sia_base: uri::Rsync,
+        rrdp_notification_uri: uri::Https,
     ) -> Self {
         RepoStats {
             publishers,
             session,
             serial,
             last_update,
-        }
-    }
-
-    pub fn empty(session: RrdpSession) -> Self {
-        RepoStats {
-            publishers: HashMap::new(),
-            session,
-            serial: 0,
-            last_update: None,
+            sia_base,
+            rrdp_notification_uri,
         }
     }
 

--- a/src/pubd/repository.rs
+++ b/src/pubd/repository.rs
@@ -351,7 +351,7 @@ impl RepositoryContent {
             self.rrdp.publish(delta, jail, config)?;
             self.write_repository(config)?;
         }
-        // remove publisher is present
+        // remove publisher if present
         self.publishers.remove(name);
         Ok(())
     }


### PR DESCRIPTION
Added to the repo stats endpoint (/stats/repo). Example output:

```
{
  "publishers": {
    "testbed": {
      "objects": 3,
      "size": 3762,
      "manifests": [
        {
          "uri": "rsync://localhost/repo/testbed/0/217876AA966B965A6EDFDED43C469B90ED11AC6D.mft",
          "this_update": "2022-09-13T15:10:12Z",
          "next_update": "2022-09-14T18:18:12Z"
        }
      ]
    },
    "ca": {
      "objects": 5,
      "size": 8247,
      "manifests": [
        {
          "uri": "rsync://localhost/repo/ca/0/CC2487CF3A9C774BFAE2DCE4DD8368441C75C720.mft",
          "this_update": "2022-09-13T15:10:12Z",
          "next_update": "2022-09-14T16:01:12Z"
        }
      ]
    },
    "ta": {
      "objects": 3,
      "size": 3663,
      "manifests": [
        {
          "uri": "rsync://localhost/repo/ta/0/0A6EA673F04AAA345D605A38E7710A2D8413B56C.mft",
          "this_update": "2022-09-13T15:10:12Z",
          "next_update": "2022-09-14T17:02:12Z"
        }
      ]
    }
  },
  "session": "0102f89f-3639-40cb-a967-68789c7da891",
  "serial": 25,
  "last_update": "2022-09-13T15:15:13.427709Z",
  "sia_base": "rsync://localhost/repo/",
  "rrdp_notification_uri": "https://localhost:3000/rrdp/notification.xml"
}
```