### PR TITLE
Purge content by uri

### DIFF
--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -514,6 +514,11 @@ impl KrillClient {
                 delete(&self.server, &self.token, &uri).await?;
                 Ok(ApiResponse::Empty)
             }
+            PubServerCommand::PurgeFiles(criteria) => {
+                let uri = "api/v1/pubd/purge";
+                post_json(&self.server, &self.token, uri, criteria).await?;
+                Ok(ApiResponse::Empty)
+            }
             PubServerCommand::ShowPublisher(handle) => {
                 let uri = format!("api/v1/pubd/publishers/{}", handle);
                 let details: PublisherDetails = get_json(&self.server, &self.token, &uri).await?;

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -514,8 +514,8 @@ impl KrillClient {
                 delete(&self.server, &self.token, &uri).await?;
                 Ok(ApiResponse::Empty)
             }
-            PubServerCommand::PurgeFiles(criteria) => {
-                let uri = "api/v1/pubd/purge";
+            PubServerCommand::DeleteFiles(criteria) => {
+                let uri = "api/v1/pubd/delete";
                 post_json(&self.server, &self.token, uri, criteria).await?;
                 Ok(ApiResponse::Empty)
             }

--- a/src/cli/options.rs
+++ b/src/cli/options.rs
@@ -32,7 +32,8 @@ use crate::{
         api::{
             self, AddChildRequest, AspaCustomer, AspaDefinition, AspaDefinitionFormatError, AspaProvidersUpdate,
             AuthorizationFmtError, BgpSecAsnKey, BgpSecDefinition, CertAuthInit, ParentCaReq, PublicationServerUris,
-            RoaConfiguration, RoaConfigurationUpdates, RoaPayload, RtaName, Token, UpdateChildRequest,
+            RepoFilePurgeCriteria, RoaConfiguration, RoaConfigurationUpdates, RoaPayload, RtaName, Token,
+            UpdateChildRequest,
         },
         crypto::SignSupport,
         error::KrillIoError,
@@ -1317,11 +1318,28 @@ impl Options {
         app.subcommand(sub)
     }
 
+    fn make_pubserver_purge_sc<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
+        let mut sub = SubCommand::with_name("purge").about("Delete specific files from the Publication Server");
+        sub = Options::add_general_args(sub);
+
+        sub = sub.arg(
+            Arg::with_name("base_uri")
+                .long("base_uri")
+                .short("u")
+                .value_name("rsync URI")
+                .help("Remove file matching the base uri if it ends with '/', or the exact uri if it refers to a file.")
+                .required(true),
+        );
+
+        app.subcommand(sub)
+    }
+
     fn make_pubserver_sc<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         let mut sub = SubCommand::with_name("pubserver")
             .about("Manage your Publication Server (only needed if you run your own)");
 
         sub = Self::make_publishers_sc(sub);
+        sub = Self::make_pubserver_purge_sc(sub);
         sub = Self::make_publication_server_sc(sub);
 
         app.subcommand(sub)
@@ -2404,9 +2422,23 @@ impl Options {
         }
     }
 
+    fn parse_matches_purge(matches: &ArgMatches) -> Result<Options, Error> {
+        let general_args = GeneralArgs::from_matches(matches)?;
+
+        let base_uri_str = matches.value_of("base_uri").unwrap();
+        let base_uri = uri::Rsync::from_str(base_uri_str).map_err(Error::UriError)?;
+
+        let criteria = RepoFilePurgeCriteria::new(base_uri);
+
+        let command = Command::PubServer(PubServerCommand::PurgeFiles(criteria));
+        Ok(Options::make(general_args, command))
+    }
+
     fn parse_matches_pubserver(matches: &ArgMatches) -> Result<Options, Error> {
         if let Some(m) = matches.subcommand_matches("publishers") {
             Self::parse_matches_publishers(m)
+        } else if let Some(m) = matches.subcommand_matches("purge") {
+            Self::parse_matches_purge(m)
         } else if let Some(m) = matches.subcommand_matches("server") {
             Self::parse_matches_publication_server(m)
         } else {
@@ -2666,6 +2698,7 @@ pub enum PubServerCommand {
     AddPublisher(idexchange::PublisherRequest),
     ShowPublisher(PublisherHandle),
     RemovePublisher(PublisherHandle),
+    PurgeFiles(RepoFilePurgeCriteria),
     RepositoryResponse(PublisherHandle),
     StalePublishers(i64),
     PublisherList,

--- a/src/commons/api/admin.rs
+++ b/src/commons/api/admin.rs
@@ -674,24 +674,24 @@ impl fmt::Display for ServerInfo {
     }
 }
 
-//------------ RepoFilePurgeCriteria -----------------------------------------
+//------------ RepoFileDeleteCriteria ----------------------------------------
 
 /// This is used to send criteria for purging matching files from the publication
 /// server. Currently only needs to support `base_uri` but it could be extended in
 /// future and therefore we introduce a type for it now.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct RepoFilePurgeCriteria {
+pub struct RepoFileDeleteCriteria {
     base_uri: uri::Rsync,
 }
 
-impl RepoFilePurgeCriteria {
+impl RepoFileDeleteCriteria {
     pub fn new(base_uri: uri::Rsync) -> Self {
-        RepoFilePurgeCriteria { base_uri }
+        RepoFileDeleteCriteria { base_uri }
     }
 }
 
-impl From<RepoFilePurgeCriteria> for uri::Rsync {
-    fn from(criteria: RepoFilePurgeCriteria) -> Self {
+impl From<RepoFileDeleteCriteria> for uri::Rsync {
+    fn from(criteria: RepoFileDeleteCriteria) -> Self {
         criteria.base_uri
     }
 }

--- a/src/commons/api/admin.rs
+++ b/src/commons/api/admin.rs
@@ -674,6 +674,28 @@ impl fmt::Display for ServerInfo {
     }
 }
 
+//------------ RepoFilePurgeCriteria -----------------------------------------
+
+/// This is used to send criteria for purging matching files from the publication
+/// server. Currently only needs to support `base_uri` but it could be extended in
+/// future and therefore we introduce a type for it now.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct RepoFilePurgeCriteria {
+    base_uri: uri::Rsync,
+}
+
+impl RepoFilePurgeCriteria {
+    pub fn new(base_uri: uri::Rsync) -> Self {
+        RepoFilePurgeCriteria { base_uri }
+    }
+}
+
+impl From<RepoFilePurgeCriteria> for uri::Rsync {
+    fn from(criteria: RepoFilePurgeCriteria) -> Self {
+        criteria.base_uri
+    }
+}
+
 //------------ Tests ---------------------------------------------------------
 
 #[cfg(test)]

--- a/src/commons/api/ca.rs
+++ b/src/commons/api/ca.rs
@@ -701,7 +701,7 @@ impl fmt::Display for ObjectName {
 ///
 /// The "revocation_date" will be used for the "revocationDate" as described in
 /// section 5.1 of RFC 5280. The "expires" time is used to determine when a CRL
-/// entry can be purged (i.e. removed) because the entry is no longer relevant.
+/// entry can be deleted because it is no longer relevant.
 ///
 /// The "revocation_date" is set to the time that this object is first created,
 /// but it will be persisted for future use. In other words: there is no support
@@ -767,8 +767,8 @@ impl Revocations {
             .collect()
     }
 
-    /// Purges all expired revocations, and returns them.
-    pub fn purge(&mut self) -> Vec<Revocation> {
+    /// Removes all expired revocations, and returns them.
+    pub fn remove_expired(&mut self) -> Vec<Revocation> {
         let (relevant, expired) = self.0.iter().partition(|r| r.expires > Time::now());
         self.0 = relevant;
         expired

--- a/src/commons/api/rrdp.rs
+++ b/src/commons/api/rrdp.rs
@@ -318,7 +318,7 @@ impl CurrentObjects {
 
     /// Returns a copy of self where elements matching the given URI
     /// are removed if there are any matches. Otherwise, returns None.
-    pub fn purge(&self, uri: &uri::Rsync) -> Option<Self> {
+    pub fn with_matching_uri_deleted(&self, uri: &uri::Rsync) -> Option<Self> {
         let mut withdraws = vec![];
 
         // We first loop through the elements to avoid having to clone in case there is no work

--- a/src/commons/api/rrdp.rs
+++ b/src/commons/api/rrdp.rs
@@ -316,6 +316,29 @@ impl CurrentObjects {
         }
     }
 
+    /// Returns a copy of self where elements matching the given URI
+    /// are removed if there are any matches. Otherwise, returns None.
+    pub fn purge(&self, uri: &uri::Rsync) -> Option<Self> {
+        let mut withdraws = vec![];
+
+        // We first loop through the elements to avoid having to clone in case there is no work
+        for (hash, el) in &self.0 {
+            if el.uri() == uri || (uri.as_str().ends_with('/') && el.uri().as_str().starts_with(uri.as_str())) {
+                withdraws.push(hash)
+            }
+        }
+
+        if withdraws.is_empty() {
+            None
+        } else {
+            let mut copy_of_self = self.clone();
+            for hash in withdraws {
+                copy_of_self.0.remove(hash);
+            }
+            Some(copy_of_self)
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.0.len()
     }

--- a/src/commons/api/rrdp.rs
+++ b/src/commons/api/rrdp.rs
@@ -208,6 +208,10 @@ pub struct WithdrawElement {
 }
 
 impl WithdrawElement {
+    pub fn new(uri: uri::Rsync, hash: Hash) -> Self {
+        WithdrawElement { uri, hash }
+    }
+
     pub fn uri(&self) -> &uri::Rsync {
         &self.uri
     }
@@ -265,8 +269,7 @@ impl CurrentObjects {
             if !jail.is_parent_of(p.uri()) {
                 return Err(PublicationDeltaError::outside(jail, p.uri()));
             }
-            let hash = p.base64().to_hash();
-            if self.0.contains_key(&hash) {
+            if self.0.values().any(|existing| existing.uri() == p.uri()) {
                 return Err(PublicationDeltaError::present(p.uri()));
             }
         }
@@ -729,5 +732,81 @@ impl DeltaData {
             })?;
 
         writer.done()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::test::*;
+
+    #[test]
+    fn current_objects_delta() {
+        let jail = rsync("rsync://example.krill.cloud/repo/publisher");
+        let file1_uri = rsync("rsync://example.krill.cloud/repo/publisher/file1.txt");
+        let file2_uri = rsync("rsync://example.krill.cloud/repo/publisher/file2.txt");
+        let file3_uri = rsync("rsync://example.krill.cloud/repo/publisher/file3.txt");
+
+        let file1_content = Base64::from_content(&[1]);
+        let file1_content_2 = Base64::from_content(&[1, 2]);
+        let file2_content = Base64::from_content(&[2]);
+        let file3_content = Base64::from_content(&[3]);
+
+        let mut objects = CurrentObjects::default();
+
+        let publish_file1 = DeltaElements {
+            publishes: vec![PublishElement::new(file1_content.clone(), file1_uri.clone())],
+            updates: vec![],
+            withdraws: vec![],
+        };
+
+        // adding a file to an empty current objects is okay
+        assert!(objects.verify_delta(&publish_file1, &jail).is_ok());
+
+        // The actual application of the delta is infallible, because event replays
+        // may not fail. It is assumed deltas were verified before they were persisted
+        // in events.
+        objects.apply_delta(publish_file1.clone());
+
+        // Now adding the same file again will fail.
+        assert!(objects.verify_delta(&publish_file1, &jail).is_err());
+
+        // Updates
+
+        // Updating a file should work
+        let update_file1 = DeltaElements {
+            publishes: vec![],
+            updates: vec![UpdateElement::new(
+                file1_uri.clone(),
+                file1_content.to_hash(),
+                file1_content_2.clone(),
+            )],
+            withdraws: vec![],
+        };
+        assert!(objects.verify_delta(&update_file1, &jail).is_ok());
+        objects.apply_delta(update_file1.clone());
+
+        // Updating again with the same delta will now fail - there is no longer and object
+        // with that uri and hash it was updated to the new content.
+        assert!(objects.verify_delta(&update_file1, &jail).is_err());
+
+        // Withdraws
+
+        // Withdrawing file with wrong hash should fail
+        let withdraw_file1 = DeltaElements {
+            publishes: vec![],
+            updates: vec![],
+            withdraws: vec![WithdrawElement::new(file1_uri.clone(), file1_content.to_hash())],
+        };
+        assert!(objects.verify_delta(&withdraw_file1, &jail).is_err());
+
+        // Withdrawing file with the right hash should work
+        let withdraw_file1_updated = DeltaElements {
+            publishes: vec![],
+            updates: vec![],
+            withdraws: vec![WithdrawElement::new(file1_uri.clone(), file1_content_2.to_hash())],
+        };
+        assert!(objects.verify_delta(&withdraw_file1_updated, &jail).is_ok());
     }
 }

--- a/src/daemon/ca/publishing.rs
+++ b/src/daemon/ca/publishing.rs
@@ -811,7 +811,7 @@ pub struct KeyObjectSet {
     //
     // When objects are replaced or removed we add a revocation.
     // When publishing revocations for expired certificates are
-    // purged.
+    // removed.
     revocations: Revocations,
 
     // The last manifest generated for this set.
@@ -1033,7 +1033,7 @@ impl KeyObjectSet {
     fn reissue(&mut self, timing: &IssuanceTimingConfig, signer: &KrillSigner) -> KrillResult<()> {
         self.revision.next(timing);
 
-        self.revocations.purge();
+        self.revocations.remove_expired();
         let signing_key = self.signing_cert.key_identifier();
         let issuer = self.signing_cert.subject().clone();
 
@@ -1053,7 +1053,7 @@ impl KeyObjectSet {
         for object in self.published_objects.values() {
             revocations.add(object.revoke());
         }
-        revocations.purge();
+        revocations.remove_expired();
 
         let retired_set = KeyObjectSet {
             signing_cert: self.signing_cert.clone(),

--- a/src/daemon/http/server.rs
+++ b/src/daemon/http/server.rs
@@ -1272,6 +1272,17 @@ async fn api_ca_sync(req: Request, path: &mut RequestPath, ca: CaHandle) -> Rout
 async fn api_publication_server(req: Request, path: &mut RequestPath) -> RoutingResult {
     match path.next() {
         Some("publishers") => api_publishers(req, path).await,
+        Some("purge") => match *req.method() {
+            Method::POST => {
+                let state = req.state.clone();
+
+                match req.json().await {
+                    Ok(criteria) => render_empty_res(state.purge_matching_files(criteria)),
+                    Err(e) => render_error(e),
+                }
+            }
+            _ => render_unknown_method(),
+        },
         Some("stale") => api_stale_publishers(req, path.next()).await,
         Some("init") => match *req.method() {
             Method::POST => {

--- a/src/daemon/http/server.rs
+++ b/src/daemon/http/server.rs
@@ -1272,12 +1272,12 @@ async fn api_ca_sync(req: Request, path: &mut RequestPath, ca: CaHandle) -> Rout
 async fn api_publication_server(req: Request, path: &mut RequestPath) -> RoutingResult {
     match path.next() {
         Some("publishers") => api_publishers(req, path).await,
-        Some("purge") => match *req.method() {
+        Some("delete") => match *req.method() {
             Method::POST => {
                 let state = req.state.clone();
 
                 match req.json().await {
-                    Ok(criteria) => render_empty_res(state.purge_matching_files(criteria)),
+                    Ok(criteria) => render_empty_res(state.delete_matching_files(criteria)),
                     Err(e) => render_error(e),
                 }
             }

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -23,9 +23,9 @@ use crate::{
             AspaProvidersUpdate, BgpSecCsrInfoList, BgpSecDefinitionUpdates, CaCommandDetails, CaRepoDetails,
             CertAuthInfo, CertAuthInit, CertAuthIssues, CertAuthList, CertAuthStats, ChildCaInfo,
             ChildrenConnectionStats, CommandHistory, CommandHistoryCriteria, ConfiguredRoa, ParentCaContact,
-            ParentCaReq, PublicationServerUris, PublisherDetails, ReceivedCert, RepositoryContact, RoaConfiguration,
-            RoaConfigurationUpdates, RoaPayload, RtaList, RtaName, RtaPrepResponse, ServerInfo, TaCertDetails,
-            Timestamp, UpdateChildRequest,
+            ParentCaReq, PublicationServerUris, PublisherDetails, ReceivedCert, RepoFilePurgeCriteria,
+            RepositoryContact, RoaConfiguration, RoaConfigurationUpdates, RoaPayload, RtaList, RtaName,
+            RtaPrepResponse, ServerInfo, TaCertDetails, Timestamp, UpdateChildRequest,
         },
         bgp::{BgpAnalyser, BgpAnalysisReport, BgpAnalysisSuggestion},
         crypto::KrillSignerBuilder,
@@ -335,6 +335,11 @@ impl KrillServer {
     /// Removes a publisher, blows up if it didn't exist.
     pub fn remove_publisher(&self, publisher: PublisherHandle, actor: &Actor) -> KrillEmptyResult {
         self.repo_manager.remove_publisher(publisher, actor)
+    }
+
+    /// Removes a publisher, blows up if it didn't exist.
+    pub fn purge_matching_files(&self, purge_criteria: RepoFilePurgeCriteria) -> KrillEmptyResult {
+        self.repo_manager.purge_matching_files(purge_criteria)
     }
 
     /// Returns a publisher.

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -23,7 +23,7 @@ use crate::{
             AspaProvidersUpdate, BgpSecCsrInfoList, BgpSecDefinitionUpdates, CaCommandDetails, CaRepoDetails,
             CertAuthInfo, CertAuthInit, CertAuthIssues, CertAuthList, CertAuthStats, ChildCaInfo,
             ChildrenConnectionStats, CommandHistory, CommandHistoryCriteria, ConfiguredRoa, ParentCaContact,
-            ParentCaReq, PublicationServerUris, PublisherDetails, ReceivedCert, RepoFilePurgeCriteria,
+            ParentCaReq, PublicationServerUris, PublisherDetails, ReceivedCert, RepoFileDeleteCriteria,
             RepositoryContact, RoaConfiguration, RoaConfigurationUpdates, RoaPayload, RtaList, RtaName,
             RtaPrepResponse, ServerInfo, TaCertDetails, Timestamp, UpdateChildRequest,
         },
@@ -338,8 +338,8 @@ impl KrillServer {
     }
 
     /// Removes a publisher, blows up if it didn't exist.
-    pub fn purge_matching_files(&self, purge_criteria: RepoFilePurgeCriteria) -> KrillEmptyResult {
-        self.repo_manager.purge_matching_files(purge_criteria)
+    pub fn delete_matching_files(&self, criteria: RepoFileDeleteCriteria) -> KrillEmptyResult {
+        self.repo_manager.delete_matching_files(criteria)
     }
 
     /// Returns a publisher.

--- a/src/pubd/manager.rs
+++ b/src/pubd/manager.rs
@@ -15,7 +15,7 @@ use rpki::{
 use crate::{
     commons::{
         actor::Actor,
-        api::{PublicationServerUris, PublisherDetails},
+        api::{PublicationServerUris, PublisherDetails, RepoFilePurgeCriteria},
         crypto::KrillSigner,
         error::Error,
         util::cmslogger::CmsLogger,
@@ -203,6 +203,27 @@ impl RepositoryManager {
         content.write_repository(self.config.rrdp_updates_config)?;
 
         Ok(None)
+    }
+
+    /// Purge URI(s) from the server.
+    pub fn purge_matching_files(&self, criteria: RepoFilePurgeCriteria) -> KrillResult<()> {
+        let content = {
+            let _lock = self.default_repo_lock.write().unwrap();
+
+            // update RRDP first so we apply any staged deltas.
+            self.content.update_rrdp(self.config.rrdp_updates_config)?;
+
+            // purge matching files using the updated snapshot and stage a delta if needed.
+            self.content.purge_matching_files(criteria.into())?;
+
+            // update RRDP again to make the delta effective immediately.
+            self.content.update_rrdp(self.config.rrdp_updates_config)?
+        };
+
+        // Write the updated repository - NOTE: we no longer lock it.
+        content.write_repository(self.config.rrdp_updates_config)?;
+
+        Ok(())
     }
 
     pub fn repo_stats(&self) -> KrillResult<RepoStats> {

--- a/src/pubd/manager.rs
+++ b/src/pubd/manager.rs
@@ -15,7 +15,7 @@ use rpki::{
 use crate::{
     commons::{
         actor::Actor,
-        api::{PublicationServerUris, PublisherDetails, RepoFilePurgeCriteria},
+        api::{PublicationServerUris, PublisherDetails, RepoFileDeleteCriteria},
         crypto::KrillSigner,
         error::Error,
         util::cmslogger::CmsLogger,
@@ -206,15 +206,15 @@ impl RepositoryManager {
     }
 
     /// Purge URI(s) from the server.
-    pub fn purge_matching_files(&self, criteria: RepoFilePurgeCriteria) -> KrillResult<()> {
+    pub fn delete_matching_files(&self, criteria: RepoFileDeleteCriteria) -> KrillResult<()> {
         let content = {
             let _lock = self.default_repo_lock.write().unwrap();
 
             // update RRDP first so we apply any staged deltas.
             self.content.update_rrdp(self.config.rrdp_updates_config)?;
 
-            // purge matching files using the updated snapshot and stage a delta if needed.
-            self.content.purge_matching_files(criteria.into())?;
+            // delete matching files using the updated snapshot and stage a delta if needed.
+            self.content.delete_matching_files(criteria.into())?;
 
             // update RRDP again to make the delta effective immediately.
             self.content.update_rrdp(self.config.rrdp_updates_config)?

--- a/src/pubd/repository.rs
+++ b/src/pubd/repository.rs
@@ -159,6 +159,9 @@ impl RepositoryContentProxy {
         let current_objects = content.objects_for_publisher(&publisher)?;
         let delta = DeltaElements::from(delta);
 
+        // Verifying the delta here before sending the command (and doing it there and then) means
+        // that we do not need to obtain a write-lock for the repository content for nothing in
+        // case there would be an issue.
         current_objects.verify_delta(&delta, jail)?;
 
         let command = RepositoryContentCommand::publish(self.default_handle.clone(), publisher, delta);
@@ -171,6 +174,12 @@ impl RepositoryContentProxy {
     pub fn rrdp_update_needed(&self, rrdp_updates_config: RrdpUpdatesConfig) -> KrillResult<RrdpUpdateNeeded> {
         self.get_default_content()
             .map(|content| content.rrdp.update_rrdp_needed(rrdp_updates_config))
+    }
+
+    /// Purge matching files from the repository and publishers
+    pub fn purge_matching_files(&self, uri: uri::Rsync) -> KrillResult<Arc<RepositoryContent>> {
+        let command = RepositoryContentCommand::purge_matching_files(self.default_handle.clone(), uri);
+        self.store.send_command(command)
     }
 
     /// Update RRDP and return the RepositoryContent so it can be used for writing.
@@ -226,6 +235,10 @@ pub enum RepositoryContentCommand {
         handle: MyHandle,
         publisher: PublisherHandle,
     },
+    PurgeMatchingFiles {
+        handle: MyHandle,
+        uri: uri::Rsync,
+    },
     Publish {
         handle: MyHandle,
         publisher: PublisherHandle,
@@ -249,6 +262,11 @@ impl RepositoryContentCommand {
     pub fn remove_publisher(handle: MyHandle, publisher: PublisherHandle) -> Self {
         RepositoryContentCommand::RemovePublisher { handle, publisher }
     }
+
+    pub fn purge_matching_files(handle: MyHandle, uri: uri::Rsync) -> Self {
+        RepositoryContentCommand::PurgeMatchingFiles { handle, uri }
+    }
+
     pub fn publish(handle: MyHandle, publisher: PublisherHandle, delta: DeltaElements) -> Self {
         RepositoryContentCommand::Publish {
             handle,
@@ -256,6 +274,7 @@ impl RepositoryContentCommand {
             delta,
         }
     }
+
     pub fn create_rrdp_delta(handle: MyHandle, rrdp_updates_config: RrdpUpdatesConfig) -> Self {
         RepositoryContentCommand::CreateRrdpDelta {
             handle,
@@ -271,6 +290,7 @@ impl WalCommand for RepositoryContentCommand {
             | RepositoryContentCommand::AddPublisher { handle, .. }
             | RepositoryContentCommand::RemovePublisher { handle, .. }
             | RepositoryContentCommand::Publish { handle, .. }
+            | RepositoryContentCommand::PurgeMatchingFiles { handle, .. }
             | RepositoryContentCommand::CreateRrdpDelta { handle, .. } => handle,
         }
     }
@@ -290,6 +310,9 @@ impl fmt::Display for RepositoryContentCommand {
             }
             RepositoryContentCommand::RemovePublisher { handle, publisher, .. } => {
                 write!(f, "remove publisher '{}' from repository {}", publisher, handle)
+            }
+            RepositoryContentCommand::PurgeMatchingFiles { handle, uri, .. } => {
+                write!(f, "remove content matching '{}' from repository {}", uri, handle)
             }
             RepositoryContentCommand::Publish { handle, publisher, .. } => {
                 write!(f, "publish for publisher '{}' under repository {}", publisher, handle)
@@ -434,6 +457,7 @@ impl WalSupport for RepositoryContent {
             } => self.create_rrdp_delta(rrdp_updates_config),
             RepositoryContentCommand::AddPublisher { publisher, .. } => self.add_publisher(publisher),
             RepositoryContentCommand::RemovePublisher { publisher, .. } => self.remove_publisher(publisher),
+            RepositoryContentCommand::PurgeMatchingFiles { uri, .. } => self.purge_files(uri),
             RepositoryContentCommand::Publish { publisher, delta, .. } => self.publish(publisher, delta),
         }
     }
@@ -490,6 +514,46 @@ impl RepositoryContent {
         // remove publisher if present
         if self.publishers.contains_key(&publisher) {
             res.push(RepositoryContentChange::PublisherRemoved { publisher });
+        }
+
+        Ok(res)
+    }
+
+    /// Purges content matching the given URI. Recursive if it ends with a '/'.
+    /// Removes the content from existing publishers if found, and removes it
+    /// from the (global) repository content. Can be used to fix broken state
+    /// resulting from issue #981. Can also be used to remove specific content,
+    /// although there is nothing stopping the publisher from publishing that
+    /// content again.
+    fn purge_files(&self, uri: uri::Rsync) -> KrillResult<Vec<RepositoryContentChange>> {
+        let mut res = vec![];
+
+        info!("Purging files matching '{}'", uri);
+
+        // withdraw objects if any
+        let uri_str = uri.as_str();
+        let mut withdraws = vec![];
+        for el in self.rrdp.snapshot.elements() {
+            // URI of el is exact match, or purge uri ends with / and el uri is more specific.
+            if el.uri() == &uri || (uri_str.ends_with('/') && el.uri().as_str().starts_with(uri_str)) {
+                withdraws.push(el.as_withdraw())
+            }
+        }
+        if !withdraws.is_empty() {
+            info!("  removing {} matching files from repository.", withdraws.len());
+            let delta = DeltaElements::new(vec![], vec![], withdraws);
+            res.push(RepositoryContentChange::RrdpDeltaStaged { delta });
+        }
+
+        // check all publishers and remove any matching objects
+        for (publisher, current_objects) in &self.publishers {
+            if let Some(purged_objects) = current_objects.purge(&uri) {
+                info!("  removing matching files from publisher {}", publisher);
+                res.push(RepositoryContentChange::PublishedObjects {
+                    publisher: publisher.clone(),
+                    current_objects: purged_objects,
+                });
+            }
         }
 
         Ok(res)

--- a/src/test.rs
+++ b/src/test.rs
@@ -256,6 +256,10 @@ pub async fn cas_refresh_all() {
     krill_admin(Command::Bulk(BulkCaCommand::Refresh)).await;
 }
 
+pub async fn cas_sync_all() {
+    krill_admin(Command::Bulk(BulkCaCommand::Sync)).await;
+}
+
 pub async fn cas_refresh_single(ca: &CaHandle) {
     krill_admin(Command::CertAuth(CaCommand::Refresh(ca.clone()))).await;
 }

--- a/tests/migrate_repository.rs
+++ b/tests/migrate_repository.rs
@@ -8,7 +8,7 @@ use rpki::ca::provisioning::ResourceClassName;
 use rpki::repository::resources::ResourceSet;
 
 use krill::{
-    commons::api::{ObjectName, RepoFilePurgeCriteria, RoaConfigurationUpdates, RoaPayload},
+    commons::api::{ObjectName, RepoFileDeleteCriteria, RoaConfigurationUpdates, RoaPayload},
     daemon::ca::ta_handle,
     test::*,
 };
@@ -90,9 +90,9 @@ async fn migrate_repository() {
             // Remove single file - let's remove the issued certificate
             let issued = expected_issued_cer(&testbed, &rcn_0).await;
             let issued_uri = rsync(&format!("rsync://localhost/repo/ta/0/{}", issued));
-            let criteria = RepoFilePurgeCriteria::new(issued_uri);
+            let criteria = RepoFileDeleteCriteria::new(issued_uri);
             krill_admin(krill::cli::options::Command::PubServer(
-                krill::cli::options::PubServerCommand::PurgeFiles(criteria),
+                krill::cli::options::PubServerCommand::DeleteFiles(criteria),
             ))
             .await;
             let expected_files = expected_mft_and_crl(&ta, &rcn_0).await;
@@ -108,9 +108,9 @@ async fn migrate_repository() {
 
         {
             // removing a directory should also work
-            let criteria = RepoFilePurgeCriteria::new(rsync("rsync://localhost/repo/ta/"));
+            let criteria = RepoFileDeleteCriteria::new(rsync("rsync://localhost/repo/ta/"));
             krill_admin(krill::cli::options::Command::PubServer(
-                krill::cli::options::PubServerCommand::PurgeFiles(criteria),
+                krill::cli::options::PubServerCommand::DeleteFiles(criteria),
             ))
             .await;
             assert!(will_publish_embedded("TA should have NO content now", &ta, &[]).await);


### PR DESCRIPTION
[draft] Merge after #PR982

This adds functionality to purge (well, maybe it should be called remove? zap? obliterate?) content from the publication server repository by URI. This will help in case a repository got into a bad state because of issue #981. But it may also help in certain other cases.

To use this from the command line:
```
krillc help pubserver purge
krillc-pubserver-purge 
Delete specific files from the Publication Server

USAGE:
    krillc pubserver purge [FLAGS] [OPTIONS] --base_uri <rsync URI>

FLAGS:
        --api        Only show the API call and exit. Or set env: KRILL_CLI_API=1
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -u, --base_uri <rsync URI>    Remove file matching the base uri if it ends with '/', or the exact uri if it refers
                                  to a file.
    -f, --format <type>           Report format: none|json|text (default). Or set env: KRILL_CLI_FORMAT
    -s, --server <URI>            The full URI to the Krill server. Or set env: KRILL_CLI_SERVER
    -t, --token <string>          The secret token for the Krill server. Or set env: KRILL_CLI_TOKEN
```