### PR TITLE
Pkg for Debian 12 Bookworm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,6 +268,7 @@ depends = "$auto, passwd"
 [package.metadata.deb.variants.debian-bullseye]
 
 [package.metadata.deb.variants.debian-bookworm]
+depends = "$auto, passwd, libssl3"
 
 # Cross compilation variants:
 # Note: we have to specifiy dependencies manually because we don't run cargo-deb

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,6 +267,8 @@ depends = "$auto, passwd"
 
 [package.metadata.deb.variants.debian-bullseye]
 
+[package.metadata.deb.variants.debian-bookworm]
+
 # Cross compilation variants:
 # Note: we have to specifiy dependencies manually because we don't run cargo-deb
 # on the target platform and so it cannot determine the dependencies correctly

--- a/pkg/common/krill-debian-bookworm.krill.service
+++ b/pkg/common/krill-debian-bookworm.krill.service
@@ -1,0 +1,1 @@
+krill-debian-bullseye.krill.service

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -12,6 +12,7 @@ image:
   - "debian:stretch" # debian/9
   - "debian:buster" # debian/10
   - "debian:bullseye" # debian/11
+  - "debian:bookworm" # debian/12
   - "centos:7"
   - "rockylinux:8" # compatible with EOL centos:8
 target:

--- a/pkg/rules/packages-to-test.yml
+++ b/pkg/rules/packages-to-test.yml
@@ -12,6 +12,7 @@ image:
   - "debian:stretch" # debian/9
   - "debian:buster" # debian/10
   - "debian:bullseye" # debian/11
+  - "debian:bookworm" # debian/12
   - "centos:7"
   - "rockylinux:8" # compatible with EOL centos:8
 target:

--- a/pkg/rules/packages-to-test.yml
+++ b/pkg/rules/packages-to-test.yml
@@ -70,8 +70,14 @@ include:
     image: "debian:buster"
     target: "aarch64-unknown-linux-gnu"
 
-# For all target, exclude upgrade testing of the krillta package as no prior released version exists to
-# test upgrading from.
+# Exclude upgrade testing on Debian Bookworm as no prior released versions exist to upgrade from.
 exclude:
+  - pkg: "krill"
+    image: "debian:bookworm"
+    mode: "upgrade-from-published"
   - pkg: "krillta"
+    image: "debian:bookworm"
+    mode: "upgrade-from-published"
+  - pkg: "krillup"
+    image: "debian:bookworm"
     mode: "upgrade-from-published"


### PR DESCRIPTION
Successful packaging test run can be seen here: https://github.com/NLnetLabs/krill/actions/runs/6318680912