### PR TITLE
Upgrade to edition 2021.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Note: some of these values are also used when building Debian packages below.
 name = "krill"
 version = "0.14.5-dev"
-edition = "2018"
+edition = "2021"
 rust-version = "1.70"
 authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]
 description = "Resource Public Key Infrastructure (RPKI) daemon"

--- a/src/cli/ta_client.rs
+++ b/src/cli/ta_client.rs
@@ -1,6 +1,6 @@
 //! Trust Anchor Client for managing the TA Proxy *and* Signer
 
-use std::{convert::TryInto, env, path::PathBuf, str::FromStr, sync::Arc};
+use std::{env, path::PathBuf, str::FromStr, sync::Arc};
 
 use bytes::Bytes;
 use clap::{App, Arg, ArgMatches, SubCommand};

--- a/src/commons/api/ca.rs
+++ b/src/commons/api/ca.rs
@@ -2,7 +2,6 @@
 //! can have access without needing to depend on the full krill_ca module.
 
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::ops::{self};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -2180,7 +2179,6 @@ impl fmt::Display for RtaPrepResponse {
 #[cfg(test)]
 mod test {
     use bytes::Bytes;
-    use std::convert::TryFrom;
 
     use rpki::crypto::PublicKeyFormat;
 

--- a/src/commons/api/rrdp.rs
+++ b/src/commons/api/rrdp.rs
@@ -2,7 +2,6 @@
 //! withdraw elements, as well as the notification, snapshot and delta file
 //! definitions.
 use std::{
-    convert::{TryFrom, TryInto},
     fmt, io,
     ops::{Add, AddAssign, Deref},
     path::PathBuf,

--- a/src/commons/crypto/signing/misc.rs
+++ b/src/commons/crypto/signing/misc.rs
@@ -1,8 +1,6 @@
 //! Support for signing mft, crl, certificates, roas..
 //! Common objects for TAs and CAs
 
-use std::convert::TryFrom;
-
 use rpki::{
     ca::{csr::RpkiCaCsr, provisioning::RequestResourceLimit},
     crypto::{KeyIdentifier, PublicKey},

--- a/src/commons/crypto/signing/signers/kmip/signer.rs
+++ b/src/commons/crypto/signing/signers/kmip/signer.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::{TryFrom, TryInto},
     net::TcpStream,
     ops::Deref,
     path::PathBuf,

--- a/src/commons/crypto/signing/signers/pkcs11/signer.rs
+++ b/src/commons/crypto/signing/signers/pkcs11/signer.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::{TryFrom, TryInto},
     marker::PhantomData,
     path::Path,
     sync::{Arc, RwLock, RwLockReadGuard},

--- a/src/daemon/auth/common/crypt.rs
+++ b/src/daemon/auth/common/crypt.rs
@@ -88,8 +88,6 @@ impl CryptState {
     }
 
     pub fn from_key_vec(key_vec: Vec<u8>) -> KrillResult<CryptState> {
-        // Rust 1.43+ compatible
-        use std::convert::TryInto;
         let boxed_array: Box<[u8; CHACHA20_KEY_BYTE_LEN]> = key_vec
             .into_boxed_slice()
             .try_into()

--- a/src/daemon/ca/certauth.rs
+++ b/src/daemon/ca/certauth.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    convert::{TryFrom, TryInto},
     ops::Deref,
     sync::Arc,
     vec,

--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, convert::TryFrom, ops::Deref, str::FromStr, sync::Arc};
+use std::{collections::HashMap, ops::Deref, str::FromStr, sync::Arc};
 
 use bytes::Bytes;
 use chrono::Duration;

--- a/src/daemon/http/mod.rs
+++ b/src/daemon/http/mod.rs
@@ -1,5 +1,4 @@
 use std::{io, str::from_utf8, str::FromStr};
-use std::convert::TryInto;
 
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};

--- a/src/daemon/http/server.rs
+++ b/src/daemon/http/server.rs
@@ -2,7 +2,6 @@
 //!
 use std::{env, process};
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::fs::File;
 use std::io::Read;
 use std::net::SocketAddr;

--- a/src/pubd/repository.rs
+++ b/src/pubd/repository.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Cow,
     collections::{HashMap, VecDeque},
-    convert::TryFrom,
     fmt, fs,
     path::{Path, PathBuf},
     str::FromStr,

--- a/src/ta/proxy.rs
+++ b/src/ta/proxy.rs
@@ -5,7 +5,7 @@
 /// is handled by the Trust Anchor Signer instead.
 use super::*;
 
-use std::{collections::HashMap, convert::TryFrom, fmt, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use chrono::Duration;
 use rpki::{

--- a/src/ta/signer.rs
+++ b/src/ta/signer.rs
@@ -6,7 +6,7 @@
 //! The proxy makes sign requests for the signer to sign.
 use super::*;
 
-use std::{collections::HashMap, convert::TryFrom, fmt, sync::Arc};
+use std::{collections::HashMap, fmt, sync::Arc};
 
 use chrono::SecondsFormat;
 use rpki::{

--- a/src/upgrades/mod.rs
+++ b/src/upgrades/mod.rs
@@ -2,7 +2,9 @@
 //! - Updating the format of commands or events
 //! - Export / Import data
 
-use std::{collections::HashMap, convert::TryInto, fmt, str::FromStr};
+use std::fmt;
+use std::collections::HashMap;
+use std::str::FromStr;
 
 use serde::{de::DeserializeOwned, Deserialize};
 

--- a/src/upgrades/pre_0_10_0/cas_migration.rs
+++ b/src/upgrades/pre_0_10_0/cas_migration.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use rpki::ca::idexchange::MyHandle;
 use rpki::{ca::idexchange::CaHandle, repository::x509::Time};
 

--- a/src/upgrades/pre_0_10_0/old_events.rs
+++ b/src/upgrades/pre_0_10_0/old_events.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    convert::{TryFrom, TryInto},
     fmt,
 };
 


### PR DESCRIPTION
This PR upgrades the codebase to Rust edition 2021.

This mostly just means removing a number of use statements for `TryFrom` and `TryInto`. There are no actual code changes.