### PR TITLE
Support listing child CAs

### DIFF
--- a/src/commons/api/ca.rs
+++ b/src/commons/api/ca.rs
@@ -1447,6 +1447,16 @@ impl From<ChildStatus> for Option<ChildExchange> {
     }
 }
 
+//------------ ChildInfo -------------------------------------------------
+
+#[derive(serde::Serialize)]
+pub struct ChildInfo {
+    #[serde(flatten)]
+    pub child: ChildCaInfo,
+    #[serde(flatten)]
+    pub status: Option<ChildStatus>,
+}
+
 //------------ ChildExchange -------------------------------------------------
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/commons/error.rs
+++ b/src/commons/error.rs
@@ -155,7 +155,7 @@ impl From<Error> for ApiAuthError {
 
 /// Wraps an error so horrible to contemplate that it should result in
 /// a server crash, as it would have lost its reason to live.
-/// 
+///
 /// Note that we do not provide any From<Error> for this in an attempt
 /// to ensure that this is only ever used explicitly and when it is
 /// appropriate.
@@ -484,7 +484,7 @@ impl fmt::Display for Error {
             Error::AspaCustomerAsProvider(_ca, asn) => write!(f, "ASPA for customer AS '{}' cannot have that AS as provider", asn),
             Error::AspaProvidersDuplicates(_ca, asn) => write!(f, "ASPA for customer AS '{}' cannot have duplicate providers", asn),
             Error::AspaCustomerUnknown(_ca, asn) => write!(f, "No current ASPA exists for customer AS '{}'", asn),
-            
+
             //-----------------------------------------------------------------
             // BGPSec
             //-----------------------------------------------------------------

--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -652,6 +652,15 @@ impl CaManager {
         ca.get_child(child).map(|details| details.clone().into())
     }
 
+    pub async fn ca_show_children(&self, ca: &CaHandle) -> KrillResult<HashMap<ChildHandle, ChildCaInfo>> {
+        trace!("Finding details for all CAs under parent: {}", ca);
+        let ca = self.get_ca(ca).await?;
+        Ok(ca
+            .children()
+            .filter_map(|ch| ca.get_child(ch).ok().map(|child| (ch.clone(), child.clone().into())))
+            .collect())
+    }
+
     /// Export a child. Fails if:
     /// - the child does not exist
     /// - the child has no received certificate

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -487,6 +487,11 @@ impl KrillServer {
         self.ca_manager.ca_show_child(ca, child).await
     }
 
+    /// Show details for all children under the CA.
+    pub async fn ca_children_show(&self, ca: &CaHandle) -> KrillResult<HashMap<ChildHandle, ChildCaInfo>> {
+        self.ca_manager.ca_show_children(ca).await
+    }
+
     /// Export a child under the CA.
     pub async fn api_ca_child_export(&self, ca: &CaHandle, child: &ChildHandle) -> KrillResult<ExportChild> {
         self.ca_manager.ca_child_export(ca, child).await


### PR DESCRIPTION
I'm attempting to add a children tab to the web ui. This route is needed for that. Listing all children seems to need data from two different places, so I added a new model to merge them together. Perhaps somewhat hacky but it works.