### PR TITLE
Enforce that id-ad-caRepository uses a trailing slash. (#1030)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
 
-        # Test against Rust 1.56.0 because in build.rs we say that is the oldest supported version.
+        # Test against Rust 1.65.0 because that is the oldest supported version.
         # Test against beta Rust to get early warning of any problems that might occur with the upcoming Rust release.
         # Order: oldest Rust to newest Rust.
-        rust: [1.56.0, stable, beta]
+        rust: [1.65.0, stable, beta]
 
         # Test with no features, default features ("") and all except UI tests.
         # Order: fewest features to most features.
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [1.56.0, stable, beta]
+        rust: [1.65.0, stable, beta]
         features: ["hsm", "hsm,hsm-tests-kmip"]
     steps:
     - name: Checkout repository
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [1.56.0, stable, beta]
+        rust: [1.65.0, stable, beta]
         features: ["hsm,hsm-tests-pkcs11"]
     steps:
     - name: Checkout repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,8 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.16.0-dev"
-source = "git+https://github.com/nLnetLabs/rpki-rs?branch=csr-ca-repo-trailing-slash#3baa8698d5fb49360a7f11995b7867f6d24ca9d1"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e574c3dfe052c4378b7fe4f3ce72f9604e023f708507df62ceb76c0a8443455d"
 dependencies = [
  "base64",
  "bcder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,9 +1719,8 @@ dependencies = [
 
 [[package]]
 name = "rpki"
-version = "0.15.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10465240cf74fe20765558e76b9c51fa36dfe2b89d5c4e653dfbae7563f23c2f"
+version = "0.16.0-dev"
+source = "git+https://github.com/nLnetLabs/rpki-rs?branch=csr-ca-repo-trailing-slash#3baa8698d5fb49360a7f11995b7867f6d24ca9d1"
 dependencies = [
  "base64",
  "bcder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ rand                  = "^0.8"
 regex                 = { version = "1.5.5", optional = true, default_features = false, features = ["std"] }
 reqwest               = { version = "0.11", features = ["json"] }
 rpassword             = { version = "^5.0", optional = true }
-rpki                  = { version = "0.15.9", features = [ "ca", "compat", "rrdp" ] }
-# rpki                  = { version = "0.15.8-dev", git = "https://github.com/nLnetLabs/rpki-rs", features = [ "ca", "compat", "rrdp" ] }
+# rpki                  = { version = "0.15.9", features = [ "ca", "compat", "rrdp" ] }
+rpki                  = { version = "0.16.0-dev", git = "https://github.com/nLnetLabs/rpki-rs", branch = "csr-ca-repo-trailing-slash", features = [ "ca", "compat", "rrdp" ] }
 scrypt                = { version = "^0.6", optional = true, default-features = false }
 serde                 = { version = "^1.0", features = ["derive", "rc"] }
 serde_json            = "^1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name    = "krill"
 version = "0.13.0-dev"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.65"
 authors = [ "The NLnet Labs RPKI team <rpki-team@nlnetlabs.nl>" ]
 description = "Resource Public Key Infrastructure (RPKI) daemon"
 homepage = "https://www.nlnetlabs.nl/projects/rpki/krill/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ rand                  = "^0.8"
 regex                 = { version = "1.5.5", optional = true, default_features = false, features = ["std"] }
 reqwest               = { version = "0.11", features = ["json"] }
 rpassword             = { version = "^5.0", optional = true }
-# rpki                  = { version = "0.15.9", features = [ "ca", "compat", "rrdp" ] }
-rpki                  = { version = "0.16.0-dev", git = "https://github.com/nLnetLabs/rpki-rs", branch = "csr-ca-repo-trailing-slash", features = [ "ca", "compat", "rrdp" ] }
+rpki                  = { version = "0.16.0", features = [ "ca", "compat", "rrdp" ] }
+# rpki                  = { version = "0.16.0-dev", git = "https://github.com/nLnetLabs/rpki-rs", branch = "csr-ca-repo-trailing-slash", features = [ "ca", "compat", "rrdp" ] }
 scrypt                = { version = "^0.6", optional = true, default-features = false }
 serde                 = { version = "^1.0", features = ["derive", "rc"] }
 serde_json            = "^1.0"

--- a/src/commons/crypto/signing/dispatch/krillsigner.rs
+++ b/src/commons/crypto/signing/dispatch/krillsigner.rs
@@ -251,7 +251,7 @@ impl KrillSigner {
         let signed_and_encoded_csr = Csr::construct_rpki_ca(
             &self.router,
             key,
-            &base_repo.ca_repository(name_space).join(&[]).unwrap(), // force trailing slash
+            &base_repo.ca_repository(name_space),
             &base_repo.resolve(name_space, mft_file_name.as_ref()),
             base_repo.rpki_notify(),
         )

--- a/src/daemon/ca/keys.rs
+++ b/src/daemon/ca/keys.rs
@@ -97,6 +97,12 @@ impl CertifiedKey {
         new_resources: &ResourceSet,
         new_not_after: Time,
     ) -> bool {
+        // If we did not have a trailing slash for the id-ad-caRepository, then
+        // we should make a new CSR which will include it. See issue #1030.
+        if !self.incoming_cert().ca_repository().ends_with("/") {
+            return true;
+        }
+
         // If resources have changed, then we need to request a new certificate.
         let resources_diff = new_resources.difference(self.incoming_cert.resources());
 


### PR DESCRIPTION
nevermind.. the change I made that fxes this is actually in rpki-rs. Hold on..