### PR TITLE
Fix locking when downloading RIS dump files (#1177)

### DIFF
--- a/src/commons/bgp/analyser.rs
+++ b/src/commons/bgp/analyser.rs
@@ -43,29 +43,35 @@ impl BgpAnalyser {
     }
 
     pub async fn update(&self) -> Result<bool, BgpAnalyserError> {
-        if let Some(loader) = &self.dump_loader {
+        let loader = match self.dump_loader.as_ref() {
+            Some(loader) => loader,
+            None => return Ok(false)
+        };
+        if let Some(last_time) = self.seen.read().await.last_checked() {
+            if (last_time + Duration::minutes(BGP_RIS_REFRESH_MINUTES))
+                > Time::now()
             {
-                let seen = self.seen.read().await;
-                if let Some(last_time) = seen.last_checked() {
-                    if (last_time + Duration::minutes(BGP_RIS_REFRESH_MINUTES)) > Time::now() {
-                        trace!("Will not check BGP Ris Dumps until the refresh interval has passed");
-                        return Ok(false); // no need to update yet
-                    }
-                }
+                trace!(
+                    "Will not check BGP RIS dumps until the \
+                    refresh interval has passed"
+                );
+                return Ok(false); // no need to update yet
             }
-            let announcements = loader.download_updates().await?;
-            let mut seen = self.seen.write().await;
-            if seen.equivalent(&announcements) {
-                debug!("BGP Ris Dumps unchanged");
-                seen.update_checked();
-                Ok(false)
-            } else {
-                info!("Updated announcements ({}) based on BGP Ris Dumps", announcements.len());
-                seen.update(announcements);
-                Ok(true)
-            }
-        } else {
+        }
+        let announcements = loader.download_updates().await?;
+        let mut seen = self.seen.write().await;
+        if seen.equivalent(&announcements) {
+            debug!("BGP Ris Dumps unchanged");
+            seen.update_checked();
             Ok(false)
+        }
+        else {
+            info!(
+                "Updated announcements ({}) based on BGP Ris Dumps",
+                announcements.len()
+            );
+            seen.update(announcements);
+            Ok(true)
         }
     }
 
@@ -352,10 +358,11 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn download_ris_dumps() {
-        let bgp_ris_dump_v4_uri = "http://www.ris.ripe.net/dumps/riswhoisdump.IPv4.gz";
-        let bgp_ris_dump_v6_uri = "http://www.ris.ripe.net/dumps/riswhoisdump.IPv6.gz";
-
-        let analyser = BgpAnalyser::new(true, bgp_ris_dump_v4_uri, bgp_ris_dump_v6_uri);
+        let analyser = BgpAnalyser::new(
+            true,
+            "http://www.ris.ripe.net/dumps/riswhoisdump.IPv4.gz",
+            "http://www.ris.ripe.net/dumps/riswhoisdump.IPv6.gz",
+        );
 
         assert!(analyser.seen.read().await.is_empty());
         assert!(analyser.seen.read().await.last_checked().is_none());


### PR DESCRIPTION
This should fix the issue observed in #1177.

The code locked the 'seen' announcements while downloading new RIR dump files. This prevented read access to the announcement during download. This change postpones getting the write lock until after the download is completed, so it only keeps it for the shortest possible time.

