### PR TITLE
Temporarily use unreleased bug fix branch of the reusable packaging workflow.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: NLnetLabs/.github/.github/workflows/pkg-rust.yml@v1
+    uses: NLnetLabs/.github/.github/workflows/pkg-rust.yml@prepare-verify-bug-fixes
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
To work around this error: https://github.com/NLnetLabs/krill/actions/runs/3060211032/jobs/4938451367#step:9:40