### PR TITLE
Allow overriding the TA manifest number.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .cargo
 .idea/
+.locks
 .vscode/
 .DS_Store
 data/

--- a/src/commons/api/import.rs
+++ b/src/commons/api/import.rs
@@ -128,7 +128,9 @@ where
 pub struct ImportTa {
     pub ta_aia: uri::Rsync,
     pub ta_uri: uri::Https,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ta_key_pem: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ta_mft_nr_override: Option<u64>,
 }
 

--- a/src/commons/api/import.rs
+++ b/src/commons/api/import.rs
@@ -37,10 +37,9 @@ pub struct Structure {
 }
 
 impl Structure {
-    pub fn new(
+    pub fn for_testbed(
         ta_aia: uri::Rsync,
         ta_uri: uri::Https,
-        ta_key_pem: Option<String>,
         publication_server_uris: PublicationServerUris,
         cas: Vec<ImportCa>,
     ) -> Self {
@@ -48,7 +47,8 @@ impl Structure {
             ta: Some(ImportTa {
                 ta_aia,
                 ta_uri,
-                ta_key_pem,
+                ta_key_pem: None,
+                ta_mft_nr_override: None,
             }),
             publication_server: Some(publication_server_uris),
             cas,
@@ -129,11 +129,12 @@ pub struct ImportTa {
     pub ta_aia: uri::Rsync,
     pub ta_uri: uri::Https,
     pub ta_key_pem: Option<String>,
+    pub ta_mft_nr_override: Option<u64>,
 }
 
 impl ImportTa {
-    pub fn unpack(self) -> (uri::Rsync, Vec<uri::Https>, Option<String>) {
-        (self.ta_aia, vec![self.ta_uri], self.ta_key_pem)
+    pub fn unpack(self) -> (uri::Rsync, Vec<uri::Https>, Option<String>, Option<u64>) {
+        (self.ta_aia, vec![self.ta_uri], self.ta_key_pem, self.ta_mft_nr_override)
     }
 }
 

--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -332,6 +332,7 @@ impl CaManager {
                 tal_https,
                 tal_rsync,
                 private_key_pem,
+                ta_mft_nr_override: None,
                 timing: self.config.ta_timing,
                 signer: self.signer.clone(),
             };
@@ -1243,7 +1244,7 @@ impl CaManager {
         }
     }
 
-    /// Synchronise the Trust Anchor Proxy with the Signer - it the Signer is local.
+    /// Synchronise the Trust Anchor Proxy with the Signer - if the Signer is local.
     pub async fn sync_ta_proxy_signer_if_possible(&self) -> KrillResult<()> {
         let ta_handle = ta_handle();
 
@@ -1262,6 +1263,7 @@ impl CaManager {
                     &ta_handle,
                     signed_request,
                     self.config.ta_timing,
+                    None, // do not override next manifest number
                     self.signer.clone(),
                     &self.system_actor,
                 );

--- a/src/daemon/ca/publishing.rs
+++ b/src/daemon/ca/publishing.rs
@@ -1016,7 +1016,7 @@ impl KeyObjectSet {
             self.revision.next_update.to_rfc3339()
         );
 
-        self.revision.next(timing.publish_next());
+        self.revision.next(timing.publish_next(), None);
 
         self.revocations.remove_expired();
         let signing_key = self.signing_cert.key_identifier();
@@ -1101,8 +1101,12 @@ impl ObjectSetRevision {
         }
     }
 
-    pub fn next(&mut self, next_update: Time) {
-        self.number += 1;
+    pub fn next(&mut self, next_update: Time, mft_number_override: Option<u64>) {
+        if let Some(forced_next) = mft_number_override {
+            self.number = forced_next;
+        } else {
+            self.number += 1;
+        }
         self.this_update = Time::five_minutes_ago();
         self.next_update = next_update;
     }

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -240,10 +240,9 @@ impl KrillServer {
                     }
                 }
 
-                let startup_structure = api::import::Structure::new(
+                let startup_structure = api::import::Structure::for_testbed(
                     testbed.ta_aia().clone(),
                     testbed.ta_uri().clone(),
-                    None,
                     testbed.publication_server_uris(),
                     import_cas,
                 );
@@ -595,7 +594,7 @@ impl KrillServer {
         if let Some(import_ta) = structure.ta.clone() {
             if self.config.ta_proxy_enabled() && self.config.ta_signer_enabled() {
                 info!("Creating embedded Trust Anchor");
-                let (ta_aia, ta_uris, ta_key_pem) = import_ta.unpack();
+                let (ta_aia, ta_uris, ta_key_pem, _ta_mft_nr_override) = import_ta.unpack();
                 self.ca_manager
                     .ta_init_fully_embedded(ta_aia, ta_uris, ta_key_pem, &self.repo_manager, &actor)
                     .await?;

--- a/src/ta/common.rs
+++ b/src/ta/common.rs
@@ -70,8 +70,17 @@ pub struct TrustAnchorObjects {
 
 impl TrustAnchorObjects {
     /// Creates a new TrustAnchorObjects for the signing certificate.
-    pub fn create(signing_cert: &ReceivedCert, next_update_weeks: i64, signer: &KrillSigner) -> KrillResult<Self> {
-        let revision = ObjectSetRevision::new(1, Self::this_update(), Self::next_update(next_update_weeks));
+    pub fn create(
+        signing_cert: &ReceivedCert,
+        initial_number: u64,
+        next_update_weeks: i64,
+        signer: &KrillSigner,
+    ) -> KrillResult<Self> {
+        let revision = ObjectSetRevision::new(
+            initial_number,
+            Self::this_update(),
+            Self::next_update(next_update_weeks),
+        );
         let key_identifier = signing_cert.key_identifier();
         let base_uri = signing_cert.ca_repository().clone();
         let revocations = Revocations::default();
@@ -104,9 +113,11 @@ impl TrustAnchorObjects {
         &mut self,
         signing_cert: &ReceivedCert,
         next_update_weeks: i64,
+        mft_number_override: Option<u64>,
         signer: &KrillSigner,
     ) -> KrillResult<()> {
-        self.revision.next(Self::next_update(next_update_weeks));
+        self.revision
+            .next(Self::next_update(next_update_weeks), mft_number_override);
 
         let signing_key = signing_cert.key_identifier();
 

--- a/src/ta/mod.rs
+++ b/src/ta/mod.rs
@@ -106,6 +106,7 @@ mod tests {
                     tal_https: tal_https.clone(),
                     tal_rsync: tal_rsync.clone(),
                     private_key_pem: Some(import_key_pem.to_string()),
+                    ta_mft_nr_override: Some(42),
                     timing,
                     signer: signer.clone(),
                 },
@@ -119,9 +120,9 @@ mod tests {
             proxy = ta_proxy_store.command(add_signer_cmd).unwrap();
 
             // The initial signer starts off with a TA certificate
-            // and a CRL and manifest with revision number 1.
+            // and a CRL and manifest with revision number 42, as specified in the init.
             let ta_objects = proxy.get_trust_anchor_objects().unwrap();
-            assert_eq!(ta_objects.revision().number(), 1);
+            assert_eq!(ta_objects.revision().number(), 42);
 
             let ta_cert_details = proxy.get_ta_details().unwrap();
             assert_eq!(ta_cert_details.tal().uris(), &tal_https);
@@ -139,6 +140,7 @@ mod tests {
                 &signer_handle,
                 signed_request,
                 timing,
+                Some(55), // override the next manifest number again
                 signer,
                 &actor,
             );
@@ -153,9 +155,9 @@ mod tests {
                 .unwrap();
 
             // The TA should have published again, the revision used for manifest and crl will
-            // have been updated.
+            // have been updated to the overridden number.
             let ta_objects = proxy.get_trust_anchor_objects().unwrap();
-            assert_eq!(ta_objects.revision().number(), 2);
+            assert_eq!(ta_objects.revision().number(), 55);
 
             // We still need to test some higher order functions:
             // - add child


### PR DESCRIPTION
Allows overriding the initial manifest number, either by specifying `--initial_manifest_number` if the CLI is used to initialise the TA signer, or by including `ta_mft_nr_override: #nr` in the ImportTa JSON.

Allows overriding the TA manifest number when signing a TA proxy request by specifying `--ta_mft_number_override` in the CLI.
