### PR TITLE
Allow for reinitialising of the TA cert

### DIFF
--- a/doc/manual/source/trust-anchor.rst
+++ b/doc/manual/source/trust-anchor.rst
@@ -468,3 +468,26 @@ friendlier to the human eye:
 .. code-block:: bash
 
   krillta signer exchanges --format text
+
+
+Changing the TA certificate
+---------------------------
+
+There may be a reason why you want to change the TA certificate without
+starting from scratch. Reasons might include: changes in the timing config,
+the TA certificate expiring, and changes in the HTTPS or rsync URI.
+
+In order to recreate the TA certificate, run the following command with the
+new parameters:
+
+.. code-block:: bash
+
+  krillta signer reinit
+
+Be aware that the private key also has to be supplied as an argument. After
+that, the flow is the same as for the initial initialisation: 
+
+.. code-block:: bash
+  krillta signer show > ./signer-info.json
+  krillta proxy signer init --info ./signer-info.json
+

--- a/doc/manual/source/trust-anchor.rst
+++ b/doc/manual/source/trust-anchor.rst
@@ -313,10 +313,10 @@ endpoints for the TA certificate.
 
 .. code-block:: bash
 
-  krillta signer init --proxy_id ./proxy-id.json \
-                      --proxy_repository_contact ./proxy-repo.json \
-                      --tal_https <HTTPS URI for TA cert on TAL> \
-                      --tal_rsync <RSYNC URI for TA cert on TAL>
+  krillta signer init --proxy-id ./proxy-id.json \
+                      --proxy-repository-contact ./proxy-repo.json \
+                      --tal-https <HTTPS URI for TA cert on TAL> \
+                      --tal-rsync <RSYNC URI for TA cert on TAL>
 
 
 Associate the TA Signer with the Proxy

--- a/src/cli/ta/options/signer.rs
+++ b/src/cli/ta/options/signer.rs
@@ -109,6 +109,10 @@ pub struct Init {
     /// Set the initial manifest number
     #[arg(long, value_name = "number", default_value = "1")]
     initial_manifest_number: u64,
+
+    /// Force the signer to reinitialise even if previously already initialised
+    #[arg(long, action)]
+    force: bool
 }
 
 impl Init {
@@ -123,6 +127,7 @@ impl Init {
                 tal_rsync: self.tal_rsync,
                 private_key_pem: self.private_key_pem.map(|x| x.0),
                 ta_mft_nr_override: Some(self.initial_manifest_number),
+                force: self.force
             }
         )
     }

--- a/src/cli/ta/signer.rs
+++ b/src/cli/ta/signer.rs
@@ -145,7 +145,8 @@ impl TrustAnchorSignerManager {
                         priv_key.as_bytes()
                     )?;
                     let signer_info = cert.get_signer_info();
-                    let pub_key = signer_info.ta_cert_details.cert().csr_info().key();
+                    let pub_key = signer_info.ta_cert_details
+                        .cert().csr_info().key();
                     let k1 = priv_key.public_key_to_der()?;
                     let k2 = pub_key.to_info_bytes().to_vec();
                     Ok((k1, k2))

