### PR TITLE
Merge release 0.12.0-rc3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "krill"
-version = "0.12.0-rc2"
+version = "0.12.0-rc3"
 dependencies = [
  "backoff",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Note: some of these values are also used when building Debian packages below.
 name    = "krill"
-version = "0.12.0-rc2"
+version = "0.12.0-rc3"
 edition = "2018"
 rust-version = "1.56"
 authors = [ "The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>" ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Rust Crate Status](https://img.shields.io/crates/v/krill.svg?color=brightgreen)](https://crates.io/crates/krill)
 [![Docker Pulls](https://img.shields.io/docker/pulls/nlnetlabs/krill?color=brightgreen)](https://hub.docker.com/r/nlnetlabs/krill)
 [![Documentation Status](https://readthedocs.org/projects/rpki/badge/?version=latest)](https://krill.docs.nlnetlabs.nl/)
-[![E2E Test Status](https://github.com/nlnetlabs/krill/workflows/E2E%20Test/badge.svg)](https://github.com/NLnetLabs/krill/actions?query=workflow%3A%22E2E+Test%22)
 [![](https://img.shields.io/discord/818584154278199396?label=rpki%20on%20discord&logo=discord)](https://discord.gg/8dvKB5Ykhy)
 [![](https://img.shields.io/twitter/follow/krillrpki.svg?label=Follow&style=social)](https://twitter.com/krillrpki)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ in this [blog post](https://blog.nlnetlabs.nl/testing-the-waters-with-krill/).
 
 # Changelog
 
-## 0.12.0 RC2 'Crickets'
+## 0.12.0 RC3 'Crickets'
+
+RC3 improves parent synchronisation scheduling and logging.
 
 RC2 fixes an issue in RC1 where the repository content would not be upgraded
 properly.

--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -829,16 +829,17 @@ impl CaManager {
         if handle != &ta_handle() {
             let ca = self.get_ca(handle).await?;
 
-            if ca.repository_contact().is_ok() {
-                let ca = self.get_ca(handle).await?;
-                let parent_contact = ca.parent(parent)?;
-                let entitlements = self
-                    .get_entitlements_from_contact(handle, parent, parent_contact, true)
-                    .await?;
+            // Return an error if the repository was not configured yet.
+            ca.repository_contact()?;
 
-                self.update_entitlements(handle, parent.clone(), entitlements, actor)
-                    .await?;
-            }
+            let ca = self.get_ca(handle).await?;
+            let parent_contact = ca.parent(parent)?;
+            let entitlements = self
+                .get_entitlements_from_contact(handle, parent, parent_contact, true)
+                .await?;
+
+            self.update_entitlements(handle, parent.clone(), entitlements, actor)
+                .await?;
         }
         Ok(())
     }

--- a/tests/remote_parent_and_repo.rs
+++ b/tests/remote_parent_and_repo.rs
@@ -1,0 +1,90 @@
+//! Perform functional tests on a Krill instance, using the API
+//!
+use std::{fs, str::FromStr};
+
+use rpki::ca::provisioning::ResourceClassName;
+
+use krill::{
+    commons::api::{ObjectName, ParentCaReq, RoaConfigurationUpdates, RoaPayload},
+    daemon::ca::ta_handle,
+    test::*,
+};
+
+#[tokio::test]
+async fn remote_parent_and_repo() {
+    init_logging();
+
+    info("test running a CA under a remote parent and repo");
+
+    let krill_dir = start_krill_testbed_with_rrdp_interval(5).await;
+    let second_krill_dir = start_second_krill().await;
+
+    let ta = ta_handle();
+    let testbed = ca_handle("testbed");
+    let ca1 = ca_handle("CA1");
+    let ca1_res = ipv4_resources("10.0.0.0/16");
+    let ca1_route_definition = RoaPayload::from_str("10.0.0.0/16-16 => 65000").unwrap();
+    let rcn_0 = ResourceClassName::from(0);
+
+    // Verify that the TA and testbed are ready
+    {
+        let mut expected_files = expected_mft_and_crl(&ta, &rcn_0).await;
+        expected_files.push(expected_issued_cer(&testbed, &rcn_0).await);
+        assert!(
+            will_publish_embedded(
+                "TA should have manifest, crl and cert for testbed",
+                &ta,
+                &expected_files
+            )
+            .await
+        );
+    }
+
+    // Create up CA1 in second server
+    {
+        init_ca_krill2(&ca1).await;
+    }
+
+    // Set up CA1 as a child to testbed
+    {
+        let req = request_krill2(&ca1).await;
+        let parent = {
+            let response = add_child_rfc6492(testbed.convert(), ca1.convert(), req, ca1_res.clone()).await;
+            ParentCaReq::new(testbed.convert(), response)
+        };
+        add_parent_to_ca_krill2(&ca1, parent).await;
+    }
+
+    // Set up CA1 as a publisher
+    {
+        let publisher_request = publisher_request_krill2(&ca1).await;
+        embedded_repo_add_publisher(publisher_request).await;
+
+        // Get a Repository Response for the CA
+        let response = embedded_repository_response(ca1.convert()).await;
+
+        // Update the repo for the child
+        repo_update_krill2(&ca1, response).await;
+    }
+
+    // Wait a bit so that CA1 can request a certificate from testbed
+    assert!(ca_contains_resources_krill2(&ca1, &ca1_res).await);
+
+    // Create a ROA for CA1
+    {
+        let mut updates = RoaConfigurationUpdates::empty();
+        updates.add(ca1_route_definition.into());
+        ca_route_authorizations_update_krill2(&ca1, updates).await;
+    }
+
+    // Verify that CA1 publishes
+    {
+        let mut expected_files = expected_mft_and_crl_krill2(&ca1, &rcn_0).await;
+        expected_files.push(ObjectName::from(&ca1_route_definition).to_string());
+
+        assert!(will_publish_embedded("CA1 should publish manifest, crl and roa", &ca1, &expected_files).await);
+    }
+
+    let _ = fs::remove_dir_all(&krill_dir);
+    let _ = fs::remove_dir_all(&second_krill_dir);
+}


### PR DESCRIPTION
There was a possible (very rare ~ 1 in 1000) race condition reported where seemingly a parent sync was not triggered if the repository was added *just* after the parent was added (same second timestamp). It's hard to see from the code how this could happen except if sync with the parent was ignored when the parent was added (because no repo was set), and adding the repo did not trigger a sync because the other sync was still pending.

In any case in this RC we make some changes that will hopefully prevent this issue, or at least improve logging if it does happen:

- do not trigger sync with parent if the repo is not yet configured
- do not ignore repo not set when syncing with a parent - error will trigger rescheduling
- improve logging
- add explicit test for remote access

The test is good to have, even though it succeeded without any of the other changes. We could not reproduce the issue.