### PR TITLE
Create new client if old client is older than 60 s

### DIFF
--- a/src/daemon/auth/providers/openid_connect/provider.rs
+++ b/src/daemon/auth/providers/openid_connect/provider.rs
@@ -181,8 +181,11 @@ impl OpenIDConnectAuthProvider {
     async fn initialize_connection_if_needed(&self) -> KrillResult<()> {
         let mut conn_guard = self.conn.write().await;
 
-        if conn_guard.is_none() || conn_guard.as_ref().unwrap()
-            .time_established.elapsed().as_secs() >= 60 {
+        // If we don’t have a connection or it is older than 60 seconds,
+        // get a new one.
+        if conn_guard.map(|c| {
+            c.time_established.elapsed().as_secs()
+        }).unwrap_or(60) >= 60 {
             *conn_guard = Some(self.initialize_connection().await?);
         }
 

--- a/src/daemon/auth/providers/openid_connect/provider.rs
+++ b/src/daemon/auth/providers/openid_connect/provider.rs
@@ -183,7 +183,7 @@ impl OpenIDConnectAuthProvider {
 
         // If we don’t have a connection or it is older than 60 seconds,
         // get a new one.
-        if conn_guard.map(|c| {
+        if conn_guard.as_ref().map(|c| {
             c.time_established.elapsed().as_secs()
         }).unwrap_or(60) >= 60 {
             *conn_guard = Some(self.initialize_connection().await?);


### PR DESCRIPTION
Based on https://github.com/ramosbugs/openidconnect-rs/issues/152 and some discussions with @partim , it seems like the OpenID connect client does not automatically rediscover anything, leading to login loops when e.g. the JWKs are rolled (as the signature can no longer be verified).

```
2024-06-27 10:29:15 [WARN] OpenID Connect: ID token verification failed: Signature verification failed [additional info: caused by: Signature verification failed, caused by: No matching key found]
```

This PR adds an explicit lifetime to the connection, and if the connection has existed for more than 60 seconds, it will initialise a new client. This is a tradeoff between doing rediscovery on every request (so requesting the /.well-known/openid-configuration endpoint, the jwk_uri inside that, and then the endpoint for the userinfo), which might slow things down on grouped requests, whilst also reasonably quickly learning about configuration changes.

The 60 seconds is arbitrary, and it might be nicer to make this configurable or document it somehow. Even nicer would be to honour the cache lifetimes of the HTTP responses, but I am not sure whether that is worth the effort.