### PR TITLE
Make cryptoki-sys optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ openidconnect = { version = "^2.0.0", optional = true, default_features = false 
 openssl = { version = "^0.10", features = ["v110"] }
 oso = { version = "^0.12", optional = true, default_features = false }
 cryptoki = { version = "^0.3", optional = true }
-cryptoki-sys = "=0.1.4" # pin cryptoki-sys because of compilation issues on various systems
+cryptoki-sys = { version = "=0.1.4", optional = true } # pin cryptoki-sys because of compilation issues on various systems
 r2d2 = { version = "0.8.9", optional = true }
 rand = "^0.8"
 regex = { version = "1.5.5", optional = true, default_features = false, features = [


### PR DESCRIPTION
cryptoki itself is marked optional and only needed for hsm builds. cryptoki-sys is still compiled unconditionally, also in builds disabling the hsm feature. This causes build failures if cryptoki isn't installed or on systems unsupported by cryptoki-sys's build script.