### PR TITLE
Upgrade pkg workflow from Ploutos v6 to v7.

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   package:
     # See: https://github.com/NLnetLabs/ploutos
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v6
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "krill"
-version = "0.14.4"
+version = "0.14.5-dev"
 dependencies = [
  "backoff",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Note: some of these values are also used when building Debian packages below.
 name = "krill"
-version = "0.14.4"
+version = "0.14.5-dev"
 edition = "2018"
 rust-version = "1.65"
 authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ in this [blog post](https://blog.nlnetlabs.nl/testing-the-waters-with-krill/).
 
 # Changelog
 
+## Unreleased next version
+
 ## 0.14.4 'A Flock of Krill'
 
 This release fixes the following issues:


### PR DESCRIPTION
A successful run of the upgraded `pkg` workflow can be seen here:

  https://github.com/NLnetLabs/krill/actions/runs/8605626059

Summary of changes in Ploutos since the current v6.3.1 that Krill is using now:

[v7.3.0](https://github.com/NLnetLabs/ploutos/releases/tag/v7.3.0)

This release contains the following changes:

- Expose optional extra_cargo_deb_args arg for package_build_rules (https://github.com/NLnetLabs/ploutos/pull/100)

---

[v7.2.5](https://github.com/NLnetLabs/ploutos/releases/tag/v7.2.5)

This bug fix release contains the following changes:

- FIX: rpmlint: command not found (https://github.com/NLnetLabs/ploutos/issues/98).

---

[v7.2.4](https://github.com/NLnetLabs/ploutos/releases/tag/v7.2.4)

- Bump actions/github-script from 6 to 7 (https://github.com/NLnetLabs/ploutos/pull/93)
- Bump docker/setup-qemu-action from 2 to 3 (https://github.com/NLnetLabs/ploutos/pull/94)

---

[v7.2.3](https://github.com/NLnetLabs/ploutos/releases/tag/v7.2.3)

This bug fix release contains the following changes:

- FIX: AttributeError: module 'tarfile' has no attribute xxx (https://github.com/NLnetLabs/ploutos/pull/90)
- Bump docker/setup-buildx-action from 2 to 3 (https://github.com/NLnetLabs/ploutos/pull/87)
- Bump docker/login-action from 2 to 3 (https://github.com/NLnetLabs/ploutos/pull/86)
- Bump docker/build-push-action from 4 to 5 (https://github.com/NLnetLabs/ploutos/pull/85)
- Bump docker/metadata-action from 4 to 5 (https://github.com/NLnetLabs/ploutos/pull/84)

---

[v7.2.1](https://github.com/NLnetLabs/ploutos/releases/tag/v7.2.1)

This release contains the following changes:

- Wait at most (approximately) 60 seconds for cloud-init to complete in the `pkg-test` phase, instead of looping forever. (fixes #77)

---

[v7.1.1](https://github.com/NLnetLabs/ploutos/releases/tag/v7.1.1)

This bug fix release contains the following changes:

- Use `ubuntu-22.04` as the GitHub host runner O/S version for all jobs instead of `ubuntu-latest` for reproducible behaviour (otherwise when `ubuntu-latest` is updated to point to a newer O/S release something could break) (part of #50).
- Work around error 'The image used by this instance requires a CGroupV1 host system' when testing packages on CentOS 7 or Ubuntu Xenial, introduced in v7.1.0, that happens when using LXD on an `ubuntu-22.04` host, by forcing the use of an `ubuntu-20.04` host instead (part of #50). 

---

[v7.1.0](https://github.com/NLnetLabs/ploutos/releases/tag/v7.1.0)

This release contains the following changes:

- Adds support for a new `runs_on` and `cross_runs_on` workflow input for controlling which type of GitHub runner Ploutos jobs run on (in particular this allows for self-hosted runners to be used).
- Run all jobs on `ubuntu-latest` rather than a mix of Ubuntu versions (partially related to #50).

---

[v7.0.1](https://github.com/NLnetLabs/ploutos/releases/tag/v7.0.1)

This bug fix release contains the following changes:

- Upgrade cargo-generate-rpm (#69) from v0.10.1 to v0.10.2 to fix an [upstream regression](https://github.com/cat-in-136/cargo-generate-rpm/issues/69) which accidentally dropped support for `metadata.generate-rpm.summary` in cargo-generate-rpm v0.9.0, which was then inherited by Ploutos v7.0.0.

If you created RPMs using Ploutos prior to v7.0.0 and were using the `package.metadata.generate-rpm.summary` key in `Cargo.toml` then Ploutos v7.0.0 would have silently ignored your `summary` setting. This releases restores the original behaviour.

---

[v7.0.0](https://github.com/NLnetLabs/ploutos/releases/tag/v7.0.0)

This breaking release contains the following changes:

- Add support for Cargo virtual manifests (#67), including two new Ploutos settings: `manifest_dir` and `workspace_package` (see the updated docs for more information)
- Upgraded tools used to versions compatible with Cargo workspaces:
  - Upgrade [cargo-deb](https://crates.io/crates/cargo-deb) from 1.38.4 to 1.42.2.
  - Upgrade [cargo-generate-rpm](https://crates.io/crates/cargo-generate-rpm) from 0.8.0 to 0.10.1.
  - Upgrade [toml-cli](https://crates.io/crates/toml-cli) from 0.2.0 to 0.2.3.