### PR TITLE
Fix an infinite recursion in PKCS11 error conversion.

### DIFF
--- a/src/commons/crypto/signing/signers/pkcs11/signer.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/signer.rs
@@ -1346,7 +1346,7 @@ impl From<Pkcs11Error> for SignerError {
 
 impl From<ProbeError<SignerError>> for InternalConnError {
     fn from(err: ProbeError<SignerError>) -> Self {
-        err.into()
+        SignerError::from(err).into()
     }
 }
 


### PR DESCRIPTION
This PR fixes a potential endless recursion when converting an error in the  PKCS11 signer.