### PR TITLE
Local publishing without HTTPS/CMS #935

### DIFF
--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -10,7 +10,6 @@ use rpki::{
     ca::{
         idexchange,
         idexchange::{CaHandle, ChildHandle, ParentHandle, PublisherHandle},
-        publication::{ListReply, PublishDelta},
     },
     repository::resources::ResourceSet,
     uri,
@@ -205,7 +204,13 @@ impl KrillServer {
                     let repo_response = repo_manager.repository_response(&testbed_ca_handle.convert())?;
                     let repo_contact = RepositoryContact::for_response(repo_response).map_err(Error::rfc8183)?;
                     ca_manager
-                        .update_repo(testbed_ca_handle.clone(), repo_contact, false, &system_actor)
+                        .update_repo(
+                            repo_manager.as_ref(),
+                            testbed_ca_handle.clone(),
+                            repo_contact,
+                            false,
+                            &system_actor,
+                        )
                         .await?;
 
                     // Establish the TA (parent) <-> testbed CA (child) relationship
@@ -297,6 +302,7 @@ impl KrillServer {
         Scheduler::build(
             self.mq.clone(),
             self.ca_manager.clone(),
+            self.repo_manager.clone(),
             self.bgp_analyser.clone(),
             #[cfg(feature = "multi-user")]
             self.login_session_cache.clone(),
@@ -403,7 +409,13 @@ impl KrillServer {
             let repo_contact = RepositoryContact::for_response(repo_response).map_err(Error::rfc8183)?;
 
             ca_manager
-                .update_repo(ca_handle.clone(), repo_contact, false, &system_actor)
+                .update_repo(
+                    repo_manager.as_ref(),
+                    ca_handle.clone(),
+                    repo_contact,
+                    false,
+                    &system_actor,
+                )
                 .await?;
 
             // Establish the Parent <-> CA relationship
@@ -767,7 +779,7 @@ impl KrillServer {
     /// orphaned, and they will only learn of this sad fact when they choose
     /// to call home.
     pub async fn ca_delete(&self, ca: &CaHandle, actor: &Actor) -> KrillResult<()> {
-        self.ca_manager.delete_ca(ca, actor).await
+        self.ca_manager.delete_ca(self.repo_manager.as_ref(), ca, actor).await
     }
 
     /// Returns the parent contact for a CA and parent, or NONE if either the CA or the parent cannot be found.
@@ -805,7 +817,9 @@ impl KrillServer {
 
     /// Update the repository for a CA, or return an error. (see `CertAuth::repo_update`)
     pub async fn ca_repo_update(&self, ca: CaHandle, contact: RepositoryContact, actor: &Actor) -> KrillEmptyResult {
-        self.ca_manager.update_repo(ca, contact, true, actor).await
+        self.ca_manager
+            .update_repo(self.repo_manager.as_ref(), ca, contact, true, actor)
+            .await
     }
 
     pub async fn ca_update_id(&self, ca: CaHandle, actor: &Actor) -> KrillEmptyResult {
@@ -944,21 +958,6 @@ impl KrillServer {
     /// Re-issue ROA objects so that they will use short subjects (see issue #700)
     pub async fn force_renew_roas(&self) -> KrillResult<()> {
         self.ca_manager.force_renew_roas_all(self.system_actor()).await
-    }
-}
-
-/// # Handle publication requests
-///
-impl KrillServer {
-    /// Handles a publish delta request sent to the API, or.. through
-    /// the CmsProxy.
-    pub fn handle_delta(&self, publisher: PublisherHandle, delta: PublishDelta) -> KrillEmptyResult {
-        self.repo_manager.publish(publisher, delta)
-    }
-
-    /// Handles a list request sent to the API, or.. through the CmsProxy.
-    pub fn handle_list(&self, publisher: &PublisherHandle) -> KrillResult<ListReply> {
-        self.repo_manager.list(publisher)
     }
 }
 

--- a/src/pubd/manager.rs
+++ b/src/pubd/manager.rs
@@ -109,20 +109,6 @@ impl RepositoryManager {
             }
         };
 
-        // let (response, should_log_cms) = match query {
-        //     publication::Query::List => {
-        //         let list_reply = self.list(&publisher_handle)?;
-        //         (publication::Message::list_reply(list_reply), false)
-        //     }
-        //     publication::Query::Delta(delta) => match self.publish(&publisher_handle, delta) {
-        //         Ok(()) => (publication::Message::success(), true),
-        //         Err(e) => {
-        //             warn!("Rejecting delta sent by: {}. Error was: {}", publisher_handle, e);
-
-        //         }
-        //     },
-        // };
-
         let response_bytes = self.access.respond(response, &self.signer)?.to_bytes();
 
         if should_log_cms {


### PR DESCRIPTION
With these changes CAs with a local publication server should bypass HTTPS and CMS for RFC 8181 (publication) and this should result in a hopefully big performance improvement.

Automated tests are okay. Will now build a package and try it in our test VMs.