### PR TITLE
Improve the feedback provided by `krillta proxy signer show-request`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ rand            = "0.8"
 regex           = { version = "1.5.5", optional = true, default-features = false, features = [ "std" ] }
 reqwest         = { version = "0.12.5", features = ["json"] }
 rpassword       = { version = "7.3.1", optional = true }
-rpki            = { version = "0.18.4", features = ["ca", "compat", "rrdp"], git = "https://github.com/NLnetLabs/rpki-rs.git" }
+rpki            = { version = "0.18.4", features = ["ca", "compat", "rrdp"], git = "https://github.com/NLnetLabs/rpki-rs.git", rev = "26397568f564836a1ef94ac5449e8e1e462de01f" }
 rustls-pemfile  = "2.1.2"
 scrypt          = { version = "0.11", optional = true, default-features = false }
 secrecy         = { version = "0.8", features = ["serde"] }

--- a/src/ta/config.rs
+++ b/src/ta/config.rs
@@ -24,7 +24,7 @@ const DFLT_TA_SIGNED_MESSAGE_VALIDITY_DAYS: i64 = 14;
 //------------------------ TaTimingConfig
 //------------------------ ---------------------------------------
 
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TaTimingConfig {
     #[serde(default = "TaTimingConfig::dflt_ta_certificate_validity_years")]
     pub certificate_validity_years: i32,

--- a/src/ta/signer.rs
+++ b/src/ta/signer.rs
@@ -465,6 +465,13 @@ impl TrustAnchorSigner {
         // and the 'content' is not tampered with.
         signed_request.validate(&self.proxy_id)?;
 
+        // Check whether the timing configs match
+        if ta_timing_config != signed_request.content().timing {
+            return Err(Error::Custom(format!(
+                "TA timing config between krillta and krill do not match!"
+            )));
+        }
+
         let mut objects = self.objects.clone();
 
         let mut child_responses: HashMap<


### PR DESCRIPTION
This changes the feedback provided by `krillta proxy signer show-request` to include information about certificate expiration and renewal time:

```
$ krillta proxy signer show-request
-------------------------------
nonce: 06d7845b-61aa-4ce9-97cf-d7942a1a5a9a
-------------------------------

Certificates will be reissued 80 weeks before expiry.
The current certificate expires on 2039-12-05T12:47:15+00:00.
Ergo the certificate is eligible for renewal on 2038-05-24T12:47:15+00:00.

NOTE: Use the JSON output for the signer.
```

Additionally, error when the TA and Krill config don't match:
```
$ krillta signer -c ta.conf --format text process --request request.json
TA timing config between krillta and krill do not match!
```

This does change the format of those request files (two additional fields), which are now required.