### PR TITLE
Replace once_cell::OnceCell with std::sync::OnceLock.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,6 @@ dependencies = [
  "kvx",
  "libflate",
  "log",
- "once_cell",
  "openidconnect",
  "openssl",
  "oso",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ kmip            = { version = "0.4.2", package = "kmip-protocol", features = [ "
 kvx             = { version = "0.9.3", features = ["macros"] }
 libflate        = "2.1.0"
 log             = "0.4"
-once_cell       = { version = "1.7.2", optional = true }
 openidconnect   = { version = "2.0.0", optional = true, default-features = false }
 openssl         = { version = "0.10", features = ["v110"] }
 oso             = { version = "0.12", optional = true, default-features = false }
@@ -78,7 +77,7 @@ syslog = "6.1.1"
 
 [features]
 default = ["multi-user", "hsm"]
-hsm = ["backoff", "kmip", "once_cell", "cryptoki", "r2d2"]
+hsm = ["backoff", "kmip", "cryptoki", "r2d2"]
 multi-user = [
     "basic-cookies",
     "jmespatch/sync",


### PR DESCRIPTION
This PR removes the dependency on `once_cell` since all the relevant functionality is now in `std`.