### PR TITLE
No session reset on 0.13 upgrade

### DIFF
--- a/src/commons/api/rrdp.rs
+++ b/src/commons/api/rrdp.rs
@@ -1044,7 +1044,7 @@ mod tests {
         }
 
         fn file_uri(name: &str) -> CurrentObjectUri {
-            CurrentObjectUri(format!("rsync://example.krill.cloud/repo/publisher/{name}").into())
+            CurrentObjectUri(format!("rsync://example.krill.cloud/repo/publisher/{}", name).into())
         }
 
         fn random_content() -> Base64 {

--- a/src/pubd/manager.rs
+++ b/src/pubd/manager.rs
@@ -232,7 +232,7 @@ impl RepositoryManager {
         let id_cert = publisher.id_cert().clone();
         let base_uri = publisher.base_uri().clone();
 
-        let current = self.content.current_objects(name)?.into_publish_elements();
+        let current = self.content.current_objects(name)?.try_into_publish_elements()?;
 
         Ok(PublisherDetails::new(name, id_cert, base_uri, current))
     }

--- a/src/pubd/manager.rs
+++ b/src/pubd/manager.rs
@@ -232,7 +232,7 @@ impl RepositoryManager {
         let id_cert = publisher.id_cert().clone();
         let base_uri = publisher.base_uri().clone();
 
-        let current = self.content.current_objects(name)?.into_elements();
+        let current = self.content.current_objects(name)?.into_publish_elements();
 
         Ok(PublisherDetails::new(name, id_cert, base_uri, current))
     }

--- a/src/pubd/repository.rs
+++ b/src/pubd/repository.rs
@@ -349,9 +349,9 @@ pub struct RrdpSessionReset {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RrdpUpdated {
-    time: Time,
-    random: RrdpFileRandom,
-    deltas_truncate: usize,
+    pub time: Time,
+    pub random: RrdpFileRandom,
+    pub deltas_truncate: usize,
 }
 
 impl fmt::Display for RepositoryContentChange {

--- a/src/pubd/repository.rs
+++ b/src/pubd/repository.rs
@@ -951,34 +951,23 @@ pub enum DeltaElement {
 }
 
 impl RrdpServer {
-    /// Migrate pre 0.13.0 repository content.
+    /// Create a new instance.
     ///
-    /// The old RepositoryContent kept the published files both
-    /// in a publishers map owned by RepositoryContent, and inside
-    /// the old RrdpServer.
-    ///
-    /// In the current set up we keep this data only in the RrdpServer.
-    ///
-    /// The old publishers map is authoritative with regards to objects
-    /// to migrate. The new server will use a new RRDP session, because
-    /// of the (remote, but existing) possibility that the content in
-    /// both places was out of sync. I.e. it would be hard to work out
-    /// what the exact delta would be in this case, but a session reset
-    /// will ensure the RPs get the latest (now correct) content.
-    pub fn migrate_old_content(
+    /// Intended to be used by migration code only and therefore
+    /// marked as deprecated.
+    #[deprecated]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
         rrdp_base_uri: uri::Https,
         rrdp_base_dir: PathBuf,
         rrdp_archive_dir: PathBuf,
-        publishers: HashMap<PublisherHandle, CurrentObjects>,
+        session: RrdpSession,
+        serial: u64,
+        last_update: Time,
+        snapshot: SnapshotData,
+        deltas: VecDeque<DeltaData>,
+        staged_elements: HashMap<PublisherHandle, StagedElements>,
     ) -> Self {
-        let session = RrdpSession::default();
-        let serial = RRDP_FIRST_SERIAL;
-        let last_update = Time::now();
-
-        let snapshot = SnapshotData::new(RrdpFileRandom::default(), publishers);
-        let deltas = VecDeque::new();
-        let staged_elements = HashMap::new();
-
         RrdpServer {
             rrdp_base_uri,
             rrdp_base_dir,

--- a/src/upgrades/pre_0_13_0/mod.rs
+++ b/src/upgrades/pre_0_13_0/mod.rs
@@ -1,10 +1,17 @@
-use std::{collections::HashMap, fmt, path::PathBuf};
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt,
+    path::PathBuf,
+};
 
-use rpki::{ca::idexchange::PublisherHandle, uri};
+use rpki::{ca::idexchange::PublisherHandle, repository::x509::Time, uri};
 
 use crate::{
     commons::{
-        api::rrdp::{CurrentObjects, DeltaElements},
+        api::rrdp::{
+            CurrentObjects, DeltaData, DeltaElements, PublishElement, RrdpFileRandom, RrdpSession, UpdateElement,
+            WithdrawElement,
+        },
         error::Error,
         eventsourcing::{WalChange, WalSupport},
     },
@@ -39,14 +46,6 @@ pub struct OldRepositoryContent {
 }
 
 /// The Old RRDP server used by a Repository instance.
-///
-/// Or well. Really just the few bits that we will need
-/// to deserialize for migration. We do not need the content
-/// as it will be regenerated based on the publishers held
-/// by the OldRepositoryContent. And we will do a session
-/// reset when we create the new server based on this.
-///
-/// The additional JSON fields are ignored when deserializing
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OldRrdpServer {
     /// The base URI for notification, snapshot and delta files.
@@ -56,6 +55,170 @@ pub struct OldRrdpServer {
     /// published.
     pub rrdp_base_dir: PathBuf,
     pub rrdp_archive_dir: PathBuf,
+
+    pub session: RrdpSession,
+    pub serial: u64,
+    #[serde(default = "Time::now")] // be backward compatible
+    pub last_update: Time,
+
+    snapshot: OldSnapshotData,
+    deltas: VecDeque<DeltaData>,
+
+    #[serde(default)]
+    staged_elements: OldStagedElements,
+}
+
+impl OldRrdpServer {
+    /// Applies the data from an RrdpUpdated change.
+    fn apply_rrdp_updated(&mut self, update: RrdpUpdated) {
+        self.serial += 1;
+
+        let mut staged_elements = OldStagedElements::default();
+        std::mem::swap(&mut self.staged_elements, &mut staged_elements);
+
+        let mut publishes = vec![];
+        let mut updates = vec![];
+        let mut withdraws = vec![];
+        for el in staged_elements.0.into_values() {
+            match el {
+                OldDeltaElement::Publish(pbl) => publishes.push(pbl),
+                OldDeltaElement::Update(upd) => updates.push(upd),
+                OldDeltaElement::Withdraw(wdr) => withdraws.push(wdr),
+            }
+        }
+        let delta_elements = DeltaElements::new(publishes, updates, withdraws);
+
+        let delta = DeltaData::new(self.serial, update.time, update.random, delta_elements);
+
+        self.snapshot = self
+            .snapshot
+            .with_delta(delta.random().clone(), delta.elements().clone());
+
+        self.deltas.truncate(update.deltas_truncate);
+        self.deltas.push_front(delta);
+        self.deltas_truncate_size();
+
+        self.last_update = update.time;
+    }
+
+    /// Truncate excessive deltas based on size. This is done
+    /// after applying an RrdpUpdate because the outcome is
+    /// deterministic. Compared to truncating the deltas based
+    /// on age and number, because *that* depends on when the
+    /// update was generated, and what the RrdpUpdatesConfig
+    /// was set to at the time.
+    fn deltas_truncate_size(&mut self) {
+        let snapshot_size = self.snapshot.size();
+        let mut total_deltas_size = 0;
+        let mut keep = 0;
+
+        for delta in &self.deltas {
+            total_deltas_size += delta.elements().size_approx();
+            if total_deltas_size > snapshot_size {
+                // never keep more than the size of the snapshot
+                break;
+            } else {
+                keep += 1;
+            }
+        }
+
+        self.deltas.truncate(keep);
+    }
+
+    /// Applies staged DeltaElements
+    fn apply_rrdp_staged(&mut self, elements: DeltaElements) {
+        let (publishes, updates, withdraws) = elements.unpack();
+        for pbl in publishes {
+            let uri = pbl.uri().clone();
+            // A publish that follows a withdraw for the same URI should be Update.
+            if let Some(OldDeltaElement::Withdraw(staged_withdraw)) = self.staged_elements.0.get(&uri) {
+                let hash = *staged_withdraw.hash();
+                let update = UpdateElement::new(uri.clone(), hash, pbl.base64().clone());
+                self.staged_elements.0.insert(uri, OldDeltaElement::Update(update));
+            } else {
+                // In any other case we just keep the new publish.
+                // Because deltas are checked before they are applied we know that publish
+                // elements cannot occur after another publish or update. They would have
+                // had to be an update in that case.
+                // Because this is checked when the publication delta is submitted, we can
+                // ignore this case here.
+                self.staged_elements.0.insert(uri, OldDeltaElement::Publish(pbl));
+            };
+        }
+
+        for mut upd in updates {
+            let uri = upd.uri().clone();
+            // An update that follows a staged publish, should be fresh publish.
+            // An update that follows a staged update, should use the hash from the previous update.
+            // An update cannot follow a staged withdraw. It would have been a publish in that case.
+            if let Some(OldDeltaElement::Publish(_)) = self.staged_elements.0.get(&uri) {
+                self.staged_elements
+                    .0
+                    .insert(uri, OldDeltaElement::Publish(upd.into_publish()));
+            } else if let Some(OldDeltaElement::Update(staged_update)) = self.staged_elements.0.get(&uri) {
+                upd.with_updated_hash(*staged_update.hash()); // set hash to previous update hash
+                self.staged_elements.0.insert(uri, OldDeltaElement::Update(upd));
+            } else {
+                self.staged_elements.0.insert(uri, OldDeltaElement::Update(upd));
+            }
+        }
+
+        for wdr in withdraws {
+            // withdraws should always remove any staged publishes or updates.
+            // they cannot follow staged withdraws (checked when delta is submitted)
+            // so just add them all to the staged elements
+            self.staged_elements
+                .0
+                .insert(wdr.uri().clone(), OldDeltaElement::Withdraw(wdr));
+        }
+    }
+}
+
+/// This type is used to combine staged delta elements for publishers.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct OldStagedElements(HashMap<uri::Rsync, OldDeltaElement>);
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum OldDeltaElement {
+    Publish(PublishElement),
+    Update(UpdateElement),
+    Withdraw(WithdrawElement),
+}
+
+/// A structure to contain the data needed to create an RRDP Snapshot.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct OldSnapshotData {
+    // The random value will be used to make the snapshot URI unguessable and
+    // prevent cache poisoning (through CDN cached 404 not founds).
+    //
+    // Old versions of Krill did not have this. We can just use a default (new)
+    // random value in these cases.
+    #[serde(default)]
+    random: RrdpFileRandom,
+
+    current_objects: CurrentObjects,
+}
+
+impl OldSnapshotData {
+    /// Creates a new snapshot with the delta applied. This assumes
+    /// that the delta had been checked before. This should not be
+    /// any issue as deltas are verified when they are submitted.
+    fn with_delta(&self, random: RrdpFileRandom, elements: DeltaElements) -> OldSnapshotData {
+        let mut current_objects = self.current_objects.clone();
+        current_objects.apply_delta(elements);
+
+        OldSnapshotData {
+            random,
+            current_objects,
+        }
+    }
+
+    fn size(&self) -> usize {
+        self.current_objects
+            .elements()
+            .iter()
+            .fold(0, |sum, p| sum + p.size_approx())
+    }
 }
 
 /// Changes for the Old RepositoryContent.
@@ -111,13 +274,8 @@ impl WalSupport for OldRepositoryContent {
                 OldRepositoryContentChange::SessionReset { .. } => {
                     // Ignore this.. we will do a new session reset after migrating
                 }
-                OldRepositoryContentChange::RrdpUpdated { .. } => {
-                    // Ignore.. we will do a session reset on the new content.
-                }
-                OldRepositoryContentChange::RrdpDeltaStaged { .. } => {
-                    // Ignore.. we only need to keep the content as kept
-                    // in the publishers hash.
-                }
+                OldRepositoryContentChange::RrdpUpdated { update } => self.rrdp.apply_rrdp_updated(update),
+                OldRepositoryContentChange::RrdpDeltaStaged { delta } => self.rrdp.apply_rrdp_staged(delta),
                 OldRepositoryContentChange::PublisherAdded { publisher } => {
                     self.publishers.insert(publisher, CurrentObjects::default());
                 }

--- a/src/upgrades/pre_0_13_0/mod.rs
+++ b/src/upgrades/pre_0_13_0/mod.rs
@@ -9,7 +9,7 @@ use rpki::{ca::idexchange::PublisherHandle, repository::x509::Time, rrdp::Hash, 
 use crate::{
     commons::{
         api::rrdp::{
-            CurrentObjectKey, CurrentObjects, DeltaData, DeltaElements, PublishElement, RrdpFileRandom, RrdpSession,
+            CurrentObjectUri, CurrentObjects, DeltaData, DeltaElements, PublishElement, RrdpFileRandom, RrdpSession,
             UpdateElement, WithdrawElement,
         },
         error::Error,
@@ -75,7 +75,10 @@ impl From<OldCurrentObjects> for CurrentObjects {
         CurrentObjects::new(
             old.0
                 .into_values()
-                .map(|el| (CurrentObjectKey::from(el.uri()), el))
+                .map(|el| {
+                    let (uri, base64) = el.unpack();
+                    (CurrentObjectUri::from(&uri), base64)
+                })
                 .collect(),
         )
     }


### PR DESCRIPTION
With this we no longer need to do an RRDP session reset after migration to 0.13.0. This will reduce the impact significantly on busy repositories.

In the process the code was reorganised a bit. Hopefully cleaner now.. in particular: in theory the same object could be published in multiple locations (names) by a publisher. It does not make sense to do so, but it's allowed by the spec. By using the URI as the object key instead of the hash this is now possible.