### PR TITLE
Upgrade to kvx that uses locks outside of scope dir.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,8 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "kvx"
-version = "0.9.0"
-source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#90a0d0fbdc10fec4a94953cf91cd666c73bb484e"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ac98d13b1cc81be8b77286558858bb31f1d9bc643ec77142c1da4f47626a63"
 dependencies = [
  "kvx_macros",
  "kvx_types",
@@ -1147,8 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "kvx_macros"
-version = "0.9.0"
-source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#90a0d0fbdc10fec4a94953cf91cd666c73bb484e"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c4c60bb89a1b1420cddf8e5d81f35f7f38a64d23a96cac2c395488ef219c9ff"
 dependencies = [
  "kvx_types",
  "proc-macro-error",
@@ -1159,8 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "kvx_types"
-version = "0.9.0"
-source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#90a0d0fbdc10fec4a94953cf91cd666c73bb484e"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35cc4a6725d21de7d030b6cfccdd2e3b75d1ac351cbbe5b55938ae4bf71f0434"
 dependencies = [
  "postgres",
  "postgres-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 [[package]]
 name = "kvx"
 version = "0.9.0"
-source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#3bffd945ae80182097fade9c0cdeb3b8dca5e9a1"
+source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#90a0d0fbdc10fec4a94953cf91cd666c73bb484e"
 dependencies = [
  "kvx_macros",
  "kvx_types",
@@ -1148,7 +1148,7 @@ dependencies = [
 [[package]]
 name = "kvx_macros"
 version = "0.9.0"
-source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#3bffd945ae80182097fade9c0cdeb3b8dca5e9a1"
+source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#90a0d0fbdc10fec4a94953cf91cd666c73bb484e"
 dependencies = [
  "kvx_types",
  "proc-macro-error",
@@ -1160,7 +1160,7 @@ dependencies = [
 [[package]]
 name = "kvx_types"
 version = "0.9.0"
-source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#3bffd945ae80182097fade9c0cdeb3b8dca5e9a1"
+source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#90a0d0fbdc10fec4a94953cf91cd666c73bb484e"
 dependencies = [
  "postgres",
  "postgres-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,8 +1130,7 @@ dependencies = [
 [[package]]
 name = "kvx"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd3053d98daca52860c508c21f32107c174396af5772ea54051110807d040cb"
+source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#3bffd945ae80182097fade9c0cdeb3b8dca5e9a1"
 dependencies = [
  "kvx_macros",
  "kvx_types",
@@ -1149,8 +1148,7 @@ dependencies = [
 [[package]]
 name = "kvx_macros"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed06dbcd44cd4f7af95fb5e0c8d020d14e64cbbd2ceacfdd9ed07f2e6d81e87f"
+source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#3bffd945ae80182097fade9c0cdeb3b8dca5e9a1"
 dependencies = [
  "kvx_types",
  "proc-macro-error",
@@ -1162,8 +1160,7 @@ dependencies = [
 [[package]]
 name = "kvx_types"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbff677c127336a6e93df7d54a036824312d4c1e9d165bd284e25b024cc83b06"
+source = "git+https://github.com/nlnetlabs/kvx?branch=lockfiles-outside-scope#3bffd945ae80182097fade9c0cdeb3b8dca5e9a1"
 dependencies = [
  "postgres",
  "postgres-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,10 @@ jmespatch = { version = "^0.3", features = ["sync"], optional = true }
 kmip = { version = "0.4.2", package = "kmip-protocol", features = [
     "tls-with-openssl",
 ], optional = true }
-kvx = { version = "0.9.0", features = ["macros"] }
-# kvx = { version = "0.8.0", git = "https://github.com/nlnetlabs/kvx", branch = "schedule-without-finish", features = [ "macros"] }
+# kvx = { version = "0.9.0", features = ["macros"] }
+kvx = { version = "0.9.0", git = "https://github.com/nlnetlabs/kvx", branch = "lockfiles-outside-scope", features = [
+    "macros",
+] }
 libflate = "^1"
 log = "^0.4"
 once_cell = { version = "^1.7.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,10 @@ jmespatch = { version = "^0.3", features = ["sync"], optional = true }
 kmip = { version = "0.4.2", package = "kmip-protocol", features = [
     "tls-with-openssl",
 ], optional = true }
-# kvx = { version = "0.9.0", features = ["macros"] }
-kvx = { version = "0.9.0", git = "https://github.com/nlnetlabs/kvx", branch = "lockfiles-outside-scope", features = [
-    "macros",
-] }
+kvx = { version = "0.9.1", features = ["macros"] }
+# kvx = { version = "0.9.0", git = "https://github.com/nlnetlabs/kvx", branch = "lockfiles-outside-scope", features = [
+#     "macros",
+# ] }
 libflate = "^1"
 log = "^0.4"
 once_cell = { version = "^1.7.2", optional = true }


### PR DESCRIPTION
We need this, otherwise getting an unknown CA would result in creating a scope for it.