### PR TITLE
Add support for Ubuntu Noble and remove support for Ubuntu Xenial, Bionic, and Debian Stretch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,9 @@ depends = "$auto, passwd"
 [package.metadata.deb.variants.debian-bookworm]
 depends = "$auto, passwd, libssl3"
 
+[package.metadata.deb.variants.ubuntu-noble]
+depends = "$auto, passwd, libssl3"
+
 # Cross compilation variants:
 # Note: we have to specifiy dependencies manually because we don't run cargo-deb
 # on the target platform and so it cannot determine the dependencies correctly

--- a/doc/manual/source/install-and-run.rst
+++ b/doc/manual/source/install-and-run.rst
@@ -113,6 +113,7 @@ public rsyncd and HTTPS web server available.
        To install a Routinator package, you need the 64-bit version of one of
        these Ubuntu versions:
 
+         - Ubuntu Noble 24.04 (LTS)
          - Ubuntu Jammy 22.04 (LTS)
          - Ubuntu Focal 20.04 (LTS)
 

--- a/pkg/common/krill-ubuntu-noble.krill.service
+++ b/pkg/common/krill-ubuntu-noble.krill.service
@@ -1,0 +1,1 @@
+krill-debian-bullseye.krill.service

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -5,11 +5,9 @@ pkg:
   - "krillup"
   - "krillta"
 image:
-  - "ubuntu:xenial" # ubuntu/16.04
-  - "ubuntu:bionic" # ubuntu/18.04
   - "ubuntu:focal" # ubuntu/20.04
   - "ubuntu:jammy" # ubuntu/22.04
-  - "debian:stretch" # debian/9
+  - "ubuntu:noble" # ubuntu/24.04
   - "debian:buster" # debian/10
   - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12

--- a/pkg/rules/packages-to-test.yml
+++ b/pkg/rules/packages-to-test.yml
@@ -5,11 +5,9 @@ pkg:
   - "krillup"
   - "krillta"
 image:
-  - "ubuntu:xenial" # ubuntu/16.04
-  - "ubuntu:bionic" # ubuntu/18.04
   - "ubuntu:focal" # ubuntu/20.04
   - "ubuntu:jammy" # ubuntu/22.04
-  - "debian:stretch" # debian/9
+  - "ubuntu:noble" # ubuntu/24.04
   - "debian:buster" # debian/10
   - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12
@@ -70,14 +68,14 @@ include:
     image: "debian:buster"
     target: "aarch64-unknown-linux-gnu"
 
-# Exclude upgrade testing on Debian Bookworm as no prior released versions exist to upgrade from.
+# Exclude upgrade testing on Ubuntu Noble as no prior released versions exist to upgrade from.
 exclude:
   - pkg: "krill"
-    image: "debian:bookworm"
+    image: "ubuntu:noble"
     mode: "upgrade-from-published"
   - pkg: "krillta"
-    image: "debian:bookworm"
+    image: "ubuntu:noble"
     mode: "upgrade-from-published"
   - pkg: "krillup"
-    image: "debian:bookworm"
+    image: "ubuntu:noble"
     mode: "upgrade-from-published"


### PR DESCRIPTION
This PR adds support for Ubuntu Noble and removes support for Ubuntu 16.04, 18.04 and Debian 9.