### PR TITLE
Update Docker Alpine to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG MODE=build
 # ========
 #
 # Only used when MODE=build.
-ARG BASE_IMG=alpine:3.18
+ARG BASE_IMG=alpine:3.21
 
 
 # CARGO_ARGS


### PR DESCRIPTION
All the other projects seem to be on 3.21 - it probably makes sense for Krill to be as well. 