### PR TITLE
Don’t try to revoke child keys for non-existing resource classes.

### DIFF
--- a/src/daemon/ca/certauth.rs
+++ b/src/daemon/ca/certauth.rs
@@ -1083,7 +1083,7 @@ impl CertAuth {
     ) -> KrillResult<Vec<CertAuthEvent>> {
         let (child_rcn, key) = request.unpack();
 
-        if !self.resources.contains_key(&rcn) {
+        if !self.resources.contains_key(&child_rcn) {
             // This request is for a resource class we don't have. We should
             // not get such requests but telling this to a child may confuse
             // them more, so just return with an empty vec of events - there

--- a/src/daemon/ca/certauth.rs
+++ b/src/daemon/ca/certauth.rs
@@ -1083,6 +1083,15 @@ impl CertAuth {
     ) -> KrillResult<Vec<CertAuthEvent>> {
         let (child_rcn, key) = request.unpack();
 
+        if !self.resources.contains_key(&rcn) {
+            // This request is for a resource class we don't have. We should
+            // not get such requests but telling this to a child may confuse
+            // them more, so just return with an empty vec of events - there
+            // is no work to do - and ensure that the child just gets a
+            // confirmation where this is called.
+            return Ok(vec![])
+        }
+
         let child = self.get_child(&child_handle)?;
         let my_rcn = child.parent_name_for_rcn(&child_rcn);
 


### PR DESCRIPTION
This PR adds a check whether the resource class exists before applying a “child revoke key” command. This fixes a crash where revoking a parent removed a resource class which then lead to children revoking keys for that now non-existing resource class. The change will cause to simply send an OK response to such requests.
