### PR TITLE
Fix Clippy warnings and enable Clippy in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
       with:
         rust-version: ${{ matrix.rust }}
     - if: matrix.rust == 'stable' && matrix.args == '--features all'
-      run: cargo clippy -- -D warnings
-    - run: cargo build --verbose ${{ matrix.args }} --locked
-    - run: cargo test --verbose ${{ matrix.args }} -- --test-threads=1 2>&1
+      run: cargo clippy ${{ matrix.args }} -- -D warnings
+    - run: cargo build ${{ matrix.args }} --locked
+    - run: cargo test ${{ matrix.args }} -- --test-threads=1 2>&1
 
   pykmip-test:
     name: pykmip-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
-    - if: matrix.rust == 'stable' && matrix.args == "--features all"
+    - if: matrix.rust == 'stable' && matrix.args == '--features all'
       run: cargo clippy -- -D warnings
     - run: cargo build --verbose ${{ matrix.args }} --locked
     - run: cargo test --verbose ${{ matrix.args }} -- --test-threads=1 2>&1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
       uses: hecrj/setup-rust-action@v1
       with:
         rust-version: ${{ matrix.rust }}
+    - if: matrix.rust == 'stable' && matrix.args == "--features all"
+      run: cargo clippy -- -D warnings
     - run: cargo build --verbose ${{ matrix.args }} --locked
     - run: cargo test --verbose ${{ matrix.args }} -- --test-threads=1 2>&1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,13 @@ kvx             = { version = "0.9.3", features = ["macros"] }
 libflate        = "2.1.0"
 log             = "0.4"
 once_cell       = { version = "1.7.2", optional = true }
-openidconnect   = { version = "2.0.0", optional = true, default_features = false }
+openidconnect   = { version = "2.0.0", optional = true, default-features = false }
 openssl         = { version = "0.10", features = ["v110"] }
-oso             = { version = "0.12", optional = true, default_features = false }
+oso             = { version = "0.12", optional = true, default-features = false }
 pin-project-lite = "0.2.4"
 r2d2            = { version = "0.8.9", optional = true }
 rand            = "0.8"
-regex           = { version = "1.5.5", optional = true, default_features = false, features = [ "std" ] }
+regex           = { version = "1.5.5", optional = true, default-features = false, features = [ "std" ] }
 reqwest         = { version = "0.12.5", features = ["json"] }
 rpassword       = { version = "7.3.1", optional = true }
 rpki            = { version = "0.18.4", features = ["ca", "compat", "rrdp"] }

