### PR TITLE
Let testbed automatically renew TA manifest and CRL #1095

### DIFF
--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -442,6 +442,18 @@ impl CaManager {
 
         Ok(())
     }
+
+    /// Renew the embedded testbed TA;
+    pub async fn ta_renew_testbed_ta(&self) -> KrillResult<()> {
+        if self.testbed_enabled() {
+            let proxy = self.get_trust_anchor_proxy().await?;
+            if !proxy.has_open_request() {
+                info!("Renew the testbed TA");
+                self.sync_ta_proxy_signer_if_possible().await?;
+            }
+        }
+        Ok(())
+    }
 }
 
 /// # CA instances and identity

--- a/src/daemon/mq.rs
+++ b/src/daemon/mq.rs
@@ -78,12 +78,13 @@ pub enum Task {
         revocation_request: RevocationRequest,
     },
 
-    // ------------- CA follow-up actions ------------------------
     SyncTrustAnchorProxySignerIfPossible,
 
     SuspendChildrenIfNeeded {
         ca_handle: CaHandle,
     },
+
+    RenewTestbedTa,
 
     RepublishIfNeeded,
     RenewObjectsIfNeeded,
@@ -135,6 +136,7 @@ impl Task {
             Task::RrdpUpdateIfNeeded => Ok(segment!("update_rrdp_if_needed").to_owned()),
             #[cfg(feature = "multi-user")]
             Task::SweepLoginCache => Ok(segment!("sweep_login_cache").to_owned()),
+            Task::RenewTestbedTa => Ok(segment!("renew_testbed_ta").to_owned()),
             Task::SyncTrustAnchorProxySignerIfPossible => Ok(segment!("sync_ta_proxy_signer").to_owned()),
             Task::QueueStartTasks => Ok(segment!("queue_start_tasks").to_owned()),
         }
@@ -150,6 +152,7 @@ impl fmt::Display for Task {
             Task::SyncParent {
                 ca_handle: ca, parent, ..
             } => write!(f, "synchronize CA '{}' with parent '{}'", ca, parent),
+            Task::RenewTestbedTa => write!(f, "renew testbed TA"),
             Task::SyncTrustAnchorProxySignerIfPossible => write!(f, "sync TA Proxy and Signer if both in this server."),
             Task::SuspendChildrenIfNeeded { ca_handle: ca } => {
                 write!(f, "verify if CA '{}' has children to suspend", ca)
@@ -556,6 +559,14 @@ pub fn in_minutes(mins: i64) -> Priority {
 
 pub fn in_hours(hours: i64) -> Priority {
     (Time::now() + chrono::Duration::hours(hours)).into()
+}
+
+pub fn in_days(days: i64) -> Priority {
+    (Time::now() + chrono::Duration::days(days)).into()
+}
+
+pub fn in_weeks(weeks: i64) -> Priority {
+    in_days(7 * weeks)
 }
 
 impl Ord for Priority {

--- a/src/ta/proxy.rs
+++ b/src/ta/proxy.rs
@@ -662,6 +662,10 @@ impl TrustAnchorProxy {
 }
 
 impl TrustAnchorProxy {
+    pub fn has_open_request(&self) -> bool {
+        self.open_signer_request.is_some()
+    }
+
     pub fn get_signer_request(
         &self,
         timing: TaTimingConfig,


### PR DESCRIPTION
Krill now schedules renewal if the testbed is enabled on startup and again every /2 of the next update period. This is implicitly tested because of tests that use the testbed setup.