### PR TITLE
Switch to rpki-rs git main to pull in fix for empty CRLs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,8 +2127,7 @@ dependencies = [
 [[package]]
 name = "rpki"
 version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7102b9a305889ef344e7b010dd256a53055ea1d436a7414277db053000f250ad"
+source = "git+https://github.com/nLnetLabs/rpki-rs#bdf9a3287badd1ab3929d962d6b88c851e6eaaa2"
 dependencies = [
  "base64 0.22.1",
  "bcder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,12 +54,8 @@ regex = { version = "1.5.5", optional = true, default_features = false, features
 ] }
 reqwest = { version = "0.11", features = ["json"] }
 rpassword = { version = "^5.0", optional = true }
-rpki = { version = "0.18.0", features = ["ca", "compat", "rrdp"] }
-# rpki = { version = "0.17.3-dev", git = "https://github.com/nLnetLabs/rpki-rs", branch = "ring-0.17", features = [
-#     "ca",
-#     "compat",
-#     "rrdp",
-# ] }
+#rpki = { version = "0.18.0", features = ["ca", "compat", "rrdp"] }
+rpki = { git = "https://github.com/nLnetLabs/rpki-rs", features = [ "ca", "compat", "rrdp" ] }
 scrypt = { version = "^0.6", optional = true, default-features = false }
 serde = { version = "^1.0", features = ["derive", "rc"] }
 serde_json = "^1.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ New
 Bug fixes
 
 * Prevent empty RRDP delta lists to be produced. ([#1181])
+* Correctly encode empty revocation lists in CRLs. (via [rpki-rs#295])
 
 Other changes
 
@@ -23,6 +24,7 @@ Other changes
 [#1178]: https://github.com/NLnetLabs/krill/pull/1178
 [#1181]: https://github.com/NLnetLabs/krill/pull/1181
 [#1198]: https://github.com/NLnetLabs/krill/pull/1198
+[rpki-rs#295]: https://github.com/NLnetLabs/rpki-rs/pull/295
 
 
 ## Previous releases

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,12 +16,15 @@ Bug fixes
 
 * Prevent empty RRDP delta lists to be produced. ([#1181])
 * Correctly encode empty revocation lists in CRLs. (via [rpki-rs#295])
+* Allow read access to the RIS dump while downloading a new dump.
+  ([#1179])
 
 Other changes
 
 * The minimum supported Rust version is now 1.70.0. ([#1198])
 
 [#1178]: https://github.com/NLnetLabs/krill/pull/1178
+[#1179]: https://github.com/NLnetLabs/krill/pull/1179
 [#1181]: https://github.com/NLnetLabs/krill/pull/1181
 [#1198]: https://github.com/NLnetLabs/krill/pull/1198
 [rpki-rs#295]: https://github.com/NLnetLabs/rpki-rs/pull/295


### PR DESCRIPTION
This is just a reminder to require the latest release of rpki-rs when we release Krill.

Fixes #1195 via [rpki-rs#295](https://github.com/NLnetLabs/rpki-rs/pull/295).