### PR TITLE
Follow move of reusable pkg workflow to new ploutos repo.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   package:
-    uses: NLnetLabs/.github/.github/workflows/pkg-rust.yml@v1
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v1
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}


### PR DESCRIPTION
Rather than pollute the org wide central repo with the reusable packaging workflow, it has been moved to its own home in a new ploutos repo. This change follows that move.