### PR TITLE
Support listening on multiple IP addresses. (#955)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,15 +200,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -227,10 +238,20 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -323,6 +344,85 @@ checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
 dependencies = [
  "nix",
  "winapi",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -750,6 +850,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +909,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -913,6 +1044,7 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
+ "serde_with",
  "syslog",
  "tiny_http",
  "tokio",
@@ -995,6 +1127,15 @@ checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1153,6 +1294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1713,6 +1863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
 name = "scrypt"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +1991,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.15",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1939,6 +2123,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,7 +2154,7 @@ dependencies = [
  "error-chain",
  "libc",
  "log",
- "time",
+ "time 0.1.44",
 ]
 
 [[package]]
@@ -1996,6 +2186,15 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2045,6 +2244,18 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
 ]
 
 [[package]]
@@ -2480,6 +2691,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
+ "time",
  "wasm-bindgen",
  "winapi",
 ]
@@ -238,7 +238,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -386,41 +386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
-dependencies = [
- "darling_core",
  "quote",
  "syn",
 ]
@@ -874,12 +839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,7 +868,6 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -1044,7 +1002,6 @@ dependencies = [
  "scrypt",
  "serde",
  "serde_json",
- "serde_with",
  "syslog",
  "tiny_http",
  "tokio",
@@ -1294,15 +1251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -1991,34 +1939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap",
- "serde",
- "serde_json",
- "serde_with_macros",
- "time 0.3.15",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,12 +2043,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,7 +2068,7 @@ dependencies = [
  "error-chain",
  "libc",
  "log",
- "time 0.1.44",
+ "time",
 ]
 
 [[package]]
@@ -2244,18 +2158,6 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
-dependencies = [
- "itoa",
- "libc",
- "num_threads",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ rpki                  = { version = "0.15.8", features = [ "ca", "compat", "rrdp
 scrypt                = { version = "^0.6", optional = true, default-features = false }
 serde                 = { version = "^1.0", features = ["derive", "rc"] }
 serde_json            = "^1.0"
-serde_with            = "2.0.1"
 tokio                 = { version = "1", features = ["macros", "rt", "rt-multi-thread", "signal", "time"] }
 tokio-rustls          = "^0.22"
 toml                  = "^0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rpki                  = { version = "0.15.8", features = [ "ca", "compat", "rrdp
 scrypt                = { version = "^0.6", optional = true, default-features = false }
 serde                 = { version = "^1.0", features = ["derive", "rc"] }
 serde_json            = "^1.0"
+serde_with            = "2.0.1"
 tokio                 = { version = "1", features = ["macros", "rt", "rt-multi-thread", "signal", "time"] }
 tokio-rustls          = "^0.22"
 toml                  = "^0.5"

--- a/defaults/krill-pubd.conf
+++ b/defaults/krill-pubd.conf
@@ -91,7 +91,7 @@
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can specify a singly IP address or an array of addresses.
+# can specify a single IP address or an array of addresses.
 #
 # If you want to support remote delegated CAs to be children under a CA and/or
 # publish their content, then you should set the "service uri" setting described

--- a/defaults/krill-pubd.conf
+++ b/defaults/krill-pubd.conf
@@ -91,16 +91,16 @@
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can also specify multiple IP addresses if you need to. In this case 'ips' needs
-# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
+# can specify a singly IP address or an array of addresses.
 #
-# If you do change the IP address(es), then the service uri will use it (or the
-# first in case of multiple) as a hostname for remote CAs and Publishers. If you
-# want to use a proper public hostname, please set 'service_uri' below.
+# If you want to support remote delegated CAs to be children under a CA and/or
+# publish their content, then you should set the "service uri" setting described
+# below. If you do not set this, then Krill will use the (first) IP address as
+# the hostname for this settting.
 #
 #
 ### ip             = "127.0.0.1"            # default
-### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### ip             = [ "127.0.0.1", "::1" ] # multiple IP addresses
 ### port           = 3000                   # applies to all ip addresses
 
 # Specify the base public service URI hostname and port.

--- a/defaults/krill-pubd.conf
+++ b/defaults/krill-pubd.conf
@@ -84,13 +84,24 @@
 #
 ### admin_token =
 
-# Specify the ip address and port number that the server will use.
+# Specify the ip addresses and port number that the server will use.
 #
-# Note: we recommend that you use the defaults and use a proxy if you
-# must make your Krill instance accessible remotely.
+# Note: by default Krill uses "127.0.0.1" (IPv4 localhost) as its IP address.
+# We recommend that you keep this setting and use a proxy server such as NGINX
+# or Apache if you must make your Krill instance accessible remotely.
 #
-### ip             = "localhost"
-### port           = 3000
+# You can use the 'ip' setting in this config file to override the default. You
+# can also specify multiple IP addresses if you need to. In this case 'ips' needs
+# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
+#
+# If you do change the IP address(es), then the service uri will use it (or the
+# first in case of multiple) as a hostname for remote CAs and Publishers. If you
+# want to use a proper public hostname, please set 'service_uri' below.
+#
+#
+### ip             = "127.0.0.1"            # default
+### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### port           = 3000                   # applies to all ip addresses
 
 # Specify the base public service URI hostname and port.
 #

--- a/defaults/krill-testbed.conf
+++ b/defaults/krill-testbed.conf
@@ -114,17 +114,24 @@
 #
 ### admin_token =
 
-# Specify the ip address and port number that the server will use.
+# Specify the ip addresses and port number that the server will use.
 #
-# Note: we recommend that you do NOT change the IP address to anything other
-# than 127.0.0.1. Please use a proxy server such as NGINX or Apache if you
-# must make your Krill instance accessible remotely.
+# Note: by default Krill uses "127.0.0.1" (IPv4 localhost) as its IP address.
+# We recommend that you keep this setting and use a proxy server such as NGINX
+# or Apache if you must make your Krill instance accessible remotely.
 #
-# If you do change the IP address, then the service uri will use it as a hostname.
-# If you want to use a proper public hostname, please set 'service_uri' below.
+# You can use the 'ip' setting in this config file to override the default. You
+# can also specify multiple IP addresses if you need to. In this case 'ips' needs
+# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
 #
-### ip             = "127.0.0.1"
-### port           = 3000
+# If you do change the IP address(es), then the service uri will use it (or the
+# first in case of multiple) as a hostname for remote CAs and Publishers. If you
+# want to use a proper public hostname, please set 'service_uri' below.
+#
+#
+### ip             = "127.0.0.1"            # default
+### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### port           = 3000                   # applies to all ip addresses
 
 # Specify the base public service URI hostname and port.
 #

--- a/defaults/krill-testbed.conf
+++ b/defaults/krill-testbed.conf
@@ -121,16 +121,16 @@
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can also specify multiple IP addresses if you need to. In this case 'ips' needs
-# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
+# can specify a singly IP address or an array of addresses.
 #
-# If you do change the IP address(es), then the service uri will use it (or the
-# first in case of multiple) as a hostname for remote CAs and Publishers. If you
-# want to use a proper public hostname, please set 'service_uri' below.
+# If you want to support remote delegated CAs to be children under a CA and/or
+# publish their content, then you should set the "service uri" setting described
+# below. If you do not set this, then Krill will use the (first) IP address as
+# the hostname for this settting.
 #
 #
 ### ip             = "127.0.0.1"            # default
-### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### ip             = [ "127.0.0.1", "::1" ] # multiple IP addresses
 ### port           = 3000                   # applies to all ip addresses
 
 # Specify the base public service URI hostname and port.

--- a/defaults/krill-testbed.conf
+++ b/defaults/krill-testbed.conf
@@ -121,7 +121,7 @@
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can specify a singly IP address or an array of addresses.
+# can specify a single IP address or an array of addresses.
 #
 # If you want to support remote delegated CAs to be children under a CA and/or
 # publish their content, then you should set the "service uri" setting described

--- a/defaults/krill.conf
+++ b/defaults/krill.conf
@@ -78,7 +78,7 @@
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can specify a singly IP address or an array of addresses.
+# can specify a single IP address or an array of addresses.
 #
 # If you want to support remote delegated CAs to be children under a CA and/or
 # publish their content, then you should set the "service uri" setting described

--- a/defaults/krill.conf
+++ b/defaults/krill.conf
@@ -78,16 +78,16 @@
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can also specify multiple IP addresses if you need to. In this case 'ips' needs
-# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
+# can specify a singly IP address or an array of addresses.
 #
-# If you do change the IP address(es), then the service uri will use it (or the
-# first in case of multiple) as a hostname for remote CAs and Publishers. If you
-# want to use a proper public hostname, please set 'service_uri' below.
+# If you want to support remote delegated CAs to be children under a CA and/or
+# publish their content, then you should set the "service uri" setting described
+# below. If you do not set this, then Krill will use the (first) IP address as
+# the hostname for this settting.
 #
 #
 ### ip             = "127.0.0.1"            # default
-### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### ip             = [ "127.0.0.1", "::1" ] # multiple IP addresses
 ### port           = 3000                   # applies to all ip addresses
 
 # Specify the HTTPS mode. Krill supports three modes:

--- a/defaults/krill.conf
+++ b/defaults/krill.conf
@@ -71,17 +71,24 @@
 #
 ### admin_token =
 
-# Specify the ip address and port number that the server will use.
+# Specify the ip addresses and port number that the server will use.
 #
-# Note: we recommend that you do NOT change the IP address to anything other
-# than 127.0.0.1. Please use a proxy server such as NGINX or Apache if you
-# must make your Krill instance accessible remotely.
+# Note: by default Krill uses "127.0.0.1" (IPv4 localhost) as its IP address.
+# We recommend that you keep this setting and use a proxy server such as NGINX
+# or Apache if you must make your Krill instance accessible remotely.
 #
-# If you do change the IP address, then the service uri will use it as a hostname.
-# If you want to use a proper public hostname, please set 'service_uri' below.
+# You can use the 'ip' setting in this config file to override the default. You
+# can also specify multiple IP addresses if you need to. In this case 'ips' needs
+# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
 #
-### ip             = "127.0.0.1"
-### port           = 3000
+# If you do change the IP address(es), then the service uri will use it (or the
+# first in case of multiple) as a hostname for remote CAs and Publishers. If you
+# want to use a proper public hostname, please set 'service_uri' below.
+#
+#
+### ip             = "127.0.0.1"            # default
+### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### port           = 3000                   # applies to all ip addresses
 
 # Specify the HTTPS mode. Krill supports three modes:
 #

--- a/src/daemon/config.rs
+++ b/src/daemon/config.rs
@@ -11,9 +11,7 @@ use chrono::Duration;
 use log::{error, LevelFilter};
 use serde::{de, Deserialize, Deserializer};
 
-use serde_with::formats::PreferOne;
-use serde_with::serde_as;
-use serde_with::OneOrMany;
+use serde_with::{formats::PreferOne, serde_as, OneOrMany};
 
 #[cfg(unix)]
 use syslog::Facility;

--- a/src/daemon/http/server.rs
+++ b/src/daemon/http/server.rs
@@ -237,11 +237,11 @@ async fn single_http_listener(krill_server: Arc<KrillServer>, socket_addr: Socke
         // It won't like a service made for a Server that is not of the type of the
         // TlsAcceptor we are about to set up.
         let service = make_service_fn(|_| {
-            let state = krill_server.clone();
+            let krill_server = krill_server.clone();
             async move {
                 Ok::<_, Infallible>(service_fn(move |req: hyper::Request<hyper::Body>| {
-                    let state = state.clone();
-                    map_requests(req, state)
+                    let krill_server = krill_server.clone();
+                    map_requests(req, krill_server)
                 }))
             }
         });

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -5,7 +5,10 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use tokio::time::sleep;
 
-use rpki::ca::idexchange::{CaHandle, ParentHandle};
+use rpki::ca::{
+    idexchange::{CaHandle, ParentHandle},
+    provisioning::{ResourceClassName, RevocationRequest},
+};
 
 use crate::{
     commons::{actor::Actor, api::Timestamp, bgp::BgpAnalyser, KrillResult},
@@ -62,11 +65,11 @@ impl Scheduler {
 
     /// Run the scheduler in the background. It will sweep the message queue for tasks
     /// and re-schedule new tasks as needed.
-    pub async fn run(&self) -> KrillResult<()> {
+    pub async fn run(&self) {
         loop {
             while let Some(evt) = self.tasks.pop(now()) {
-                match evt {
-                    Task::QueueStartTasks => self.queue_start_tasks().await?, // return error and stop server on failure
+                if let Err(e) = match evt {
+                    Task::QueueStartTasks => self.queue_start_tasks().await, // return error and stop server on failure
 
                     Task::SyncRepo { ca } => self.sync_repo(ca).await,
 
@@ -74,9 +77,9 @@ impl Scheduler {
 
                     Task::SuspendChildrenIfNeeded { ca } => self.suspend_children_if_needed(ca).await,
 
-                    Task::RepublishIfNeeded => self.republish_if_needed().await?,
+                    Task::RepublishIfNeeded => self.republish_if_needed().await,
 
-                    Task::RenewObjectsIfNeeded => self.renew_objects_if_needed().await?,
+                    Task::RenewObjectsIfNeeded => self.renew_objects_if_needed().await,
 
                     Task::RefreshAnnouncementsInfo => self.announcements_refresh().await,
 
@@ -92,46 +95,16 @@ impl Scheduler {
                         parent,
                         rcn,
                         revocation_requests,
-                    } => {
-                        info!(
-                            "Trigger send revoke requests for removed RC for '{}' under '{}'",
-                            ca, parent
-                        );
-
-                        let requests = HashMap::from([(rcn, revocation_requests)]);
-
-                        if self
-                            .ca_manager
-                            .send_revoke_requests(&ca, &parent, requests)
-                            .await
-                            .is_err()
-                        {
-                            warn!(
-                                "Could not revoke key for removed resource class. This is not \
-                            an issue, because typically the parent will revoke our keys pro-actively, \
-                            just before removing the resource class entitlements."
-                            );
-                        }
-                    }
+                    } => self.resource_class_removed(ca, parent, rcn, revocation_requests).await,
 
                     Task::UnexpectedKey {
                         ca,
                         rcn,
                         revocation_request,
-                    } => {
-                        info!(
-                            "Trigger sending revocation requests for unexpected key with id '{}' in RC '{}'",
-                            revocation_request.key(),
-                            rcn
-                        );
-                        if let Err(e) = self
-                            .ca_manager
-                            .send_revoke_unexpected_key(&ca, rcn, revocation_request)
-                            .await
-                        {
-                            error!("Could not revoke unexpected surplus key at parent: {}", e);
-                        }
-                    }
+                    } => self.unexpected_key(ca, rcn, revocation_request).await,
+                } {
+                    error!("Fatal error in scheduler: {}", e);
+                    return;
                 }
             }
 
@@ -224,7 +197,7 @@ impl Scheduler {
         Ok(())
     }
 
-    async fn sync_repo(&self, ca: CaHandle) {
+    async fn sync_repo(&self, ca: CaHandle) -> KrillResult<()> {
         debug!("Synchronize CA {} with repository", ca);
 
         if let Err(e) = self
@@ -241,10 +214,12 @@ impl Scheduler {
 
             self.tasks.sync_repo(ca, next);
         }
+
+        Ok(())
     }
 
     /// Try to synchronize a CA with a specific parent, reschedule if this fails
-    async fn sync_parent(&self, ca: CaHandle, parent: ParentHandle) {
+    async fn sync_parent(&self, ca: CaHandle, parent: ParentHandle) -> KrillResult<()> {
         info!("Synchronize CA '{}' with its parent '{}'", ca, parent);
         if let Err(e) = self.ca_manager.ca_sync_parent(&ca, &parent, &self.system_actor).await {
             let next = self.config.requeue_remote_failed();
@@ -258,16 +233,20 @@ impl Scheduler {
             let next = self.config.ca_refresh_next();
             self.tasks.sync_parent(ca, parent, next);
         }
+
+        Ok(())
     }
 
     /// Try to suspend children for a CA
-    async fn suspend_children_if_needed(&self, ca_handle: CaHandle) {
+    async fn suspend_children_if_needed(&self, ca_handle: CaHandle) -> KrillResult<()> {
         debug!("Verify if CA '{}' has children that need to be suspended", ca_handle);
         self.ca_manager
             .ca_suspend_inactive_children(&ca_handle, self.started, &self.system_actor)
             .await;
 
         self.tasks.suspend_children(ca_handle, in_hours(1));
+
+        Ok(())
     }
 
     /// Let CAs that need it republish their CRL/MFT
@@ -288,14 +267,16 @@ impl Scheduler {
     }
 
     /// Update announcement info
-    async fn announcements_refresh(&self) {
+    async fn announcements_refresh(&self) -> KrillResult<()> {
         if let Err(e) = self.bgp_analyser.update().await {
             error!("Failed to update BGP announcements: {}", e)
         }
 
         // check again in 10 minutes, note.. this is a no-op in case the actual update was less
         // then 1 hour ago. See BGP_RIS_REFRESH_MINUTES constant.
-        self.tasks.refresh_announcements_info(in_minutes(10))
+        self.tasks.refresh_announcements_info(in_minutes(10));
+
+        Ok(())
     }
 
     /// Let CAs that need it re-issue signed objects
@@ -309,23 +290,27 @@ impl Scheduler {
     }
 
     #[cfg(feature = "multi-user")]
-    fn sweep_login_cache(&self) {
+    fn sweep_login_cache(&self) -> KrillResult<()> {
         if let Err(e) = self.login_session_cache.sweep() {
             error!("Background sweep of session decryption cache failed: {}", e);
         }
 
         self.tasks.sweep_login_cache(in_minutes(1));
+
+        Ok(())
     }
 
-    fn update_snapshots(&self) {
+    fn update_snapshots(&self) -> KrillResult<()> {
         if let Err(e) = self.repo_manager.update_snapshots() {
             error!("Could not update snapshots on disk! Error: {}", e);
         }
 
         self.tasks.update_snapshots(in_hours(24));
+
+        Ok(())
     }
 
-    fn update_rrdp_if_needed(&self) {
+    fn update_rrdp_if_needed(&self) -> KrillResult<()> {
         match self.repo_manager.update_rrdp_if_needed() {
             Err(e) => {
                 error!("Could not update RRDP deltas! Error: {}", e);
@@ -342,5 +327,59 @@ impl Scheduler {
                 self.tasks.update_rrdp_if_needed(later_time.into());
             }
         }
+
+        Ok(())
+    }
+
+    async fn resource_class_removed(
+        &self,
+        ca: CaHandle,
+        parent: ParentHandle,
+        rcn: ResourceClassName,
+        revocation_requests: Vec<RevocationRequest>,
+    ) -> KrillResult<()> {
+        info!(
+            "Trigger send revoke requests for removed RC for '{}' under '{}'",
+            ca, parent
+        );
+
+        let requests = HashMap::from([(rcn, revocation_requests)]);
+
+        if self
+            .ca_manager
+            .send_revoke_requests(&ca, &parent, requests)
+            .await
+            .is_err()
+        {
+            warn!(
+                "Could not revoke key for removed resource class. This is not \
+                            an issue, because typically the parent will revoke our keys pro-actively, \
+                            just before removing the resource class entitlements."
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn unexpected_key(
+        &self,
+        ca: CaHandle,
+        rcn: ResourceClassName,
+        revocation_request: RevocationRequest,
+    ) -> KrillResult<()> {
+        info!(
+            "Trigger sending revocation requests for unexpected key with id '{}' in RC '{}'",
+            revocation_request.key(),
+            rcn
+        );
+        if let Err(e) = self
+            .ca_manager
+            .send_revoke_unexpected_key(&ca, rcn, revocation_request)
+            .await
+        {
+            error!("Could not revoke unexpected surplus key at parent: {}", e);
+        }
+
+        Ok(())
     }
 }

--- a/test-resources/krill-init-multi-user.conf
+++ b/test-resources/krill-init-multi-user.conf
@@ -71,17 +71,24 @@ log_file = "/var/log/krill/krill.log"
 #
 admin_token = "secret"
 
-# Specify the ip address and port number that the server will use.
+# Specify the ip addresses and port number that the server will use.
 #
-# Note: we recommend that you do NOT change the IP address to anything other
-# than 127.0.0.1. Please use a proxy server such as NGINX or Apache if you
-# must make your Krill instance accessible remotely.
+# Note: by default Krill uses "127.0.0.1" (IPv4 localhost) as its IP address.
+# We recommend that you keep this setting and use a proxy server such as NGINX
+# or Apache if you must make your Krill instance accessible remotely.
 #
-# If you do change the IP address, then the service uri will use it as a hostname.
-# If you want to use a proper public hostname, please set 'service_uri' below.
+# You can use the 'ip' setting in this config file to override the default. You
+# can also specify multiple IP addresses if you need to. In this case 'ips' needs
+# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
 #
-### ip             = "127.0.0.1"
-### port           = 3000
+# If you do change the IP address(es), then the service uri will use it (or the
+# first in case of multiple) as a hostname for remote CAs and Publishers. If you
+# want to use a proper public hostname, please set 'service_uri' below.
+#
+#
+### ip             = "127.0.0.1"            # default
+### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### port           = 3000                   # applies to all ip addresses
 
 # Specify the HTTPS mode. Krill supports three modes:
 #

--- a/test-resources/krill-init-multi-user.conf
+++ b/test-resources/krill-init-multi-user.conf
@@ -78,7 +78,7 @@ admin_token = "secret"
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can specify a singly IP address or an array of addresses.
+# can specify a single IP address or an array of addresses.
 #
 # If you want to support remote delegated CAs to be children under a CA and/or
 # publish their content, then you should set the "service uri" setting described

--- a/test-resources/krill-init-multi-user.conf
+++ b/test-resources/krill-init-multi-user.conf
@@ -78,16 +78,16 @@ admin_token = "secret"
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can also specify multiple IP addresses if you need to. In this case 'ips' needs
-# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
+# can specify a singly IP address or an array of addresses.
 #
-# If you do change the IP address(es), then the service uri will use it (or the
-# first in case of multiple) as a hostname for remote CAs and Publishers. If you
-# want to use a proper public hostname, please set 'service_uri' below.
+# If you want to support remote delegated CAs to be children under a CA and/or
+# publish their content, then you should set the "service uri" setting described
+# below. If you do not set this, then Krill will use the (first) IP address as
+# the hostname for this settting.
 #
 #
 ### ip             = "127.0.0.1"            # default
-### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### ip             = [ "127.0.0.1", "::1" ] # multiple IP addresses
 ### port           = 3000                   # applies to all ip addresses
 
 # Specify the HTTPS mode. Krill supports three modes:

--- a/test-resources/krill-init.conf
+++ b/test-resources/krill-init.conf
@@ -71,17 +71,24 @@ log_file = "/var/log/krill/krill.log"
 #
 admin_token = "secret"
 
-# Specify the ip address and port number that the server will use.
+# Specify the ip addresses and port number that the server will use.
 #
-# Note: we recommend that you do NOT change the IP address to anything other
-# than 127.0.0.1. Please use a proxy server such as NGINX or Apache if you
-# must make your Krill instance accessible remotely.
+# Note: by default Krill uses "127.0.0.1" (IPv4 localhost) as its IP address.
+# We recommend that you keep this setting and use a proxy server such as NGINX
+# or Apache if you must make your Krill instance accessible remotely.
 #
-# If you do change the IP address, then the service uri will use it as a hostname.
-# If you want to use a proper public hostname, please set 'service_uri' below.
+# You can use the 'ip' setting in this config file to override the default. You
+# can also specify multiple IP addresses if you need to. In this case 'ips' needs
+# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
 #
-### ip             = "127.0.0.1"
-### port           = 3000
+# If you do change the IP address(es), then the service uri will use it (or the
+# first in case of multiple) as a hostname for remote CAs and Publishers. If you
+# want to use a proper public hostname, please set 'service_uri' below.
+#
+#
+### ip             = "127.0.0.1"            # default
+### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### port           = 3000                   # applies to all ip addresses
 
 # Specify the HTTPS mode. Krill supports three modes:
 #

--- a/test-resources/krill-init.conf
+++ b/test-resources/krill-init.conf
@@ -78,7 +78,7 @@ admin_token = "secret"
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can specify a singly IP address or an array of addresses.
+# can specify a single IP address or an array of addresses.
 #
 # If you want to support remote delegated CAs to be children under a CA and/or
 # publish their content, then you should set the "service uri" setting described

--- a/test-resources/krill-init.conf
+++ b/test-resources/krill-init.conf
@@ -78,16 +78,16 @@ admin_token = "secret"
 # or Apache if you must make your Krill instance accessible remotely.
 #
 # You can use the 'ip' setting in this config file to override the default. You
-# can also specify multiple IP addresses if you need to. In this case 'ips' needs
-# to be set instead of 'ip'. If you set both, then 'ips' takes precedence.
+# can specify a singly IP address or an array of addresses.
 #
-# If you do change the IP address(es), then the service uri will use it (or the
-# first in case of multiple) as a hostname for remote CAs and Publishers. If you
-# want to use a proper public hostname, please set 'service_uri' below.
+# If you want to support remote delegated CAs to be children under a CA and/or
+# publish their content, then you should set the "service uri" setting described
+# below. If you do not set this, then Krill will use the (first) IP address as
+# the hostname for this settting.
 #
 #
 ### ip             = "127.0.0.1"            # default
-### ips            = [ "127.0.0.1", "::1" ] # overrides 'ip'
+### ip             = [ "127.0.0.1", "::1" ] # multiple IP addresses
 ### port           = 3000                   # applies to all ip addresses
 
 # Specify the HTTPS mode. Krill supports three modes:


### PR DESCRIPTION
Allows optional configuration of multiple `ips` but will not change default behaviour and will still accept `ip` if it was set.

This will allow Krill to listen on both IPv4 and IPv6, of multiple of either of course..

Internally the code was reworked a bit so that the futures do not return an error anymore.. they just log an error and come back. This was needed to make the wiring a bit more manageable.