--- a/src/commons/api/ca.rs
+++ b/src/commons/api/ca.rs
@@ -1145,7 +1145,7 @@ impl ParentStatus {
     pub fn set_entitlements(&mut self, uri: ServiceUri, entitlements: &ResourceClassListResponse) {
         self.set_last_updated(uri);
 
-        self.classes = entitlements.classes().clone();
+        self.classes.clone_from(entitlements.classes());
 
         let mut all_resources = ResourceSet::default();
         for class in &self.classes {

--- a/src/commons/api/import.rs
+++ b/src/commons/api/import.rs
@@ -223,7 +223,7 @@ impl fmt::Display for ImportChild {
         writeln!(
             f,
             "Id Key:       {}",
-            self.id_cert.public_key().key_identifier().to_string()
+            self.id_cert.public_key().key_identifier()
         )?;
         writeln!(f, "Resources:    {}", self.resources)?;
         if let Some(class_name) = &self.issued_cert.class_name {

--- a/src/commons/eventsourcing/store.rs
+++ b/src/commons/eventsourcing/store.rs
@@ -184,13 +184,16 @@ where
     /// This will:
     /// - Wait for a lock for the latest aggregate for this command.
     /// - Call the A::process_command function
+    ///
     /// on success:
     ///   - call pre-save listeners with events
     ///   - save command and events
     ///   - call post-save listeners with events
     ///   - return aggregate
+    ///
     /// on no-op (empty event list):
     ///   - do not save anything, return aggregate
+    ///
     /// on error:
     ///   - save command and error, return error
     pub fn command(&self, cmd: A::Command) -> Result<Arc<A>, A::Error> {

--- a/src/daemon/auth/common/session.rs
+++ b/src/daemon/auth/common/session.rs
@@ -69,7 +69,7 @@ impl ClientSession {
     }
 
     pub fn get_secret(&self, key: &str) -> Option<&String> {
-        self.secrets.get(&key.to_string())
+        self.secrets.get(key)
     }
 }
 

--- a/src/daemon/auth/providers/openid_connect/provider.rs
+++ b/src/daemon/auth/providers/openid_connect/provider.rs
@@ -854,7 +854,7 @@ impl OpenIDConnectAuthProvider {
 
     fn verify_csrf_token(&self, state: String, csrf_token_hash: String) -> KrillResult<()> {
         let request_csrf_hash = sha256(state.as_bytes());
-        match URL_BASE64_ENGINE.decode(&csrf_token_hash) {
+        match URL_BASE64_ENGINE.decode(csrf_token_hash) {
             Ok(cookie_csrf_hash) if request_csrf_hash == cookie_csrf_hash => Ok(()),
             Ok(cookie_csrf_hash) => Err(Self::internal_error(
                 "OpenID Connect: CSRF token mismatch",

--- a/src/daemon/ca/certauth.rs
+++ b/src/daemon/ca/certauth.rs
@@ -931,6 +931,7 @@ impl CertAuth {
     /// = the csr is invalid,
     /// = the limit exceeds the child allocation,
     /// = the signer throws up..
+    #[allow(clippy::too_many_arguments)]
     fn child_certify_from_command(
         &self,
         child_handle: ChildHandle,
@@ -947,6 +948,7 @@ impl CertAuth {
         self.child_certify(child_handle, child.resources(), my_rcn, csr_info, limit, config, signer)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn child_certify(
         &self,
         child_handle: ChildHandle,

--- a/src/daemon/ca/status.rs
+++ b/src/daemon/ca/status.rs
@@ -95,6 +95,7 @@ impl StatusStore {
     /// issues parsing data then default values are used - this data is not critical
     /// so any missing, corrupted, or no longer supported data format - can be ignored.
     /// It will get updated with new status values as Krill is running.
+    #[allow(clippy::manual_unwrap_or_default)] // False positive in nightly
     fn load_full_status(&self, ca: &CaHandle) -> KrillResult<()> {
         let repo: RepoStatus = match self.store.get(&Self::repo_status_key(ca)) {
             Ok(Some(status)) => status,

--- a/src/daemon/krillserver.rs
+++ b/src/daemon/krillserver.rs
@@ -852,7 +852,7 @@ impl KrillServer {
     /// Returns the parent contact for a CA and parent, or NONE if either the CA or the parent cannot be found.
     pub async fn ca_my_parent_contact(&self, ca: &CaHandle, parent: &ParentHandle) -> KrillResult<ParentCaContact> {
         let ca = self.ca_manager.get_ca(ca).await?;
-        ca.parent(parent).map(|p| p.clone())
+        ca.parent(parent).cloned()
     }
 
     /// Returns the history for a CA.

--- a/src/pubd/repository.rs
+++ b/src/pubd/repository.rs
@@ -1605,7 +1605,7 @@ impl RepositoryAccessProxy {
     }
 
     pub fn get_publisher(&self, name: &PublisherHandle) -> KrillResult<Publisher> {
-        self.read()?.get_publisher(name).map(|p| p.clone())
+        self.read()?.get_publisher(name).cloned()
     }
 
     pub fn add_publisher(&self, req: idexchange::PublisherRequest, actor: &Actor) -> KrillResult<()> {

--- a/src/upgrades/mod.rs
+++ b/src/upgrades/mod.rs
@@ -78,8 +78,15 @@ impl AspaMigrationConfigs {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+}
 
-    pub fn into_iter(self) -> impl Iterator<Item = (CaHandle, Vec<AspaDefinition>)> {
+impl IntoIterator for AspaMigrationConfigs {
+    type Item = (CaHandle, Vec<AspaDefinition>);
+    type IntoIter = std::collections::hash_map::IntoIter<
+        CaHandle, Vec<AspaDefinition>
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
@@ -613,10 +620,7 @@ pub trait UpgradeAggregateStorePre0_14 {
     fn data_upgrade_info(&self, scope: &Scope) -> UpgradeResult<DataUpgradeInfo> {
         self.preparation_key_value_store()
             .get(&Self::data_upgrade_info_key(scope.clone()))
-            .map(|opt| match opt {
-                None => DataUpgradeInfo::default(),
-                Some(info) => info,
-            })
+            .map(|opt| opt.unwrap_or_default())
             .map_err(UpgradeError::KeyStoreError)
     }
 


### PR DESCRIPTION
This PR fixes all warnings from nightly Clippy as of today and enables a Clippy run in the CI workflow for the stable channel with all features enabled.