### PR TITLE
Crash Krill if a fatal error is encountered by the task scheduler.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "kvx"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ba9dfb918a4c8e2f326d72a86891ace7c83d13c550e40c543d4cec57a9bf34"
+checksum = "dbd3053d98daca52860c508c21f32107c174396af5772ea54051110807d040cb"
 dependencies = [
  "kvx_macros",
  "kvx_types",
@@ -1148,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "kvx_macros"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87fdea2c4bf35291921c3a224b4cc0abf86cadb6818a4c09facefc755f2e3dd"
+checksum = "ed06dbcd44cd4f7af95fb5e0c8d020d14e64cbbd2ceacfdd9ed07f2e6d81e87f"
 dependencies = [
  "kvx_types",
  "proc-macro-error",
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "kvx_types"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0569372a25dd8a7177baf7fb0575709d1121f4ec829623c424150d653200f8d7"
+checksum = "fbff677c127336a6e93df7d54a036824312d4c1e9d165bd284e25b024cc83b06"
 dependencies = [
  "postgres",
  "postgres-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ jmespatch = { version = "^0.3", features = ["sync"], optional = true }
 kmip = { version = "0.4.2", package = "kmip-protocol", features = [
     "tls-with-openssl",
 ], optional = true }
-kvx = { version = "0.8.0", features = ["macros"] }
-# kvx                   = { version = "0.6.0", git = "https://github.com/nlnetlabs/kvx", features = ["macros"] }
+kvx = { version = "0.9.0", features = ["macros"] }
+# kvx = { version = "0.8.0", git = "https://github.com/nlnetlabs/kvx", branch = "schedule-without-finish", features = [ "macros"] }
 libflate = "^1"
 log = "^0.4"
 once_cell = { version = "^1.7.2", optional = true }

--- a/src/commons/error.rs
+++ b/src/commons/error.rs
@@ -151,6 +151,23 @@ impl From<Error> for ApiAuthError {
     }
 }
 
+//------------ FatalError --------------------------------------------------
+
+/// Wraps an error so horrible to contemplate that it should result in
+/// a server crash, as it would have lost its reason to live.
+/// 
+/// Note that we do not provide any From<Error> for this in an attempt
+/// to ensure that this is only ever used explicitly and when it is
+/// appropriate.
+#[derive(Debug)]
+pub struct FatalError(pub Error);
+
+impl fmt::Display for FatalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 //------------ Error -------------------------------------------------------
 
 #[derive(Debug)]

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -101,7 +101,9 @@ impl Scheduler {
                         Ok(result) => {
                             if let Err(e) = match result {
                                 TaskResult::Done => self.tasks.finish(&task_key),
-                                TaskResult::FollowUp(task, priority) => self.tasks.schedule(task, priority),
+                                TaskResult::FollowUp(task, priority) => {
+                                    self.tasks.schedule_and_finish_existing(task, priority)
+                                }
                                 TaskResult::Reschedule(priority) => self.tasks.reschedule(&task_key, priority),
                             } {
                                 error!("Error finishing / scheduling task {}. Krill will stop as there is no good way to recover from this. When Krill starts it will try to reschedule any missing tasks. Error was: {}", task_key, e);
@@ -220,7 +222,7 @@ impl Scheduler {
             let ca_handle = ca.handle();
             let ca_version = ca.version();
 
-            trace!("Adding tasks for CA {}, using jitter: {}", ca.handle(), use_jitter);
+            debug!("Adding tasks for CA {}, using jitter: {}", ca.handle(), use_jitter);
 
             for parent in ca.parents() {
                 self.tasks


### PR DESCRIPTION
Note that FatalError is only used for issues in using the storage. We can't recover from that.

If the storage issues are resolved and Krill restarts, it will also schedule any missing tasks. If that scheduling fails, then this is again a fatal error. This is by design. Someone should look at the issue.