--- a/src/cli/ta/signer.rs
+++ b/src/cli/ta/signer.rs
@@ -148,7 +148,7 @@ impl TrustAnchorSignerManager {
                     let pub_key = signer_info.ta_cert_details.cert().csr_info().key();
                     let k1 = priv_key.public_key_to_der()?;
                     let k2 = pub_key.to_info_bytes().to_vec();
-                    return Ok((k1, k2));
+                    Ok((k1, k2))
                 }();
                 if let Ok((k1, k2)) = res {
                     if k1 != k2 {

--- a/src/cli/ta/signer.rs
+++ b/src/cli/ta/signer.rs
@@ -258,3 +258,9 @@ impl TrustAnchorSignerManager {
     }
 }
 
+impl TrustAnchorSignerManager {
+    pub fn get_krill_signer(&self) -> Arc<KrillSigner> {
+        self.signer.clone()
+    }
+}
+

--- a/src/commons/error.rs
+++ b/src/commons/error.rs
@@ -538,7 +538,7 @@ impl fmt::Display for Error {
             Error::TaProxyAlreadyHasRepository => write!(f, "Trust Anchor Proxy already has repository"),
             Error::TaProxyHasNoRepository => write!(f, "Trust Anchor Proxy has no repository"),
             Error::TaProxyHasNoSigner => write!(f, "Trust Anchor Proxy has no associated signer"),
-            Error::TaProxyAlreadyHasSigner => write!(f, "Trust Anchor Proxy already has associated signer"),
+            Error::TaProxyAlreadyHasSigner => write!(f, "Trust Anchor Proxy already has associated signer with a different key identifier"),
             Error::TaProxyHasNoRequest => write!(f, "Trust Anchor Proxy has no signer request"),
             Error::TaProxyHasRequest => write!(f, "Trust Anchor Proxy already has signer request"),
             Error::TaProxyRequestNonceMismatch(rcvd, expected) => write!(f, "Trust Anchor Response nonce '{}' does not match open Request nonce '{}'", rcvd, expected),

--- a/src/commons/eventsourcing/store.rs
+++ b/src/commons/eventsourcing/store.rs
@@ -244,6 +244,14 @@ where
             .map_err(AggregateStoreError::KeyStoreError)
     }
 
+    /// Returns Ok() if key was found and dropped
+    pub fn drop(&self, id: &MyHandle) -> Result<(), AggregateStoreError> {
+        let init_command_key = Self::key_for_command(id, 0);
+        self.kv
+            .drop_key(&init_command_key)
+            .map_err(AggregateStoreError::KeyStoreError)
+    }
+
     /// Lists all known ids.
     pub fn list(&self) -> Result<Vec<MyHandle>, AggregateStoreError> {
         self.aggregates()

--- a/src/daemon/ca/manager.rs
+++ b/src/daemon/ca/manager.rs
@@ -388,6 +388,7 @@ impl CaManager {
                 ta_mft_nr_override: None,
                 timing: self.config.ta_timing,
                 signer: self.signer.clone(),
+                force_recreate: false
             };
             let cmd = TrustAnchorSignerInitCommand::new(
                 &handle,

--- a/src/ta/mod.rs
+++ b/src/ta/mod.rs
@@ -147,6 +147,7 @@ mod tests {
                     ta_mft_nr_override: Some(42),
                     timing,
                     signer: signer.clone(),
+                    force_recreate: true
                 },
                 &actor,
             );

--- a/src/ta/proxy.rs
+++ b/src/ta/proxy.rs
@@ -716,11 +716,7 @@ impl TrustAnchorProxy {
         &self,
         signer: TrustAnchorSignerInfo,
     ) -> KrillResult<Vec<TrustAnchorProxyEvent>> {
-        if self.signer.is_none() {
-            Ok(vec![TrustAnchorProxyEvent::SignerAdded(signer)])
-        } else {
-            Err(Error::TaProxyAlreadyHasSigner)
-        }
+        Ok(vec![TrustAnchorProxyEvent::SignerAdded(signer)])
     }
 
     fn process_make_signer_request(

--- a/src/ta/proxy.rs
+++ b/src/ta/proxy.rs
@@ -716,6 +716,11 @@ impl TrustAnchorProxy {
         &self,
         signer: TrustAnchorSignerInfo,
     ) -> KrillResult<Vec<TrustAnchorProxyEvent>> {
+        if let Some(s) = &self.signer {
+            if s.ta_cert_details.cert().key_identifier() != signer.ta_cert_details.cert().key_identifier() {
+                return Err(Error::TaProxyAlreadyHasSigner);
+            }
+        }
         Ok(vec![TrustAnchorProxyEvent::SignerAdded(signer)])
     }
 

--- a/src/ta/signer.rs
+++ b/src/ta/signer.rs
@@ -79,6 +79,7 @@ pub struct TrustAnchorSignerInitCommandDetails {
     pub tal_rsync: uri::Rsync,
     pub private_key_pem: Option<String>,
     pub ta_mft_nr_override: Option<u64>,
+    pub force_recreate: bool,
     pub timing: TaTimingConfig,
     pub signer: Arc<KrillSigner>,
 }
@@ -296,6 +297,7 @@ impl eventsourcing::Aggregate for TrustAnchorSigner {
             timing.certificate_validity_years,
             &signer,
         )?;
+        
         let objects = TrustAnchorObjects::create(
             ta_cert_details.cert(),
             cmd.ta_mft_nr_override.unwrap_or(1),

--- a/tests/functional_ta.rs
+++ b/tests/functional_ta.rs
@@ -1,6 +1,7 @@
 //! Test setting up Krill as a trust anchor.
 
 use std::str::FromStr;
+use krill::commons::crypto::dispatch::signerprovider::SignerProvider;
 use rpki::uri;
 use rpki::repository::resources::ResourceSet;
 use krill::cli::ta::signer::{SignerInitInfo, TrustAnchorSignerManager};
@@ -47,10 +48,21 @@ async fn functional_at() {
         ).unwrap()
     ).unwrap();
 
-    let rsa = openssl::rsa::Rsa::generate(2048).unwrap();
-    let private_key = openssl::pkey::PKey::from_rsa(rsa).unwrap();
-    let pem = String::from_utf8(
-        private_key.private_key_to_pem_pkcs8().unwrap()).unwrap();
+    let pem: Option<String>;
+
+    if signer
+        .get_krill_signer()
+        .get_active_signers()
+        .into_values()
+        .any(|x| matches!(*x, SignerProvider::OpenSsl(_, _))) {
+            // The other signer types do not allow a PEM input causing this test to fail.
+            pem = None;  
+    } else {
+        let rsa = openssl::rsa::Rsa::generate(2048).unwrap();
+        let private_key = openssl::pkey::PKey::from_rsa(rsa).unwrap();
+        pem = Some(String::from_utf8(
+            private_key.private_key_to_pem_pkcs8().unwrap()).unwrap());
+    }
 
     eprintln!(">>>> Initialise the TA signer.");
     signer.init(
@@ -67,7 +79,7 @@ async fn functional_at() {
             tal_rsync: uri::Rsync::from_str(
                 "rsync://localhost/ta/ta.cer"
             ).unwrap(),
-            private_key_pem: Some(pem.clone()),
+            private_key_pem: pem.clone(),
             ta_mft_nr_override: None,
             force: true
         }
@@ -117,36 +129,38 @@ async fn functional_at() {
     let response = signer.show_last_response().unwrap();
     server.client().ta_proxy_signer_response(response).await.unwrap();
 
-    eprintln!(">>>> Reinitialise the TA signer.");
-    signer.init(
-        SignerInitInfo {
-            proxy_id: server.client().ta_proxy_id().await.unwrap(),
-            repo_info: {
-                server.client().ta_proxy_repo_contact().await.unwrap().into()
-            },
-            tal_https: vec![
-                uri::Https::from_string(
-                    format!("https://localhost:{}/ta/ta.cer", port)
-                ).unwrap()
-            ],
-            tal_rsync: uri::Rsync::from_str(
-                "rsync://localhost/resignedta/ta.cer"
-            ).unwrap(),
-            private_key_pem: Some(pem.clone()),
-            ta_mft_nr_override: None,
-            force: true
-        }
-    ).unwrap();
+    if pem.is_some() {
+        eprintln!(">>>> Reinitialise the TA signer.");
+        signer.init(
+            SignerInitInfo {
+                proxy_id: server.client().ta_proxy_id().await.unwrap(),
+                repo_info: {
+                    server.client().ta_proxy_repo_contact().await.unwrap().into()
+                },
+                tal_https: vec![
+                    uri::Https::from_string(
+                        format!("https://localhost:{}/ta/ta.cer", port)
+                    ).unwrap()
+                ],
+                tal_rsync: uri::Rsync::from_str(
+                    "rsync://localhost/resignedta/ta.cer"
+                ).unwrap(),
+                private_key_pem: pem.clone(),
+                ta_mft_nr_override: None,
+                force: true
+            }
+        ).unwrap();
 
-    eprintln!(">>>> Reassociate the TA signer with the proxy.");
-    let signer_info = signer.show().unwrap();
-    server.client().ta_proxy_signer_add(signer_info).await.unwrap();
+        eprintln!(">>>> Reassociate the TA signer with the proxy.");
+        let signer_info = signer.show().unwrap();
+        server.client().ta_proxy_signer_add(signer_info).await.unwrap();
 
-    eprintln!(">>>> Refetch TAL and check it isn’t empty.");
-    assert!(!server.client().testbed_tal().await.unwrap().is_empty());
+        eprintln!(">>>> Refetch TAL and check it isn’t empty.");
+        assert!(!server.client().testbed_tal().await.unwrap().is_empty());
 
-    eprintln!(">>>> Refetch TAL and check it was resigned.");
-    assert!(server.client().testbed_tal().await.unwrap().contains("resigned"));
+        eprintln!(">>>> Refetch TAL and check it was resigned.");
+        assert!(server.client().testbed_tal().await.unwrap().contains("resigned"));
+    }
 
     // XXX This should probably test that everything is in order but I don’t
     //     know how just yet.

--- a/tests/functional_ta.rs
+++ b/tests/functional_ta.rs
@@ -63,7 +63,8 @@ async fn functional_at() {
                 "rsync://localhost/ta/ta.cer"
             ).unwrap(),
             private_key_pem: None,
-            ta_mft_nr_override: None
+            ta_mft_nr_override: None,
+            force: true
         }
     ).unwrap();
 

--- a/tests/functional_ta.rs
+++ b/tests/functional_ta.rs
@@ -73,7 +73,8 @@ async fn functional_at() {
         }
     );
     
-    if let Err(SignerClientError::Other(msg)) = &init {
+    if let Err(SignerClientError::KrillError(
+        krill::commons::error::Error::SignerError(msg))) = &init {
         // If this fails, it's likely because of the signer not supporting an
         // explicit private key (e.g. HSMs)
         if msg.contains("import key not supported") {


### PR DESCRIPTION
Previously, once the TA cert was created, there was no way to reinitialise it. That meant that any changes regarding the rsync URI, HTTPS URI, validity, etc. could not be made. This PR adds a `--force` switch to allow the signer to be created again, provided the same key is used, as well as a convenient `reinit` shorthand.

```
koen@beta:~/Code/krill$ target/debug/krillta signer reinit --help
Reinitialise an already initialised signer

Usage: krillta signer reinit [OPTIONS] --proxy-id <path> --proxy-repository-contact <path> --tal-rsync <rsync URI> --private-key-pem <path>

Options:
  -i, --proxy-id <path>                   Path to the proxy ID JSON file
  -r, --proxy-repository-contact <path>   Path to the proxy repository contact JSON file
      --tal-rsync <rsync URI>             The rsync URI used for TA certificate on TAL and AIA
      --tal-https <HTTPS URI>             The HTTPS URI used for the TAL
      --private-key-pem <path>            The private key for the already initialised signer in PEM format
      --initial-manifest-number <number>  Set the manifest number [default: 1]
  -h, --help                              Print help
```