### PR TITLE
Remove RepositoryManager RwLock

### DIFF
--- a/src/pubd/manager.rs
+++ b/src/pubd/manager.rs
@@ -211,8 +211,6 @@ impl RepositoryManager {
 
     /// Returns a list reply for a known publisher in a repository.
     pub fn list(&self, publisher: &PublisherHandle) -> KrillResult<ListReply> {
-        let _lock = self.default_repo_lock.read().unwrap();
-
         self.content.list_reply(publisher)
     }
 }

--- a/src/pubd/manager.rs
+++ b/src/pubd/manager.rs
@@ -185,7 +185,6 @@ impl RepositoryManager {
     pub fn update_rrdp_if_needed(&self) -> KrillResult<Option<Time>> {
         // See if an update is needed
         {
-            let _lock = self.default_repo_lock.read().unwrap();
             match self.content.rrdp_update_needed(self.config.rrdp_updates_config)? {
                 RrdpUpdateNeeded::No => return Ok(None),
                 RrdpUpdateNeeded::Later(time) => return Ok(Some(time)),


### PR DESCRIPTION
[draft] We should make a branch for `prep-0.12.2` and merge to that if this is stable.

This PR removes the RwLock in RepositoryManager.

We saw issues where a busy Krill Publication Server would freeze without any reported issues. We suspect that this may be due to a deadlock or lock starvation issue in RepositoryManager. A version where read locks were no longer acquired (they are actually not needed) - was deployed and so far seems stable.

Then one more commit was done to remove the RwLock altogether in this layer. It is in fact not needed because there are existing RwLocks in the layers below this (`WalStore::send_command`) to ensure that actual updates do happen sequentially.