### PR TITLE
Pin Python to version compatible with PyKMIP.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        # Pin to Python 3.11 because 3.12 removes the ssl.wrap_socket()
+        # function which PyKMIP uses.
+        python-version: '3.11'
 
     - name: Install PyKMIP
       uses: BSFishy/pip-action@v1


### PR DESCRIPTION
Work around the backward incompatible Python removal of deprecated `ssl.wrap_socket()` function which breaks PyKMIP (as there is no newer version of PyKMIP to upgrade to which would follow the change in Python).

From: https://docs.python.org/3/whatsnew/3.12.html#ssl
> Remove the ssl.wrap_socket() function, deprecated in Python 3.7