### PR TITLE
Import KVX with disk and memory stores.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         # Test against the oldest supported version.
         # Test against beta Rust to get early warning of any problems that might occur with the upcoming Rust release.
         # Order: oldest Rust to newest Rust.
-        rust: [1.74.0, stable, beta]
+        rust: [1.79.0, stable, beta]
 
         # Test with no features, default features ("") and all except UI tests.
         # Order: fewest features to most features.
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [1.74.0, stable, beta]
+        rust: [1.79.0, stable, beta]
         features: ["hsm", "hsm,hsm-tests-kmip"]
     steps:
     - name: Checkout repository
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        rust: [1.74.0, stable, beta]
+        rust: [1.79.0, stable, beta]
         features: ["hsm,hsm-tests-pkcs11"]
     steps:
     - name: Checkout repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,17 +101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,7 +118,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "instant",
  "rand",
 ]
@@ -232,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -244,15 +233,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "cc"
-version = "1.2.10"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "shlex",
 ]
@@ -290,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -300,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -313,14 +302,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -359,9 +348,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -441,7 +430,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -465,7 +454,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -476,7 +465,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -541,14 +530,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
 name = "ecdsa"
@@ -657,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -679,12 +668,6 @@ checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -772,7 +755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -789,7 +771,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -812,7 +794,6 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-macro",
- "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -839,8 +820,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -985,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -997,9 +990,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1206,7 +1199,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1387,6 +1380,7 @@ dependencies = [
  "chrono",
  "clap",
  "cryptoki",
+ "fd-lock",
  "fern",
  "futures-util",
  "hex",
@@ -1395,7 +1389,7 @@ dependencies = [
  "hyper-util",
  "intervaltree",
  "kmip-protocol",
- "kvx",
+ "lazy_static",
  "log",
  "openidconnect",
  "openssl",
@@ -1422,50 +1416,6 @@ dependencies = [
  "url",
  "urlparse",
  "uuid",
-]
-
-[[package]]
-name = "kvx"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1754d54b4647a80cfe3a028ea091ff1e397b4dd7ce732e3dd89c574ee7069ce6"
-dependencies = [
- "fd-lock",
- "kvx_macros",
- "kvx_types",
- "lazy_static",
- "postgres",
- "postgres-types",
- "r2d2_postgres",
- "rand",
- "serde_json",
- "tempfile",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "kvx_macros"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d19a4fb5d927de5c763835ad6eb8cb1a8d7f7e7a0b3e13c12b7bc96c06ef081"
-dependencies = [
- "kvx_types",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "kvx_types"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced4f07c148b135c7e3541eed9afc749fa6cf8451f52ebac4bd12d148c0c51a3"
-dependencies = [
- "postgres",
- "postgres-types",
- "thiserror",
 ]
 
 [[package]]
@@ -1582,17 +1532,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1609,9 +1549,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
 ]
@@ -1623,15 +1563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
 dependencies = [
  "libc",
  "log",
@@ -1720,7 +1660,7 @@ checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
 dependencies = [
  "base64 0.13.1",
  "chrono",
- "getrandom",
+ "getrandom 0.2.15",
  "http 0.2.12",
  "rand",
  "serde",
@@ -1742,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openidconnect"
@@ -1780,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -1801,29 +1741,29 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -1855,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "p384"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1930,30 +1870,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
 name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.1",
+ "siphasher",
 ]
 
 [[package]]
@@ -2002,64 +1924,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
-name = "postgres"
-version = "0.19.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c918733159f4d55d2ceb262950f00b0aebd6af4aa97b5a47bb0655120475ed"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "futures-util",
- "log",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
-name = "postgres-derive"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69700ea4603c5ef32d447708e6a19cd3e8ac197a000842e97f527daea5e4175f"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "postgres-protocol"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
-dependencies = [
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "hmac",
- "md-5",
- "memchr",
- "rand",
- "sha2",
- "stringprep",
-]
-
-[[package]]
-name = "postgres-types"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ea23a2d0e5734297357705193335e0a957696f34bed2f2faefacb2fec336f"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "postgres-derive",
- "postgres-protocol",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,30 +1951,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -2152,16 +1992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r2d2_postgres"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd4b47636dbca581cd057e2f27a5d39be741ea4f85fd3c29e415c55f71c7595"
-dependencies = [
- "postgres",
- "r2d2",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,7 +2018,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -2206,7 +2036,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -2296,15 +2126,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2397,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "log",
  "once_cell",
@@ -2421,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -2444,9 +2273,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "salsa20"
@@ -2590,14 +2419,14 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -2672,7 +2501,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2713,12 +2542,6 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
@@ -2734,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -2785,26 +2608,14 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+checksum = "938d512196766101d333398efde81bc1f37b00cb42c2f8350e5df639f040bbbe"
 dependencies = [
  "new_debug_unreachable",
- "once_cell",
  "parking_lot",
- "phf_shared 0.10.0",
+ "phf_shared",
  "precomputed-hash",
-]
-
-[[package]]
-name = "stringprep"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
- "unicode-properties",
 ]
 
 [[package]]
@@ -2832,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2858,7 +2669,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2897,13 +2708,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "a40f762a77d2afa88c2d919489e390a12bdd261ed568e60cfa7e48d4e20f0d33"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2956,7 +2767,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3061,7 +2872,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3072,32 +2883,6 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-postgres"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5d3742945bc7d7f210693b0c58ae542c6fd47b17adbbda0885f3dcb34a6bdb"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "futures-channel",
- "futures-util",
- "log",
- "parking_lot",
- "percent-encoding",
- "phf",
- "pin-project-lite",
- "postgres-protocol",
- "postgres-types",
- "rand",
- "socket2",
- "tokio",
- "tokio-util",
- "whoami",
 ]
 
 [[package]]
@@ -3125,9 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3146,9 +2931,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
@@ -3227,16 +3012,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
-
-[[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-normalization"
@@ -3246,12 +3025,6 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-xid"
@@ -3303,11 +3076,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -3348,10 +3121,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3375,7 +3151,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -3410,7 +3186,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3432,17 +3208,6 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "whoami"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
-dependencies = [
- "redox_syscall",
- "wasite",
- "web-sys",
 ]
 
 [[package]]
@@ -3665,11 +3430,20 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -3704,7 +3478,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -3726,7 +3500,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3746,7 +3520,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -3775,5 +3549,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ bytes           = "1"
 chrono          = { version = "0.4", features = ["serde"] }
 clap            = { version = "4.5.23", features = ["cargo", "derive", "env",  "wrap_help"]}
 cryptoki        = { version = "0.7", optional = true }
+fd-lock         = "4.0.1"
 fern            = { version = "0.6.2", features = ["syslog-6"] }
 futures-util    = "0.3"
 hex             = "0.4"
@@ -36,7 +37,7 @@ hyper           = { version = "1.5.2", features = ["server"] }
 hyper-util      = { version = "0.1", features = [ "server" ] }
 intervaltree    = "0.2.7"
 kmip            = { version = "0.4.3", package = "kmip-protocol", features = [ "tls-with-openssl" ], optional = true }
-kvx             = { version = "0.9.3", features = ["macros"] }
+lazy_static     = "1.5"
 log             = "0.4"
 openidconnect   = { version = "3.5.0", optional = true, default-features = false }
 openssl         = { version = "0.10", features = ["v110"] }
@@ -53,6 +54,7 @@ scrypt          = { version = "0.11", optional = true, default-features = false 
 secrecy         = { version = "0.8", features = ["serde"] }
 serde           = { version = "1.0", features = ["derive", "rc"] }
 serde_json      = "1.0"
+tempfile        = "3.14.0"
 tokio           = { version = "1", features = [ "macros", "rt", "rt-multi-thread", "signal", "time" ] }
 tokio-rustls    = { version = "0.26", default-features = false, features = [ "ring", "logging", "tls12" ] }
 toml            = "0.8.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "krill"
 version = "0.14.5-dev"
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.79"
 authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]
 description = "Resource Public Key Infrastructure (RPKI) daemon"
 homepage = "https://www.nlnetlabs.nl/projects/rpki/krill/"

--- a/src/cli/ta/signer.rs
+++ b/src/cli/ta/signer.rs
@@ -8,9 +8,8 @@ use crate::commons::actor::Actor;
 use crate::commons::api::{IdCertInfo, Success};
 use crate::commons::crypto::KrillSigner;
 use crate::commons::error::Error as KrillError;
-use crate::commons::eventsourcing::{
-    namespace, AggregateStore, AggregateStoreError, Namespace,
-};
+use crate::commons::eventsourcing::{AggregateStore, AggregateStoreError};
+use crate::commons::storage::Namespace;
 use crate::commons::util::httpclient;
 use crate::ta::{
     Config, TrustAnchorHandle, TrustAnchorProxySignerExchanges,
@@ -110,10 +109,9 @@ impl TrustAnchorSignerManager {
     pub fn create(config: Config) -> Result<Self, SignerClientError> {
         let store = AggregateStore::create(
             &config.storage_uri,
-            namespace!("signer"),
+            const { Namespace::make("signer") },
             config.use_history_cache,
-        )
-        .map_err(KrillError::AggregateStoreError)?;
+        ).map_err(SignerClientError::other)?;
         let ta_handle = TrustAnchorHandle::new("ta".into());
         let signer = config.signer()?;
         let actor = crate::constants::ACTOR_DEF_KRILLTA;

--- a/src/commons/crypto/signing/signers/softsigner.rs
+++ b/src/commons/crypto/signing/signers/softsigner.rs
@@ -27,7 +27,7 @@ use crate::{
             dispatch::signerinfo::SignerMapper, signers::error::SignerError,
             SignerHandle,
         },
-        eventsourcing::{Key, KeyValueStore, Segment, SegmentExt},
+        storage::{Key, KeyValueStore, Segment},
     },
     constants::KEYS_NS,
 };

--- a/src/commons/eventsourcing/mod.rs
+++ b/src/commons/eventsourcing/mod.rs
@@ -18,35 +18,24 @@ pub use self::store::*;
 mod listener;
 pub use self::listener::*;
 
-mod kv;
-pub use self::kv::{
-    namespace, segment, Key, KeyValueError, KeyValueStore, Namespace, Scope,
-    Segment, SegmentBuf, SegmentExt,
-};
-
 //------------ Tests ---------------------------------------------------------
 
 #[cfg(test)]
-mod tests {
+mod test {
 
     //! Example implementation using the eventsourcing module.
     //!
     //! Goal is two-fold: document using a simple domain, and test the module.
 
-    use std::{fmt, str::FromStr, sync::Arc};
-
+    use std::fmt;
+    use std::str::FromStr;
+    use std::sync::Arc;
     use serde::Serialize;
-
     use rpki::ca::idexchange::MyHandle;
-
-    use crate::{
-        commons::{
-            api::{CommandHistoryCriteria, CommandSummary},
-        },
-        constants::ACTOR_DEF_TEST,
-        test::mem_storage,
-    };
-
+    use crate::commons::api::{CommandHistoryCriteria, CommandSummary};
+    use crate::commons::storage::Namespace;
+    use crate::constants::ACTOR_DEF_TEST;
+    use crate::test::mem_storage;
     use super::*;
 
     //------------ PersonInitEvent
@@ -385,7 +374,7 @@ mod tests {
 
         let mut manager = AggregateStore::<Person>::create(
             &storage_uri,
-            namespace!("person"),
+            const { Namespace::make("person") },
             false,
         )
         .unwrap();
@@ -429,7 +418,7 @@ mod tests {
         // mapping.
         let manager = AggregateStore::<Person>::create(
             &storage_uri,
-            namespace!("person"),
+            const { Namespace::make("person") },
             false,
         )
         .unwrap();

--- a/src/commons/eventsourcing/store.rs
+++ b/src/commons/eventsourcing/store.rs
@@ -5,7 +5,6 @@ use std::{
     sync::{Arc, Mutex, RwLock},
 };
 
-use kvx::Namespace;
 use rpki::{ca::idexchange::MyHandle, repository::x509::Time};
 use serde::{de::DeserializeOwned, Serialize};
 use url::Url;
@@ -14,10 +13,11 @@ use crate::commons::{
     api::{CommandHistory, CommandHistoryCriteria, CommandHistoryRecord},
     error::KrillIoError,
     eventsourcing::{
-        cmd::Command, segment, Aggregate, Key, KeyValueError, KeyValueStore,
-        PostSaveEventListener, PreSaveEventListener, Scope, Segment,
-        SegmentExt, StoredCommand, StoredCommandBuilder,
+        cmd::Command, Aggregate,
+        PostSaveEventListener, PreSaveEventListener,
+        StoredCommand, StoredCommandBuilder,
     },
+    storage::{Key, KeyValueError, KeyValueStore, Namespace, Segment, Scope},
 };
 
 use super::InitCommand;
@@ -56,7 +56,7 @@ impl<A: Aggregate> AggregateStore<A> {
         use_history_cache: bool,
     ) -> StoreResult<Self> {
         let kv = KeyValueStore::create(storage_uri, namespace)?;
-        Self::create_from_kv(kv, use_history_cache)
+        Ok(Self::create_from_kv(kv, use_history_cache))
     }
 
     /// Creates an AggregateStore for upgrades using the given storage url
@@ -67,13 +67,13 @@ impl<A: Aggregate> AggregateStore<A> {
     ) -> StoreResult<Self> {
         let kv =
             KeyValueStore::create_upgrade_store(storage_uri, name_space)?;
-        Self::create_from_kv(kv, use_history_cache)
+        Ok(Self::create_from_kv(kv, use_history_cache))
     }
 
     fn create_from_kv(
         kv: KeyValueStore,
         use_history_cache: bool,
-    ) -> StoreResult<Self> {
+    ) -> Self {
         let cache = RwLock::new(HashMap::new());
         let history_cache = if !use_history_cache {
             None
@@ -83,15 +83,13 @@ impl<A: Aggregate> AggregateStore<A> {
         let pre_save_listeners = vec![];
         let post_save_listeners = vec![];
 
-        let store = AggregateStore {
+        AggregateStore {
             kv,
             cache,
             history_cache,
             pre_save_listeners,
             post_save_listeners,
-        };
-
-        Ok(store)
+        }
     }
 
     /// Warms up the cache, to be used after startup. Will fail if any
@@ -195,9 +193,7 @@ where
                             let processed_command = processed_command_builder
                                 .finish_with_init_event(init_event);
 
-                            let json =
-                                serde_json::to_value(&processed_command)?;
-                            kv.store(&init_command_key, json)?;
+                            kv.store(&init_command_key, &processed_command)?;
 
                             let arc = Arc::new(aggregate);
 
@@ -279,18 +275,15 @@ where
 
                         let snapshot_key = Self::key_for_snapshot(handle);
                         match kv.get(&snapshot_key)? {
-                            Some(value) => {
+                            Some(agg) => {
                                 trace!("found snapshot for {handle}");
-                                let agg: A = serde_json::from_value(value)?;
                                 Ok(Arc::new(agg))
                             }
                             None => {
                                 let init_key = Self::key_for_command(handle, 0);
-                                match kv.get(&init_key)? {
-                                    Some(value) => {
+                                match kv.get::<StoredCommand<A>>(&init_key)? {
+                                    Some(init_command) => {
                                         trace!("found init command for {handle}");
-                                        let init_command: StoredCommand<A> = serde_json::from_value(value)?;
-
                                         match init_command.into_init() {
                                             Some(init_event) => {
                                                 let agg = A::init(handle.clone(), init_event);
@@ -332,11 +325,10 @@ where
 
                         let key = Self::key_for_command(handle, version);
 
-                        match kv.get(&key)? {
+                        match kv.get::<StoredCommand<A>>(&key)? {
                             None => break,
-                            Some(value) => {
+                            Some(command) => {
                                 trace!("found next command found for {handle}: {}", key);
-                                let command: StoredCommand<A> = serde_json::from_value(value)?;
                                 aggregate.apply_command(command);
                                 changed_from_cached = true;
                             }
@@ -380,11 +372,10 @@ where
                             // Store the processed command with the error.
                             let processed_command = processed_command_builder.finish_with_error(&e);
 
-                            let json = serde_json::to_value(&processed_command)?;
-                            aggregate.apply_command(processed_command);
+                            aggregate.apply_command(processed_command.clone());
 
                             changed_from_cached = true;
-                            kv.store(&command_key, json)?;
+                            kv.store(&command_key, &processed_command)?;
 
                             Err(e)
                         }
@@ -421,8 +412,7 @@ where
                                     Err(e)
                                 } else {
                                     // Save the latest command.
-                                    let json = serde_json::to_value(&processed_command)?;
-                                    kv.store(&command_key, json)?;
+                                    kv.store(&command_key, &processed_command)?;
 
                                     // Now send the events to the 'post-save' listeners.
                                     if let Some(events) = processed_command.events() {
@@ -448,8 +438,7 @@ where
 
                 if save_snapshot {
                     let key = Self::key_for_snapshot(handle);
-                    let value = serde_json::to_value(agg.as_ref())?;
-                    kv.store(&key, value)?;
+                    kv.store(&key, agg.as_ref())?;
                 }
 
                 if let Err(e) = res {
@@ -587,7 +576,10 @@ where
     }
 
     fn key_for_snapshot(agg: &MyHandle) -> Key {
-        Key::new_scoped(Self::scope_for_agg(agg), segment!("snapshot.json"))
+        Key::new_scoped(
+            Self::scope_for_agg(agg),
+            const { Segment::make("snapshot.json") }
+        )
     }
 
     fn key_for_command(agg: &MyHandle, version: u64) -> Key {

--- a/src/commons/mod.rs
+++ b/src/commons/mod.rs
@@ -5,6 +5,8 @@ pub mod bgp;
 pub mod crypto;
 pub mod error;
 pub mod eventsourcing;
+pub mod queue;
+pub mod storage;
 pub mod util;
 
 //------------ Response Aliases ----------------------------------------------

--- a/src/commons/queue.rs
+++ b/src/commons/queue.rs
@@ -1,0 +1,860 @@
+//! A task queue on top of a key-value store.
+
+use std::{error, fmt};
+use std::borrow::Cow;
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use url::Url;
+use crate::commons::storage::{
+    Key, KeyValueError, KeyValueStore, Namespace, Scope, Segment, SegmentBuf,
+};
+
+
+//------------ Queue ---------------------------------------------------------
+
+#[derive(Debug)]
+pub struct Queue {
+    store: KeyValueStore,
+}
+
+impl Queue {
+    const RESCHEDULE_AFTER: Duration = Duration::from_secs(15 * 60);
+
+    fn lock_scope() -> Scope {
+        Scope::global()
+    }
+
+    fn pending_scope() -> Scope {
+        Scope::from_segment(PendingTask::SEGMENT)
+    }
+
+    fn running_scope() -> Scope {
+        Scope::from_segment(RunningTask::SEGMENT)
+    }
+}
+
+impl Queue {
+    /// Creates a new queue.
+    pub fn create(
+        storage_uri: &Url,
+        namespace: &Namespace,
+    ) -> Result<Self, Error> {
+        Ok(Queue {
+            store: KeyValueStore::create(storage_uri, namespace)?,
+        })
+    }
+
+    /// Returns the number of pending tasks remaining
+    pub fn pending_tasks_remaining(&self) -> Result<usize, Error> {
+        Ok(self.store.execute(&Self::lock_scope(), |kv| {
+            kv.list_keys(&Self::pending_scope()).map(|list| list.len())
+        })?)
+    }
+
+    /// Returns the number of running tasks
+    pub fn running_tasks_remaining(&self) -> Result<usize, Error> {
+        Ok(self.store.execute(&Self::lock_scope(), |kv| {
+            kv.list_keys(&Self::running_scope()).map(|list| list.len())
+        })?)
+    }
+
+    /// Returns the currently running tasks
+    pub fn running_tasks_keys(&self) -> Result<Vec<Key>, Error> {
+        Ok(self.store.execute(&Self::lock_scope(), |kv| {
+            kv.list_keys(&Self::running_scope())
+        })?)
+    }
+
+    /// Schedule a task.
+    pub fn schedule_task(
+        &self,
+        name: SegmentBuf,
+        value: serde_json::Value,
+        timestamp_millis: Option<u128>,
+        mode: ScheduleMode,
+    ) -> Result<(), Error> {
+        Ok(self.store.execute(
+            &Self::lock_scope(),
+            |s| {
+                let mut new_task = PendingTask {
+                    name: name.as_ref(),
+                    timestamp_millis: timestamp_millis.unwrap_or(now()),
+                    value: &value,
+                };
+                let new_task_key = Key::from(new_task);
+
+                let running_key_opt = s
+                    .list_keys(&Self::running_scope())?
+                    .into_iter()
+                    .filter_map(|k| TaskKey::try_from(&k).ok())
+                    .find(|running| running.name.as_ref() == new_task.name)
+                    .map(|tk| tk.running_key());
+
+                let pending_key_opt = s
+                    .list_keys(&Self::pending_scope())?
+                    .into_iter()
+                    .filter_map(|k| TaskKey::try_from(&k).ok())
+                    .find(|p| p.name.as_ref() == new_task.name)
+                    .map(|tk| tk.pending_key());
+
+                match mode {
+                    ScheduleMode::IfMissing => {
+                        if pending_key_opt.is_some()
+                            || running_key_opt.is_some()
+                        {
+                            // nothing to do, there is something
+                            Ok(())
+                        }
+                        else {
+                            // no pending or running task exists, just add
+                            // the new task
+                            s.store(&new_task_key, new_task.value)
+                        }
+                    }
+                    ScheduleMode::ReplaceExisting => {
+                        if let Some(pending) = pending_key_opt {
+                            s.delete(&pending)?;
+                        }
+                        s.store(&new_task_key, new_task.value)
+                    }
+                    ScheduleMode::ReplaceExistingSoonest => {
+                        if let Some(pending) = pending_key_opt {
+                            if let Ok(tk) = TaskKey::try_from(&pending) {
+                                new_task.timestamp_millis =
+                                    new_task.timestamp_millis.min(
+                                        tk.timestamp_millis
+                                    );
+                            }
+                            s.delete(&pending)?;
+                        }
+
+                        let new_task_key = Key::from(new_task);
+                        s.store(&new_task_key, new_task.value)
+                    }
+                    ScheduleMode::FinishOrReplaceExisting => {
+                        if let Some(running) = running_key_opt {
+                            s.delete(&running)?;
+                        }
+                        if let Some(pending) = pending_key_opt {
+                            s.delete(&pending)?;
+                        }
+                        s.store(&new_task_key, new_task.value)
+                    }
+                    ScheduleMode::FinishOrReplaceExistingSoonest => {
+                        if let Some(running) = running_key_opt {
+                            s.delete(&running)?;
+                        }
+
+                        if let Some(pending) = pending_key_opt {
+                            if let Ok(tk) = TaskKey::try_from(&pending) {
+                                new_task.timestamp_millis =
+                                    new_task.timestamp_millis.min(
+                                        tk.timestamp_millis
+                                    );
+                            }
+                            s.delete(&pending)?;
+                        }
+
+                        let new_task_key = Key::from(new_task);
+                        s.store(&new_task_key, new_task.value)
+                    }
+                }
+            },
+        )?)
+    }
+
+    /// Returns the scheduled timestamp in ms for the named task, if any.
+    pub fn pending_task_scheduled(
+        &self, name: &Segment
+    ) -> Result<Option<u128>, Error> {
+        Ok(self.store.execute(&Self::lock_scope(), |kv| {
+            kv.list_keys(&Self::pending_scope()).map(|keys| {
+                keys.into_iter()
+                    .filter_map(|k| TaskKey::try_from(&k).ok())
+                    .find(|p| p.name.as_ref() == name)
+                    .map(|p| p.timestamp_millis)
+            })
+        })?)
+    }
+
+    /// Marks a running task as finished. Fails if the task is not running.
+    pub fn finish_running_task(
+        &self, running_key: &Key
+    ) -> Result<(), Error> {
+        self.store.execute(&Self::lock_scope(), |kv| {
+            if kv.has(running_key)? {
+                kv.delete(running_key)?;
+                Ok(Ok(()))
+            } else {
+                Ok(Err(Error::other(format!(
+                    "Cannot finish task {}. It is not running.",
+                    running_key
+                ))))
+            }
+        })?
+    }
+
+    /// Reschedules a running task as pending. Fails if the task is not running.
+    pub fn reschedule_running_task(
+        &self, running: &Key, timestamp_millis: Option<u128>
+    ) -> Result<(), Error> {
+        let pending_key = {
+            let mut task_key = TaskKey::try_from(running)?;
+            task_key.timestamp_millis = timestamp_millis.unwrap_or_else(now);
+
+            task_key.pending_key()
+        };
+
+        Ok(self.store.execute(&Self::lock_scope(), |kv| {
+            kv.move_value(running, &pending_key)
+        })?)
+    }
+
+    /// Claims the next scheduled pending task, if any.
+    pub fn claim_scheduled_pending_task(
+        &self
+    ) -> Result<Option<RunningTask>, Error> {
+        Ok(self.store.execute(&Self::lock_scope(), |kv| {
+            let tasks_before = now();
+
+            if let Some(pending) = kv
+                .list_keys(&Self::pending_scope())?
+                .into_iter()
+                .filter_map(|k| TaskKey::try_from(&k).ok())
+                .filter(|tk| tk.timestamp_millis <= tasks_before)
+                .min_by_key(|tk| tk.timestamp_millis)
+            {
+                let pending_key = pending.pending_key();
+
+                if let Some(value) = kv.get(&pending_key)? {
+                    let mut running_task = RunningTask {
+                        name: pending.name.into_owned(),
+                        timestamp_millis: tasks_before,
+                        value,
+                    };
+                    let mut running_key = Key::from(&running_task);
+
+                    if kv.has(&running_key)? {
+                        // It's not pretty to sleep blocking, even if it's
+                        // for 1 ms, but if we don't then get a name collision
+                        // with an existing running task.
+                        std::thread::sleep(Duration::from_millis(1));
+                        running_task.timestamp_millis = now();
+                        running_key = Key::from(&running_task);
+                    }
+
+                    kv.move_value(&pending_key, &running_key)?;
+
+                    Ok(Some(running_task))
+                } else {
+                    Ok(None)
+                }
+            } else {
+                Ok(None)
+            }
+        })?)
+    }
+
+    /// Reschedules running tasks that have timed out.
+    pub fn reschedule_long_running_tasks(
+        &self, reschedule_after: Option<&Duration>
+    ) -> Result<(), Error> {
+        let now = now();
+
+        let reschedule_after = reschedule_after.unwrap_or(
+            &Self::RESCHEDULE_AFTER
+        );
+        let reschedule_timeout = now - reschedule_after.as_millis();
+
+        Ok(self.store.execute(
+            &Self::lock_scope(),
+            |s| {
+                s.list_keys(&Self::running_scope())?
+                    .into_iter()
+                    .filter_map(|k| {
+                        let task = TaskKey::try_from(&k).ok()?;
+                        if task.timestamp_millis <= reschedule_timeout {
+                            Some(task)
+                        } else {
+                            None
+                        }
+                    })
+                    .for_each(|tk| {
+                        let running_key = tk.running_key();
+
+                        let pending_key = TaskKey {
+                            name: Cow::Borrowed(&tk.name),
+                            timestamp_millis: now,
+                        }
+                        .pending_key();
+
+                        let _ = s.move_value(&running_key, &pending_key);
+                    });
+
+                Ok(())
+            },
+        )?)
+    }
+}
+
+
+//------------ TaskKey -------------------------------------------------------
+
+struct TaskKey<'a> {
+    pub name: Cow<'a, Segment>,
+    pub timestamp_millis: u128,
+}
+
+impl TaskKey<'_> {
+    fn key(&self) -> Key {
+        Key::from_str(&format!(
+            "{}{}{}",
+            self.timestamp_millis, SEPARATOR, self.name
+        ))
+        .unwrap()
+    }
+
+    fn running_key(&self) -> Key {
+        let mut key = self.key();
+        key.add_super_scope(RunningTask::SEGMENT);
+        key
+    }
+
+    fn pending_key(&self) -> Key {
+        let mut key = self.key();
+        key.add_super_scope(PendingTask::SEGMENT);
+        key
+    }
+}
+
+impl TryFrom<&Key> for TaskKey<'_> {
+    type Error = InvalidKey;
+
+    fn try_from(key: &Key) -> Result<Self, Self::Error> {
+        let (ts, name) = key
+            .name()
+            .as_str()
+            .split_once(SEPARATOR)
+            .ok_or(InvalidKey(()))?;
+        Ok(TaskKey {
+            name: Cow::Owned(
+                Segment::parse(name).map_err(|_| InvalidKey(()))?.into()
+            ),
+            timestamp_millis: ts.parse().map_err(|_| InvalidKey(()))?,
+        })
+    }
+}
+
+impl From<PendingTask<'_>> for Key {
+    fn from(p: PendingTask<'_>) -> Self {
+        let mut key = Key::from_str(&p.to_string()).unwrap();
+        key.add_super_scope(PendingTask::SEGMENT);
+        key
+    }
+}
+
+impl<'a> From<&'a RunningTask> for Key {
+    fn from(p: &'a RunningTask) -> Self {
+        let mut key = Key::from_str(&p.to_string()).unwrap();
+        key.add_super_scope(RunningTask::SEGMENT);
+        key
+    }
+}
+
+
+//------------ PendingTask ---------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+pub struct PendingTask<'a> {
+    pub name: &'a Segment,
+    pub timestamp_millis: u128,
+    pub value: &'a serde_json::Value,
+}
+
+impl PendingTask<'static> {
+    const SEGMENT: &'static Segment = Segment::make("pending");
+}
+
+
+impl<'a> PartialEq<PendingTask<'a>> for PendingTask<'_> {
+    fn eq(&self, other: &PendingTask<'a>) -> bool {
+        self.name == other.name
+    }
+}
+
+impl fmt::Display for PendingTask<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{}{}",
+            self.timestamp_millis,
+            SEPARATOR.encode_utf8(&mut [0; 4]),
+            self.name,
+        )
+    }
+}
+
+
+//------------ RunningTask ---------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub struct RunningTask {
+    pub name: SegmentBuf,
+    pub timestamp_millis: u128,
+    pub value: serde_json::Value,
+}
+
+impl RunningTask {
+    const SEGMENT: &'static Segment = Segment::make("running");
+}
+
+impl fmt::Display for RunningTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{}{}",
+            self.timestamp_millis,
+            SEPARATOR.encode_utf8(&mut [0; 4]),
+            self.name,
+        )
+    }
+}
+
+/// Defines scheduling behaviour in case a task by the same name already exists.
+#[derive(Clone, Copy, Debug)]
+pub enum ScheduleMode {
+    /// Store new task:
+    /// - replace old task if it exists
+    /// - do NOT finish old task
+    ReplaceExisting,
+
+    /// Store new task:
+    /// - replace old task if it exists
+    /// - use the soonest scheduled time if old task exists
+    /// - do NOT finish old task if it is running
+    ReplaceExistingSoonest,
+
+    /// Store new task:
+    /// - replace old task if it exists
+    /// - finish old task if it is running
+    FinishOrReplaceExisting,
+
+    /// Store new task:
+    /// - replace old task if it exists
+    /// - use the soonest scheduled time if old task exists
+    /// - finish old task if it is running
+    FinishOrReplaceExistingSoonest,
+
+    /// Keep existing pending or running task and in that case do not
+    /// add the new task. Otherwise just add the new task.
+    IfMissing,
+}
+
+
+//------------ Helpers -------------------------------------------------------
+
+
+const SEPARATOR: char = '-';
+
+fn now() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time-travel is not supported")
+        .as_millis()
+}
+
+
+//============ Errors Types ==================================================
+
+//------------ InvalidKey ----------------------------------------------------
+
+#[derive(Clone, Copy, Debug)]
+pub struct InvalidKey(());
+
+impl fmt::Display for InvalidKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("invalid key")
+    }
+}
+
+impl error::Error for InvalidKey { }
+
+
+//------------ Error ---------------------------------------------------------
+
+#[derive(Debug)]
+pub struct Error(ErrorInner);
+
+#[derive(Debug)]
+enum ErrorInner {
+    Store(KeyValueError),
+    InvalidKey,
+    Other(String),
+}
+
+impl Error {
+    fn other(info: impl Into<String>) -> Self {
+        Self(ErrorInner::Other(info.into()))
+    }
+}
+
+impl From<KeyValueError> for Error {
+    fn from(src: KeyValueError) -> Self {
+        Self(ErrorInner::Store(src))
+    }
+}
+
+impl From<InvalidKey> for Error {
+    fn from(_: InvalidKey) -> Self {
+        Self(ErrorInner::InvalidKey)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.0 {
+            ErrorInner::Store(inner) => inner.fmt(f),
+            ErrorInner::InvalidKey => InvalidKey(()).fmt(f),
+            ErrorInner::Other(inner) => f.write_str(inner)
+        }
+    }
+}
+
+impl error::Error for Error { }
+
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+    use std::time::Duration;
+    use serde_json::Value;
+    use url::Url;
+    use super::*;
+
+    fn queue_store(ns: &str) -> Queue {
+        let storage_url = Url::parse("memory://").unwrap();
+        Queue::create(&storage_url, Namespace::parse(ns).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn queue_thread_workers() {
+        let queue = queue_store("queue_thread_workers");
+        queue.store.wipe().unwrap();
+
+        thread::scope(|s| {
+            let create = s.spawn(|| {
+                let queue = queue_store("queue_thread_workers");
+
+                for i in 1..=10 {
+                    let name = &format!("job-{i}");
+                    let segment = Segment::parse(name).unwrap();
+                    let value = Value::from("value");
+
+                    queue
+                        .schedule_task(
+                            segment.into(),
+                            value,
+                            None,
+                            ScheduleMode::FinishOrReplaceExisting,
+                        )
+                        .unwrap();
+                    println!("> Scheduled job {}", &name);
+                }
+            });
+
+            create.join().unwrap();
+            let keys = queue.store.execute(&Scope::global(), |tran| {
+                tran.list_keys(
+                    &Scope::from_segment(PendingTask::SEGMENT)
+                )
+            }).unwrap();
+            assert_eq!(keys.len(), 10);
+
+            for _i in 1..=10 {
+                s.spawn(move || {
+                    let queue = queue_store("queue_thread_workers");
+
+                    while queue.pending_tasks_remaining().unwrap() > 0 {
+                        if let Some(running_task) = queue.claim_scheduled_pending_task().unwrap() {
+                            queue
+                                .finish_running_task(&Key::from(&running_task))
+                                .unwrap();
+                        }
+
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                    }
+                });
+            }
+        });
+
+        let pending = queue.pending_tasks_remaining().unwrap();
+        assert_eq!(pending, 0);
+
+        let running = queue.running_tasks_remaining().unwrap();
+        assert_eq!(running, 0);
+    }
+
+    #[test]
+    fn test_reschedule_long_running() {
+        let queue = queue_store("test_reschedule_long_running");
+        queue.store.wipe().unwrap();
+
+        let name = "job";
+        let segment = Segment::parse(name).unwrap();
+        let value = Value::from("value");
+
+        queue
+            .schedule_task(
+                segment.into(),
+                value,
+                None,
+                ScheduleMode::FinishOrReplaceExisting,
+            )
+            .unwrap();
+
+        assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+
+        let job = queue.claim_scheduled_pending_task().unwrap();
+
+        assert!(job.is_some());
+        assert_eq!(queue.pending_tasks_remaining().unwrap(), 0);
+
+        let job = queue.claim_scheduled_pending_task().unwrap();
+
+        assert!(job.is_none());
+
+        queue
+            .reschedule_long_running_tasks(Some(&Duration::from_secs(0)))
+            .unwrap();
+
+        let existing = queue.pending_task_scheduled(segment).unwrap();
+
+        assert!(existing.is_some());
+        assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+
+        let job = queue.claim_scheduled_pending_task().unwrap();
+
+        assert!(job.is_some());
+        assert_eq!(queue.pending_tasks_remaining().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_reschedule_finished_task() {
+        let queue = queue_store("test_reschedule_finished_task");
+        queue.store.wipe().unwrap();
+
+        let name = "task";
+        let segment = Segment::parse(name).unwrap();
+        let value = Value::from("value");
+
+        // Schedule the task
+        queue
+            .schedule_task(
+                segment.into(),
+                value,
+                None,
+                ScheduleMode::FinishOrReplaceExisting,
+            )
+            .unwrap();
+        assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+
+        // Get the task
+        let running_task = queue.claim_scheduled_pending_task().unwrap().unwrap();
+        assert_eq!(queue.pending_tasks_remaining().unwrap(), 0);
+        assert_eq!(queue.running_tasks_remaining().unwrap(), 1);
+
+        // Finish the task and reschedule
+        // queue.finish_running_task(task, Some(rescheduled)).unwrap();
+        queue
+            .schedule_task(
+                running_task.name,
+                running_task.value,
+                Some(now()),
+                ScheduleMode::FinishOrReplaceExisting,
+            )
+            .unwrap();
+
+        // There should now be a new pending task, and the
+        // running task should be removed.
+        assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+        assert_eq!(queue.running_tasks_remaining().unwrap(), 0);
+
+        // Get and finish the pending task, but do not reschedule it
+        let running_task = queue.claim_scheduled_pending_task().unwrap().unwrap();
+        assert_eq!(queue.pending_tasks_remaining().unwrap(), 0);
+        queue
+            .finish_running_task(&Key::from(&running_task))
+            .unwrap();
+
+        // There should not be a new pending task
+        assert_eq!(queue.pending_tasks_remaining().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_schedule_with_existing_task() {
+        let queue = queue_store("test_schedule_with_existing_task");
+        queue.store.wipe().unwrap();
+
+        let name: SegmentBuf = const { Segment::make("task") }.into();
+        let value_1 = Value::from("value_1");
+        let value_2 = Value::from("value_2");
+
+        let in_a_while = now() + 180;
+
+        // Schedule a task, and then schedule again replacing the old
+        {
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    None,
+                    ScheduleMode::FinishOrReplaceExisting,
+                )
+                .unwrap();
+            assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+
+            // Schedule again, replacing the existing task
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_2.clone(),
+                    None,
+                    ScheduleMode::FinishOrReplaceExisting,
+                )
+                .unwrap();
+            assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+
+            // We should have one task and the value should match the new task.
+            let task = queue.claim_scheduled_pending_task().unwrap().unwrap();
+            assert_eq!(task.value, value_2);
+
+            assert_eq!(queue.running_tasks_remaining().unwrap(), 1);
+            queue.finish_running_task(&Key::from(&task)).unwrap();
+        }
+
+        // Schedule a task, and then schedule again keeping the old
+        {
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    None,
+                    ScheduleMode::FinishOrReplaceExisting,
+                )
+                .unwrap();
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_2.clone(),
+                    Some(in_a_while),
+                    ScheduleMode::IfMissing,
+                )
+                .unwrap();
+
+            // there should be only one task, it should not be rescheduled,
+            // so we get get it and its value should match old.
+            assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+            let task = queue.claim_scheduled_pending_task().unwrap().unwrap();
+            assert_eq!(task.value, value_1);
+        }
+
+        // Schedule a task, and then schedule again rescheduling it
+        {
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    None,
+                    ScheduleMode::FinishOrReplaceExisting,
+                )
+                .unwrap();
+
+            // we expect one pending task
+            assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+
+            // reschedule that task to 3 minutes from now, keeping the
+            // soonest value
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_2.clone(),
+                    Some(in_a_while),
+                    ScheduleMode::FinishOrReplaceExistingSoonest,
+                )
+                .unwrap();
+
+            // we still expect one pending task with the earlier
+            // time and the new value.
+            assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+            let task = queue.claim_scheduled_pending_task().unwrap().unwrap();
+            assert_eq!(task.value, value_2);
+
+            // But if we now schedule a task and then reschedule
+            // it to 3 minutes from now NOT using the soonest. Then
+            // we should see 1 pending task that we cannot claim
+            // because it is not due.
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    None,
+                    ScheduleMode::FinishOrReplaceExisting,
+                )
+                .unwrap();
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    Some(in_a_while),
+                    ScheduleMode::FinishOrReplaceExisting,
+                )
+                .unwrap();
+
+            assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+            assert!(queue.claim_scheduled_pending_task().unwrap().is_none());
+        }
+
+        // Schedule a task, claim it, and then finish and schedule a new task
+        {
+            // schedule a task
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    None,
+                    ScheduleMode::FinishOrReplaceExisting,
+                )
+                .unwrap();
+
+            // there should be 1 pending task, and 0 running
+            assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+            assert_eq!(queue.running_tasks_remaining().unwrap(), 0);
+
+            // claim the task
+            let task = queue.claim_scheduled_pending_task().unwrap().unwrap();
+            assert_eq!(task.value, value_1);
+            assert_eq!(queue.pending_tasks_remaining().unwrap(), 0);
+            assert_eq!(queue.running_tasks_remaining().unwrap(), 1);
+
+            // schedule a new task
+            queue
+                .schedule_task(
+                    name.clone(),
+                    value_2.clone(),
+                    None,
+                    ScheduleMode::FinishOrReplaceExisting,
+                )
+                .unwrap();
+
+            // the running task should now be finished, and there should be 1 new pending task
+            assert_eq!(queue.running_tasks_remaining().unwrap(), 0);
+            assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+
+            // claim the task, it should match the new task
+            let task = queue.claim_scheduled_pending_task().unwrap().unwrap();
+            assert_eq!(task.value, value_2);
+        }
+    }
+}

--- a/src/commons/storage/backends/disk.rs
+++ b/src/commons/storage/backends/disk.rs
@@ -1,0 +1,712 @@
+//! Filesystem-based storage.
+
+use std::{fmt, fs, io, path};
+use std::borrow::Cow;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use serde_json::Value;
+use tempfile::NamedTempFile;
+use url::Url;
+use crate::commons::storage::types::{
+    Key, Namespace, Segment, SegmentBuf, Scope
+};
+use super::{
+    Error as SuperError,
+    Transaction as SuperTransaction
+};
+
+
+//------------ Constants -----------------------------------------------------
+
+/// The directory under the root that contains temporary files.
+const TMP_FILE_DIR: &str = ".tmp";
+
+/// The directory under the root that contains the lock files.
+const LOCK_FILE_DIR: &str = ".locks";
+
+/// The name of the lock file for a scope.
+pub const LOCK_FILE_NAME: &str = "lockfile.lock";
+
+
+
+//------------ Store ---------------------------------------------------------
+
+/// A storage backend that uses the filesystem for storing values.
+///
+/// The backend uses files under a root directory. Each namespace will have
+/// its own directory under this root. In addition, the directory `.tmp` is
+/// used as a temporary storage space. A key’s scope is translated into a
+/// directory path under the namespace directory and its name is translated
+/// into a file name with the extension `.json`. Values are stored in this
+/// file as JSON objects.
+///
+/// In addition, the backend employes a locking strategy as a transaction
+/// replacement. When executing on a given scope, a lock file is created
+/// in a directory under `.locks/$(namespace)/$(scope)` with an advisory
+/// lock on it.
+///
+/// # Notes
+///
+/// * The use of `.tmp` is a change from earlier versions which used `tmp`.
+///   However, since this is a valid namespace, using this directory may
+///   lead to surprises.
+/// * The lock directory used to be under the namespace directory. This has
+///   now been moved to a directory under the base directory so that there
+///   is no collision with an actual scope starting with `.locks`.
+#[derive(Debug)]
+pub struct Store {
+    /// The root path for the store.
+    ///
+    /// This will be a directory with the namespace name under the base
+    /// directory.
+    root: PathBuf,
+
+    /// The path for temporary files within the store.
+    ///
+    /// This will be directly under the base directory and shared between
+    /// namespaces.
+    tmp: PathBuf,
+
+    /// The path for lock files for this namespace.
+    ///
+    /// This will be a directory with the namespace name under the locks
+    /// directory under the base_name.
+    locks: PathBuf,
+}
+
+impl Store {
+    pub fn from_uri(
+        uri: &Url, namespace: &Namespace
+    ) -> Result<Option<Self>, Error> {
+        if uri.scheme() != "local" {
+            return Ok(None)
+        }
+
+        let path = PathBuf::from(format!(
+            "{}{}", uri.host_str().unwrap_or_default(), uri.path()
+        ));
+        let root = path.join(namespace.as_str());
+        let tmp = path.join(TMP_FILE_DIR);
+        let mut locks = path.join(LOCK_FILE_DIR);
+        locks.push(namespace.as_str());
+
+        fs::create_dir_all(&tmp).map_err(|err| {
+            Error::io(
+                format!(
+                    "failed to create temporary directory '{}'",
+                    tmp.display()
+                ),
+                err
+            )
+        })?;
+
+        Ok(Some(Self { root, tmp, locks }))
+    }
+
+    pub fn execute<F, T>(&self, scope: &Scope, op: F) -> Result<T, SuperError>
+    where
+        F: for<'a> Fn(&mut SuperTransaction<'a>) -> Result<T, SuperError>
+    {
+        let mut file_lock = FileLock::create(self.scope_lock_path(scope))?;
+        let _write_lock = file_lock.write()?;
+        op(&mut SuperTransaction::from(self))
+    }
+
+    /// Returns the path for the given key.
+    fn key_path(&self, key: &Key) -> PathBuf {
+        let mut path = self.scope_path(key.scope());
+        path.push(key.name().as_str());
+        path
+    }
+
+    /// Returns the path for the given scope.
+    fn scope_path(&self, scope: &Scope) -> PathBuf {
+        let mut path = self.root.to_path_buf();
+        for segment in scope {
+            path.push(segment.as_str());
+        }
+        path
+    }
+
+    /// Returns the lock file path for the given scope.
+    fn scope_lock_path(&self, scope: &Scope) -> PathBuf {
+        let mut path = self.locks.clone();
+        for segment in scope {
+            path.push(segment.as_str());
+        }
+        path
+    }
+
+    /// Returns a scope for the given path.
+    ///
+    /// Assumes that the path refers to a directory.
+    ///
+    /// Returns `None` if `path` isn’t under the root directory or if it
+    /// contains strange path components.
+    fn path_scope(&self, path: &Path) -> Option<Scope> {
+        let path = path.strip_prefix(&self.root).ok()?;
+
+        let mut scope = Scope::global();
+        for comp in path.components() {
+            match comp {
+                path::Component::Normal(segment) => {
+                    scope.add_sub_scope(
+                        Segment::parse(segment.to_str()?).ok()?
+                    );
+                }
+                _ => return None
+            }
+        }
+        Some(scope)
+    }
+}
+
+
+/// # Reading
+impl Store {
+    /// Returns whether the store is empty.
+    pub fn is_empty(&self) -> Result<bool, Error> {
+        Ok(
+            self.root.read_dir().map(|mut d| {
+                d.next().is_none()
+            }).unwrap_or(true)
+        )
+    }
+
+    /// Returns whether the store contains the given key.
+    pub fn has(&self, key: &Key) -> Result<bool, Error> {
+        self.key_path(key).try_exists().map_err(|err| {
+            Error::io(
+                format!("failed to check existance of key '{}'", key),
+                err
+            )
+        })
+    }
+
+    /// Returns whether the store contains the given scope.
+    pub fn has_scope(&self, scope: &Scope) -> Result<bool, Error> {
+        self.scope_path(scope).try_exists().map_err(|err| {
+            Error::io(
+                format!("failed to check existance of scope '{}'", scope),
+                err
+            )
+        })
+    }
+
+    /// Returns the contents of the stored value with the given key.
+    ///
+    /// If the value does not exist, returns `Ok(None)?.
+    pub fn get<T: DeserializeOwned>(
+        &self, key: &Key
+    ) -> Result<Option<T>, Error> {
+        let path = self.key_path(key);
+        let file = match File::open(&path) {
+            Ok(file) => file,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Ok(None)
+            }
+            Err(err) => {
+                return Err(Error::io(
+                    format!("failed to open file '{}'", path.display()),
+                    err
+                ))
+            }
+        };
+        match serde_json::from_reader(file) {
+            Ok(value) => {
+                Ok(Some(value))
+            }
+            Err(err) => {
+                if err.is_io() {
+                    Err(Error::io(
+                        format!(
+                            "failed to read stored file '{}'",
+                            path.display()
+                        ),
+                        err.into()
+                    ))
+                }
+                else {
+                    Err(Error::deserialize(key.clone(), err))
+                }
+            }
+        }
+    }
+
+    pub fn get_any(&self, key: &Key) -> Result<Option<Value>, Error> {
+        self.get(key)
+    }
+
+    /// Returns all the keys in the given scope.
+    ///
+    /// This includes all keys directly under the given scope as well as
+    /// all keys in sub-scopes.
+    pub fn list_keys(&self, scope: &Scope) -> Result<Vec<Key>, Error> {
+        let path = self.scope_path(scope);
+        let mut res = Vec::new();
+        self.list_dir_keys(&path, &mut res)?;
+        Ok(res)
+    }
+
+    /// Adds all the keys in `path` to `res`.
+    ///
+    /// This is the recursive portion of `Self::list_keys`.
+    fn list_dir_keys(
+        &self, path: &Path, res: &mut Vec<Key>
+    ) -> Result<(), Error> {
+        let dir = match fs::read_dir(path) {
+            Ok(dir) => dir,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Ok(());
+            }
+            Err(err) => {
+                return Err(Error::io(
+                    format!(
+                        "failed to read directory '{}'", path.display()
+                    ),
+                    err
+                ));
+            }
+        };
+        let scope = match self.path_scope(path) {
+            Some(scope) => scope,
+            None => return Ok(())
+        };
+        for item in dir {
+            let item = match item {
+                Ok(item) => item,
+                Err(err) => {
+                    return Err(Error::io(
+                        format!(
+                            "failed to read directory '{}'", path.display()
+                        ),
+                        err
+                    ));
+                }
+            };
+            let file_type = match item.file_type() {
+                Ok(file_type) => file_type,
+                Err(err) => {
+                    return Err(Error::io(
+                        format!(
+                            "failed to read directory '{}'", path.display()
+                        ),
+                        err
+                    ));
+                }
+            };
+            if file_type.is_dir() {
+                self.list_dir_keys(&item.path(), res)?;
+            }
+            else if file_type.is_file() {
+                if let Some(name) =
+                    item.file_name().into_string().ok().and_then(|name| {
+                        SegmentBuf::try_from(name).ok()
+                    })
+                {
+                    res.push(Key::new_scoped(scope.clone(), name))
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns all the scopes in the score.
+    ///
+    pub fn list_scopes(&self) -> Result<Vec<Scope>, Error> {
+        let mut res = Vec::new();
+        self.list_dir_scopes(&self.root, &mut res)?;
+        Ok(res)
+    }
+
+    /// Adds all the scopes under `path` to `res`.
+    ///
+    /// This is the recursive portion of `Self::list_scopes`.
+    fn list_dir_scopes(
+        &self, path: &Path, res: &mut Vec<Scope>
+    ) -> Result<(), Error> {
+        let dir = match fs::read_dir(path) {
+            Ok(dir) => dir,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Ok(());
+            }
+            Err(err) => {
+                return Err(Error::io(
+                    format!(
+                        "failed to read directory '{}'", path.display()
+                    ),
+                    err
+                ));
+            }
+        };
+        match self.path_scope(path) {
+            Some(scope) => res.push(scope),
+            None => return Ok(())
+        };
+        for item in dir {
+            let item = match item {
+                Ok(item) => item,
+                Err(err) => {
+                    return Err(Error::io(
+                        format!(
+                            "failed to read directory '{}'", path.display()
+                        ),
+                        err
+                    ));
+                }
+            };
+            let file_type = match item.file_type() {
+                Ok(file_type) => file_type,
+                Err(err) => {
+                    return Err(Error::io(
+                        format!(
+                            "failed to read directory '{}'", path.display()
+                        ),
+                        err
+                    ));
+                }
+            };
+            if file_type.is_dir() {
+                self.list_dir_scopes(&item.path(), res)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+
+/// # Writing
+impl Store {
+    /// Stores the provided value under the gvien key.
+    ///
+    /// Quielty overwrites a possibly already existing value.
+    pub fn store<T: Serialize>(
+        &self, key: &Key, value: &T
+    ) -> Result<(), Error> {
+        let path = self.key_path(key);
+
+        Self::create_dirs(path.parent())?;
+
+
+        // Write to a temporary file first to ensure that the file can be
+        // written entirely.
+        //
+        // tempfile ensures that the temporary file is cleaned up in case it
+        // would be left behind because of some issue.
+        let mut tmp_file = NamedTempFile::new_in(&self.tmp).map_err(|err| {
+            Error::io(
+                format!(
+                    "writing temp file failed for key: '{}'",
+                    key
+                ),
+                err,
+            )
+        })?;
+
+        serde_json::to_writer_pretty(&mut tmp_file, value).map_err(|err| {
+            if err.is_io() {
+                Error::io(
+                    format!(
+                        "failed to write temp file '{}' for key '{}'",
+                        tmp_file.as_ref().display(),
+                        key
+                    ),
+                    err.into(),
+                )
+            }
+            else {
+                Error::serialize(key.clone(), err)
+            }
+        })?;
+
+        // Move the temporary file to its final location.
+        tmp_file.persist(&path).map_err(|err| {
+            Error::io(
+                format!(
+                    "failed to rename temp file '{}' to '{}'",
+                    err.file.path().display(),
+                    path.display()
+                ),
+                err.error,
+            )
+        })?;
+
+        Ok(())
+    }
+
+    pub fn store_any(&self, key: &Key, value: &Value) -> Result<(), Error> {
+        self.store(key, value)
+    }
+
+    /// Moves a value from one key to another.
+    pub fn move_value(&self, from: &Key, to: &Key) -> Result<(), Error> {
+        let from_path = self.key_path(from);
+        let to_path = self.key_path(to);
+
+        Self::create_dirs(to_path.parent())?;
+
+        fs::rename(&from_path, &to_path).map_err(|err| {
+            Error::io(
+                format!(
+                    "failed to move '{}' to '{}'",
+                    from_path.display(),
+                    to_path.display()
+                ),
+                err
+            )
+        })?;
+        self.remove_empty_dirs(from_path.parent());
+
+        Ok(())
+    }
+
+    /// Moves an entire scope to a new scope.
+    pub fn move_scope(
+        &self, from: &Scope, to: &Scope
+    ) -> Result<(), Error> {
+        let from_path = self.scope_path(from);
+        let to_path = self.scope_path(to);
+
+        Self::create_dirs(Some(&to_path))?;
+
+        fs::rename(from_path.as_path(), to_path.as_path()).map_err(|err| {
+            Error::io(
+                format!(
+                    "failed to move '{}' to '{}'",
+                    from_path.display(),
+                    to_path.display()
+                ),
+                err
+            )
+        })?;
+        self.remove_empty_dirs(Some(&from_path));
+
+        Ok(())
+    }
+
+    /// Removes the stored value for a given key.
+    pub fn delete(&self, key: &Key) -> Result<(), Error> {
+        let path = self.key_path(key);
+
+        fs::remove_file(&path).map_err(|err| {
+            Error::io(
+                format!(
+                    "failed to delete file '{}'", path.display()
+                ),
+                err
+            )
+        })?;
+        self.remove_empty_dirs(path.parent());
+
+        Ok(())
+    }
+
+    /// Removes an entire scope.
+    pub fn delete_scope(&self, scope: &Scope) -> Result<(), Error> {
+        let path = self.scope_path(scope);
+
+        fs::remove_dir_all(&path).map_err(|err| {
+            Error::io(
+                format!(
+                    "failed to recursively delete directory '{}'",
+                    path.display()
+                ),
+                err
+            )
+        })?;
+        self.remove_empty_dirs(path.parent());
+
+        Ok(())
+    }
+
+    /// Removes the entire store.
+    pub fn clear(&self) -> Result<(), Error> {
+        // XXX Not sure this is the best way to do this?
+        if self.root.exists() {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+
+        Ok(())
+    }
+
+    pub fn migrate_namespace(
+        &mut self, namespace: &Namespace
+    ) -> Result<(), Error> {
+        let root_parent = self.root.parent().ok_or_else(|| {
+            Error::other(
+                format!("cannot get parent dir for: {}", self.root.display())
+            )
+        })?;
+
+        let new_root = root_parent.join(namespace.as_str());
+
+        if new_root.exists() {
+            // If the target directory already exists, then it must be empty.
+            if new_root
+                .read_dir()
+                .map_err(|err| {
+                    Error::io(
+                        format!(
+                            "cannot read directory '{}'",
+                            new_root.display(),
+                        ),
+                        err
+                    )
+                })?
+                .next()
+                .is_some()
+            {
+                return Err(Error::other(format!(
+                    "target dir {} already exists and is not empty",
+                    new_root.display(),
+                )));
+            }
+        }
+
+        fs::rename(&self.root, &new_root).map_err(|err| {
+            Error::io(
+                format!(
+                    "cannot rename dir from {} to {}",
+                    self.root.display(),
+                    new_root.display(),
+                ),
+                err
+            )
+        })?;
+        self.root = new_root;
+        Ok(())
+    }
+
+    /// Creates the given directory if necessary.
+    fn create_dirs(path: Option<&Path>) -> Result<(), Error> {
+        if let Some(path) = path {
+            fs::create_dir_all(path).map_err(|err| {
+                Error::io(
+                    format!(
+                        "Failed to create directory '{}'", path.display()
+                    ),
+                    err
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Removes parent directories if they are empty.
+    fn remove_empty_dirs(&self, path: Option<&Path>) {
+        let path = match path {
+            Some(path) => path,
+            None => return
+        };
+        let mut ancestors = path.ancestors();
+        while ancestors.next().and_then(|path| {
+            fs::remove_dir(path).ok()
+        }).is_some()
+        { }
+    }
+}
+
+
+//------------ Transaction ---------------------------------------------------
+
+pub type Transaction<'a> = &'a Store;
+
+
+//------------ FileLock ------------------------------------------------------
+
+#[derive(Debug)]
+struct FileLock {
+    lock: fd_lock::RwLock<File>,
+}
+
+impl FileLock {
+    fn create(path: PathBuf) -> Result<Self, Error> {
+        let lock_path = path.join(LOCK_FILE_NAME);
+        Store::create_dirs(Some(&path))?;
+
+        let mut options = OpenOptions::new();
+        options.create(true).read(true).write(true);
+        let lock_file = options.open(&lock_path).map_err(|err| {
+            Error::io(
+                format!(
+                    "failed to open lock file '{}'", lock_path.display(),
+                ),
+                err
+            )
+        })?;
+
+        Ok(FileLock { lock: fd_lock::RwLock::new(lock_file) })
+    }
+
+    fn write(&mut self) -> Result<fd_lock::RwLockWriteGuard<'_, File>, Error> {
+        self.lock
+            .write()
+            .map_err(|e| Error::other(format!("Cannot get file lock: {}", e)))
+    }
+}
+
+
+//------------ Error ---------------------------------------------------------
+
+#[derive(Debug)]
+pub enum Error {
+    Io {
+        context: Cow<'static, str>,
+        err: io::Error,
+    },
+    Deserialize {
+        key: Key,
+        err: String,
+    },
+    Serialize {
+        key: Key,
+        err: String,
+    },
+    Other(String),
+}
+
+impl Error {
+    fn io(context: impl Into<Cow<'static, str>>, err: io::Error) -> Self {
+        Error::Io { context: context.into(), err }
+    }
+
+    fn deserialize(key: Key, err: impl fmt::Display) -> Self {
+        Error::Deserialize { key, err: err.to_string() }
+    }
+
+    fn serialize(key: Key, err: impl fmt::Display) -> Self {
+        Error::Serialize { key, err: err.to_string() }
+    }
+
+    fn other(info: impl Into<String>) -> Self {
+        Error::Other(info.into())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Io { context, err } => {
+                write!(f, "{}: {}", context, err)
+            }
+            Error::Deserialize { key, err } => {
+                write!(f,
+                    "failed to deserialize value for key '{}': {}",
+                    key, err
+                )
+            }
+            Error::Serialize { key, err } => {
+                write!(f,
+                    "failed to serialize value for key '{}': {}",
+                    key, err
+                )
+            }
+            Error::Other(s) => f.write_str(s)
+        }
+    }
+}
+

--- a/src/commons/storage/backends/memory.rs
+++ b/src/commons/storage/backends/memory.rs
@@ -1,0 +1,385 @@
+//! In-memory storage.
+
+use std::{error, fmt, mem, thread};
+use std::collections::{HashMap, HashSet};
+use std::ops::DerefMut;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+use lazy_static::lazy_static;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use serde_json::Value;
+use url::Url;
+use crate::commons::storage::{
+    Key, Namespace, NamespaceBuf, SegmentBuf, Scope
+};
+use super::{
+    Error as SuperError,
+    Transaction as SuperTransaction
+};
+
+
+//------------ Store ---------------------------------------------------------
+
+#[derive(Debug)]
+pub struct Store {
+    namespace: Arc<MemoryNamespace>,
+}
+
+impl Store {
+    pub fn from_uri(
+        uri: &Url, namespace: &Namespace
+    ) -> Result<Option<Self>, Error> {
+        if uri.scheme() != "memory" {
+            return Ok(None)
+        }
+    
+        Ok(Some(Store {
+            namespace: MEMORY.get_namespace(
+                uri.host_str().unwrap_or_default().into(),
+                namespace.into()
+            )
+        }))
+    }
+
+    pub fn execute<F, T>(&self, scope: &Scope, op: F) -> Result<T, SuperError>
+    where
+        F: for<'a> Fn(&mut SuperTransaction<'a>) -> Result<T, SuperError>
+    {
+        let wait = Duration::from_millis(10);
+        let tries = 1000;
+
+        for i in 0..tries {
+            if self.namespace.locks().insert(scope.clone()) {
+                // The scope was not yet present. We’ve won and can go on.
+                break
+            }
+            else if i >= tries {
+                return Err(Error::ScopeLocked(scope.clone()).into())
+            }
+            thread::sleep(wait);
+        }
+
+        let res = op(&mut SuperTransaction::from(self));
+
+        self.namespace.locks().remove(scope);
+
+        res
+    }
+}
+
+
+/// # Reading
+impl Store {
+    /// Returns whether the store is empty.
+    pub fn is_empty(&self) -> Result<bool, Error> {
+        Ok(self.namespace.values().is_empty())
+    }
+
+    /// Returns whether the store contains the given key.
+    pub fn has(&self, key: &Key) -> Result<bool, Error> {
+        Ok(
+            self.namespace.values().get(key.scope()).map(|scope| {
+                scope.contains_key(key.name())
+            }).unwrap_or(false)
+        )
+    }
+
+    /// Returns whether the store contains the given scope.
+    pub fn has_scope(&self, scope: &Scope) -> Result<bool, Error> {
+        Ok(self.namespace.values().contains_key(scope))
+    }
+
+    /// Returns the contents of the stored value with the given key.
+    ///
+    /// If the value does not exist, returns `Ok(None)?.
+    pub fn get<T: DeserializeOwned>(
+        &self, key: &Key
+    ) -> Result<Option<T>, Error> {
+        match self.namespace.values().get(key.scope()).and_then(|scope| {
+            scope.get(key.name())
+        }) {
+            Some(value) => {
+                serde_json::from_value(value.clone()).map_err(|err| {
+                    Error::deserialize(key.clone(), err)
+                })
+            }
+            None => Ok(None)
+        }
+    }
+
+    pub fn get_any(&self, key: &Key) -> Result<Option<Value>, Error> {
+        self.get(key)
+    }
+
+    /// Returns all the keys in the given scope.
+    ///
+    /// This includes all keys directly under the given scope as well as
+    /// all keys in sub-scopes.
+    pub fn list_keys(&self, scope: &Scope) -> Result<Vec<Key>, Error> {
+        let values = self.namespace.values();
+        let mut res = Vec::new();
+        for (stored_scope, stored_names) in values.iter() {
+            if !stored_scope.starts_with(scope) {
+                continue
+            }
+            for name in stored_names.keys() {
+                res.push(Key::new_scoped(stored_scope.clone(), name.clone()))
+            }
+        }
+        Ok(res)
+    }
+
+    /// Returns all the scopes in the score.
+    ///
+    pub fn list_scopes(&self) -> Result<Vec<Scope>, Error> {
+        Ok(self.namespace.values().keys().cloned().collect())
+    }
+}
+
+
+/// # Writing
+impl Store {
+    /// Stores the provided value under the gvien key.
+    ///
+    /// Quielty overwrites a possibly already existing value.
+    pub fn store<T: Serialize>(
+        &self, key: &Key, value: &T
+    ) -> Result<(), Error> {
+        self.namespace.values().entry(
+            key.scope().clone()
+        ).or_default().insert(
+            key.name().into(),
+            serde_json::to_value(value).map_err(|err| {
+                Error::serialize(key.clone(), err)
+            })?,
+        );
+        Ok(())
+    }
+
+    pub fn store_any(&self, key: &Key, value: &Value) -> Result<(), Error> {
+        self.store(key, value)
+    }
+
+    /// Moves a value from one key to another.
+    pub fn move_value(&self, from: &Key, to: &Key) -> Result<(), Error> {
+        let mut values = self.namespace.values();
+        
+        let value = values.get_mut(from.scope()).and_then(|scope| {
+            scope.remove(from.name())
+        }).ok_or_else(|| Error::NotFound(from.clone()))?;
+
+        values.entry(to.scope().clone()).or_default().insert(
+            to.name().into(), value
+        );
+        Ok(())
+    }
+
+    /// Moves an entire scope to a new scope.
+    pub fn move_scope(
+        &self, from: &Scope, to: &Scope
+    ) -> Result<(), Error> {
+        let mut values = self.namespace.values();
+        let scope = match values.remove(from) {
+            Some(scope) => scope,
+            None => {
+                return Err(Error::NoScope(from.clone()));
+            }
+        };
+        values.insert(to.clone(), scope);
+        Ok(())
+    }
+
+    /// Removes the stored value for a given key.
+    pub fn delete(&self, key: &Key) -> Result<(), Error> {
+        let mut values = self.namespace.values();
+        let scope = match values.get_mut(key.scope()) {
+            Some(scope) => scope,
+            None => return Err(Error::NotFound(key.clone()))
+        };
+        if scope.remove(key.name()).is_none() {
+            return Err(Error::NotFound(key.clone()))
+        }
+        if !scope.is_empty() {
+            return Ok(())
+        }
+        values.remove(key.scope());
+        Ok(())
+    }
+
+    /// Removes an entire scope.
+    pub fn delete_scope(&self, scope: &Scope) -> Result<(), Error> {
+        self.namespace.values().remove(scope);
+        Ok(())
+    }
+
+    /// Removes the entire store.
+    pub fn clear(&self) -> Result<(), Error> {
+        self.namespace.values().clear();
+        Ok(())
+    }
+
+    pub fn migrate_namespace(
+        &mut self, target: &Namespace
+    ) -> Result<(), Error> {
+        if !self.namespace.locks().is_empty() {
+            return Err(Error::PendingLocks);
+        }
+        let mut namespaces = MEMORY.namespaces.lock().expect("poisoned lock");
+        let new_key = (self.namespace.ns_key.0.clone(), target.into());
+        let new = namespaces.entry(new_key.clone()).or_insert_with(|| {
+            MemoryNamespace::new(new_key).into()
+        }).clone();
+
+        // Check that new is empty.
+        let mut new_values = new.values();
+        if !new_values.is_empty() {
+            return Err(Error::NonemptyTargetNamespace(target.into()))
+        }
+
+        // Swap out the values.
+        mem::swap(new_values.deref_mut(), self.namespace.values().deref_mut());
+
+        // Delete our namespace
+        namespaces.remove(&self.namespace.ns_key);
+
+        self.namespace = new.clone();
+        Ok(())
+    }
+}
+
+
+//------------ Transaction ---------------------------------------------------
+
+pub type Transaction<'a> = &'a Store;
+
+
+//------------ MemoryValues --------------------------------------------------
+
+type MemoryValues = HashMap<Scope, HashMap<SegmentBuf, Value>>;
+
+
+//------------ MemoryNamespace -----------------------------------------------
+
+#[derive(Debug)]
+struct MemoryNamespace {
+    ns_key: NsKey,
+    values: Mutex<MemoryValues>,
+    locks: Mutex<HashSet<Scope>>,
+}
+
+impl MemoryNamespace {
+    fn new(ns_key: NsKey) -> Self {
+        Self {
+            ns_key,
+            values: Default::default(),
+            locks: Default::default(),
+        }
+    }
+
+    fn values(&self) -> MutexGuard<MemoryValues> {
+        self.values.lock().expect("poisoned lock")
+    }
+
+    fn locks(&self) -> MutexGuard<HashSet<Scope>> {
+        self.locks.lock().expect("poisoned lock")
+    }
+}
+
+
+//------------ NsKey ---------------------------------------------------------
+
+type NsKey = (String, NamespaceBuf);
+
+
+//------------ Memory --------------------------------------------------------
+
+/// The place where data is actually stored.
+#[derive(Debug, Default)]
+struct Memory {
+    namespaces: Mutex<HashMap<NsKey, Arc<MemoryNamespace>>>,
+}
+
+impl Memory {
+    fn get_namespace(
+        &self,
+        prefix: String,
+        namespace: NamespaceBuf,
+    ) -> Arc<MemoryNamespace> {
+        let ns_key = (prefix, namespace);
+        let mut namespaces = self.namespaces.lock().expect("poisoned lock");
+        namespaces.entry(ns_key.clone()).or_insert_with(|| {
+            MemoryNamespace::new(ns_key).into()
+        }).clone()
+    }
+}
+
+
+//------------ MEMORY --------------------------------------------------------
+
+lazy_static! {
+    static ref MEMORY: Memory = Memory::default();
+}
+
+
+//------------ Error ---------------------------------------------------------
+
+#[derive(Debug)]
+pub enum Error {
+    ScopeLocked(Scope),
+    Deserialize {
+        key: Key,
+        err: String,
+    },
+    Serialize {
+        key: Key,
+        err: String,
+    },
+    NotFound(Key),
+    NoScope(Scope),
+    NonemptyTargetNamespace(NamespaceBuf),
+    PendingLocks,
+}
+
+impl Error {
+    fn deserialize(key: Key, err: impl fmt::Display) -> Self {
+        Error::Deserialize { key, err: err.to_string() }
+    }
+
+    fn serialize(key: Key, err: impl fmt::Display) -> Self {
+        Error::Serialize { key, err: err.to_string() }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::ScopeLocked(scope) => {
+                write!(f, "scope {scope} already locked")
+            }
+            Error::Deserialize { key, err } => {
+                write!(f,
+                    "failed to deserialize value for key '{}': {}",
+                    key, err
+                )
+            }
+            Error::Serialize { key, err } => {
+                write!(f,
+                    "failed to serialize value for key '{}': {}",
+                    key, err
+                )
+            }
+            Error::NotFound(key) => write!(f, "no such key '{key}'"),
+            Error::NoScope(scope) => write!(f, "no such scope '{scope}'"),
+            Error::NonemptyTargetNamespace(ns) => {
+                write!(f, "non-empty target namespace '{ns}'")
+            }
+            Error::PendingLocks => {
+                f.write_str("pending locks on migration")
+            }
+        }
+    }
+}
+
+impl error::Error for Error { }
+

--- a/src/commons/storage/backends/mod.rs
+++ b/src/commons/storage/backends/mod.rs
@@ -1,0 +1,320 @@
+//! Storage backends.
+
+
+//============ Modules =======================================================
+//
+// These need to be added to the macro invocation at the very bottom of this
+// file.
+
+mod disk;
+mod memory;
+
+
+//============ Backend Enum ==================================================
+
+use std::fmt;
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+use url::Url;
+use super::types::{Key, Namespace, Scope};
+
+macro_rules! store {
+    ( $( ( $variant:ident, $module:ident ) )* ) => {
+
+
+        //------------ Backend -----------------------------------------------
+
+        #[derive(Debug)]
+        pub struct Backend(StoreInner);
+
+        #[derive(Debug)]
+        enum StoreInner {
+            $(
+                $variant( self::$module::Store),
+            )*
+        }
+
+        impl Backend {
+            pub fn new(
+                storage_uri: &Url, namespace: &Namespace
+            ) -> Result<Option<Self>, Error> {
+                $(
+                    if let Some(inner) =
+                    self::$module::Store::from_uri(
+                        storage_uri, namespace
+                    )? {
+                        return Ok(Some(Backend(StoreInner::$variant(inner))))
+                    }
+                )*
+
+                Ok(None)
+            }
+
+            pub fn execute<F, T>(
+                &self, scope: &Scope, op: F
+            ) -> Result<T, Error>
+            where
+                F: for<'a> Fn(&mut Transaction<'a>) -> Result<T, Error>
+            {
+                match &self.0 {
+                    $(
+                        StoreInner::$variant(inner) => {
+                            inner.execute(scope, op)
+                        }
+                    )*
+                }
+            }
+
+            pub fn is_empty(&self) -> Result<bool, Error> {
+                match &self.0 {
+                    $(
+                        StoreInner::$variant(inner) => {
+                            Ok(inner.is_empty()?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn get_any(&self, key: &Key) -> Result<Option<Value>, Error> {
+                match &self.0 {
+                    $(
+                        StoreInner::$variant(inner) => {
+                            Ok(inner.get_any(key)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn store_any(
+                &self, key: &Key, value: &Value
+            ) -> Result<(), Error> {
+                match &self.0 {
+                    $(
+                        StoreInner::$variant(inner) => {
+                            Ok(inner.store_any(key, value)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn migrate_namespace(
+                &mut self, to: &Namespace
+            ) -> Result<(), Error> {
+                match &mut self.0 {
+                    $(
+                        StoreInner::$variant(inner) => {
+                            Ok(inner.migrate_namespace(to)?)
+                        }
+                    )*
+                }
+            }
+        }
+
+
+        //------------ Transaction -------------------------------------------
+
+        #[derive(Debug)]
+        pub struct Transaction<'a>(TransactionInner<'a>);
+
+        #[derive(Debug)]
+        enum TransactionInner<'a> {
+            $(
+                $variant(self::$module::Transaction<'a>),
+            )*
+        }
+
+        $(
+            impl<'a> From<self::$module::Transaction<'a>>
+            for Transaction<'a> {
+                fn from(
+                    src: self::$module::Transaction<'a>
+                ) -> Self {
+                    Self(TransactionInner::$variant(src))
+                }
+            }
+
+            impl<'a> TryFrom<Transaction<'a>>
+            for self::$module::Transaction<'a> {
+                type Error = ();
+
+                fn try_from(
+                    src: Transaction<'a>
+                ) -> Result<Self, Self::Error> {
+                    match src.0 {
+                        TransactionInner::$variant(inner) => Ok(inner),
+                        _ => Err(())
+                    }
+                }
+            }
+        )*
+
+        /// # Reading
+        impl<'a> Transaction<'a> {
+            pub fn has(&mut self, key: &Key) -> Result<bool, Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.has(key)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn has_scope(&mut self, scope: &Scope) -> Result<bool, Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.has_scope(scope)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn get<T: DeserializeOwned>(
+                &mut self, key: &Key
+            ) -> Result<Option<T>, Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.get(key)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn list_keys(
+                &mut self, scope: &Scope
+            ) -> Result<Vec<Key>, Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.list_keys(scope)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn list_scopes(&mut self) -> Result<Vec<Scope>, Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.list_scopes()?)
+                        }
+                    )*
+                }
+            }
+        }
+
+
+        /// # Writing
+        impl<'a> Transaction<'a> {
+            pub fn store<T: Serialize>(
+                &mut self, key: &Key, value: &T
+            ) -> Result<(), Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.store(key, value)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn move_value(
+                &mut self, from: &Key, to: &Key
+            ) -> Result<(), Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.move_value(from, to)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn move_scope(
+                &mut self, from: &Scope, to: &Scope
+            ) -> Result<(), Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.move_scope(from, to)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn delete(&mut self, key: &Key) -> Result<(), Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.delete(key)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn delete_scope(&mut self, scope: &Scope) -> Result<(), Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.delete_scope(scope)?)
+                        }
+                    )*
+                }
+            }
+
+            pub fn clear(&mut self) -> Result<(), Error> {
+                match &mut self.0 {
+                    $(
+                        TransactionInner::$variant(inner) => {
+                            Ok(inner.clear()?)
+                        }
+                    )*
+                }
+            }
+        }
+
+
+        //------------ Value -------------------------------------------------
+
+        pub type Value = serde_json::Value;
+
+
+        //------------ Error -------------------------------------------------
+
+        #[derive(Debug)]
+        pub struct Error(ErrorInner);
+
+        #[derive(Debug)]
+        enum ErrorInner {
+            $(
+                $variant(self::$module::Error),
+            )*
+        }
+
+        $(
+            impl From<self::$module::Error> for Error {
+                fn from(src: self::$module::Error) -> Self {
+                    Self(ErrorInner::$variant(src))
+                }
+            }
+        )*
+
+        impl fmt::Display for Error {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match &self.0 {
+                    $(
+                        ErrorInner::$variant(inner) => inner.fmt(f),
+                    )*
+                }
+            }
+        }
+    }
+}
+
+store! {
+    (Disk, disk)
+    (Memory, memory)
+}
+

--- a/src/commons/storage/mod.rs
+++ b/src/commons/storage/mod.rs
@@ -1,0 +1,13 @@
+//! Persistent storage of data.
+
+pub use self::backends::{Backend, Transaction, Error};
+pub use self::store::{KeyValueStore, KeyValueError};
+pub use self::types::{
+    Key, Namespace, NamespaceBuf, ParseNamespaceError, ParseSegmentError,
+    Scope, Segment, SegmentBuf
+};
+
+mod backends;
+mod store;
+mod types;
+

--- a/src/commons/storage/types/key.rs
+++ b/src/commons/storage/types/key.rs
@@ -1,0 +1,109 @@
+//! The key of a stored value.
+
+use std::{fmt, str};
+use super::scope::Scope;
+use super::segment::{ParseSegmentError, Segment, SegmentBuf};
+
+
+//------------ Key -----------------------------------------------------------
+
+/// The key of a stored value.
+///
+/// A key consists of a [`Scope`] and a *name* represented by a
+/// [`SegmentBuf`].
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Key {
+    scope: Scope,
+    name: SegmentBuf,
+}
+
+impl Key {
+    /// Create a key from both a scope and a name.
+    pub fn new_scoped(scope: Scope, name: impl Into<SegmentBuf>) -> Key {
+        Key {
+            name: name.into(),
+            scope,
+        }
+    }
+
+    /// Create a key in the global scope.
+    pub fn new_global(name: impl Into<SegmentBuf>) -> Key {
+        Key::new_scoped(Scope::default(), name)
+    }
+
+    /// Returns a reference to the name of the key.
+    pub fn name(&self) -> &Segment {
+        &self.name
+    }
+
+    /// Returns a reference to the scope of the key.
+    pub fn scope(&self) -> &Scope {
+        &self.scope
+    }
+
+    /// Creates a new key in a subscope of the current scope.
+    ///
+    /// The returned key will use the same name. Its scope will have the
+    /// given segment added to its end.
+    pub fn with_sub_scope(&self, sub_scope: impl Into<SegmentBuf>) -> Self {
+        let mut clone = self.clone();
+        clone.add_sub_scope(sub_scope);
+        clone
+    }
+
+    /// Adds a segment to the end of the scope of the key.
+    pub fn add_sub_scope(&mut self, sub_scope: impl Into<SegmentBuf>) {
+        self.scope.add_sub_scope(sub_scope);
+    }
+
+    /// Creates a new key in a super-scope of the current scope.
+    ///
+    /// The returned key will use the same name. Its scope will have the
+    /// given segment added to its front.
+    pub fn with_super_scope(
+        &self, super_scope: impl Into<SegmentBuf>
+    ) -> Self {
+        let mut clone = self.clone();
+        clone.add_super_scope(super_scope);
+        clone
+    }
+
+    /// Adds a segment to the front of the scope of the key.
+    pub fn add_super_scope(&mut self, super_scope: impl Into<SegmentBuf>) {
+        self.scope.add_super_scope(super_scope);
+    }
+}
+
+
+//--- FromStr
+
+impl str::FromStr for Key {
+    type Err = ParseSegmentError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut segments: Vec<SegmentBuf> = s
+            .split(Segment::SEPARATOR)
+            .map(SegmentBuf::from_str)
+            .collect::<Result<_, _>>()?;
+        let name = segments.pop().unwrap();
+        let scope = Scope::new(segments);
+
+        Ok(Key { name, scope })
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for Key {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.scope.is_global() {
+            write!(f, "{}", self.name)
+        } else {
+            write!(f, "{}{}{}", self.scope, Segment::SEPARATOR, self.name)
+        }
+    }
+}
+
+
+

--- a/src/commons/storage/types/mod.rs
+++ b/src/commons/storage/types/mod.rs
@@ -1,0 +1,11 @@
+//! Types for addressing stored data.
+
+pub use self::key::Key;
+pub use self::namespace::{Namespace, NamespaceBuf, ParseNamespaceError};
+pub use self::scope::Scope;
+pub use self::segment::{ParseSegmentError, Segment, SegmentBuf};
+
+mod key;
+mod namespace;
+mod scope;
+mod segment;

--- a/src/commons/storage/types/namespace.rs
+++ b/src/commons/storage/types/namespace.rs
@@ -1,0 +1,195 @@
+//! Namespaces identifiers.
+
+use std::{borrow, error, fmt, mem, ops, str};
+
+
+//------------ NamespaceBuf --------------------------------------------------
+
+/// An owned namespace identifier.
+///
+/// See [`Namespace`] for more details.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct NamespaceBuf(String);
+
+
+//--- FromStr, From
+
+impl str::FromStr for NamespaceBuf {
+    type Err = ParseNamespaceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Namespace::parse(s)?.to_owned())
+    }
+}
+
+impl From<&Namespace> for NamespaceBuf {
+    fn from(value: &Namespace) -> Self {
+        value.to_owned()
+    }
+}
+
+
+//--- Deref, AsRef, Borrow
+
+impl ops::Deref for NamespaceBuf {
+    type Target = Namespace;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { Namespace::from_str_unchecked(&self.0) }
+    }
+}
+
+impl AsRef<Namespace> for NamespaceBuf {
+    fn as_ref(&self) -> &Namespace {
+        self
+    }
+}
+
+impl borrow::Borrow<Namespace> for NamespaceBuf {
+    fn borrow(&self) -> &Namespace {
+        self
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for NamespaceBuf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+
+//------------ Namespace -----------------------------------------------------
+
+/// A slice with a namespace identifier.
+///
+/// Namespaces are used by the store to separate different instances that use
+/// a shared storage location.
+///
+/// Namespaces must not contain any characters other than ASCII letters,
+/// digits, dash, and underscore. It can at most be 255 characters long.
+///
+/// For the owned variant of a namespace identifier, see [`NamespaceBuf`].
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct Namespace(str);
+
+impl Namespace {
+    /// Parses a namespace from a string slice.
+    pub const fn parse(value: &str) -> Result<&Self, ParseNamespaceError> {
+        if value.is_empty() {
+            return Err(ParseNamespaceError(ParseErrorEnum::Empty))
+        }
+
+        if value.len() > 255 {
+            return Err(ParseNamespaceError(ParseErrorEnum::TooLong))
+        }
+
+        let mut bytes = value.as_bytes();
+        while let Some((head, tail)) = bytes.split_first() {
+            if !head.is_ascii_alphanumeric()
+                && *head != b'-' && *head != b'_'
+            {
+                return Err(
+                    ParseNamespaceError(ParseErrorEnum::IllegalCharacter)
+                )
+            }
+            bytes = tail;
+        }
+
+        Ok(unsafe { Namespace::from_str_unchecked(value) })
+    }
+
+    /// Creates a namespace from the given slice or panics.
+    ///
+    /// This function should be used to create segment constants.
+    pub const fn make(s: &str) -> &Self {
+        match Namespace::parse(s) {
+            Ok(some) => some,
+            Err(_) => panic!("invalid namespace identifier")
+        }
+    }
+
+    /// Creates a namespace from a string slice without checking.
+    ///
+    /// # Safety
+    ///
+    /// The string slice must not be empty, must only contain valid characters
+    /// and must not be longer than 255 characters.
+    pub const unsafe fn from_str_unchecked(s: &str) -> &Self {
+        // SAFETY: Self has #repr(transparent)
+        mem::transmute(s)
+    }
+
+    /// Returns a string slice of the namespace.
+    pub const fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+
+//--- ToOwned
+
+impl ToOwned for Namespace {
+    type Owned = NamespaceBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        NamespaceBuf(self.0.to_owned())
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for Namespace {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+
+//------------ ParseNamespaceError -------------------------------------------
+
+/// An error happened while parsing a string into a [`Namespace`].
+#[derive(Clone, Copy, Debug)]
+pub struct ParseNamespaceError(ParseErrorEnum);
+
+#[derive(Clone, Copy, Debug)]
+enum ParseErrorEnum {
+    Empty,
+    TooLong,
+    IllegalCharacter
+}
+
+impl fmt::Display for ParseNamespaceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::ParseErrorEnum::*;
+
+        f.write_str(
+            match self.0 {
+                Empty => "empty namespace",
+                TooLong => "namespace longer than 255 characters",
+                IllegalCharacter => "namespace contains illegal character",
+            }
+        )
+    }
+}
+
+impl error::Error for ParseNamespaceError { }
+
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_namespace_fails() {
+        assert!(Namespace::parse("").is_err());
+    }
+}
+

--- a/src/commons/storage/types/scope.rs
+++ b/src/commons/storage/types/scope.rs
@@ -1,0 +1,233 @@
+//! The scope portion of a value address.
+
+use std::{cmp, fmt, str};
+use super::segment::{ParseSegmentError, Segment, SegmentBuf};
+
+
+//------------ Scope ---------------------------------------------------------
+
+/// The scope of a key.
+///
+/// A scope consists of a sequence of zero or more segments.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Scope {
+    segments: Vec<SegmentBuf>,
+}
+
+impl Scope {
+    /// Create a new scope from a vec of segments.
+    pub fn new(segments: Vec<SegmentBuf>) -> Self {
+        Scope { segments }
+    }
+
+    /// Create an empty scope.
+    pub fn global() -> Self {
+        Scope::new(Vec::new())
+    }
+    /// Create a scope from a single segment.
+    pub fn from_segment(segment: impl Into<SegmentBuf>) -> Self {
+        Scope::new(vec![segment.into()])
+    }
+
+    /// Returns whether the scope is the global scope, ie., empty.
+    pub fn is_global(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    /// Returns the number of segments in the scope.
+    pub fn len(&self) -> usize {
+        self.segments.len()
+    }
+
+    /// Returns whether the scope is empty.
+    ///
+    /// This is identical to being global.
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    /// Returns the first segment of the scope of any.
+    pub fn first_segment(&self) -> Option<&Segment> {
+        self.segments.first().map(AsRef::as_ref)
+    }
+
+    /// Returns whether the scope matches some other scope.
+    ///
+    /// Two scopes match if the longest of the two contains all [`Segment`]s
+    /// of the other.
+    pub fn matches(&self, other: &Self) -> bool {
+        let min_len = cmp::min(self.segments.len(), other.segments.len());
+        self.segments[0..min_len] == other.segments[0..min_len]
+    }
+
+    /// Returns whether the scope starts with a certain prefix.
+    pub fn starts_with(&self, prefix: &Self) -> bool {
+        if prefix.segments.len() <= self.segments.len() {
+            self.segments[0..prefix.segments.len()] == prefix.segments
+        } else {
+            false
+        }
+    }
+
+    /// Returns a vector of all prefixes of the scope.
+    pub fn sub_scopes(&self) -> Vec<Scope> {
+        self.segments
+            .iter()
+            .scan(Scope::default(), |state, segment| {
+                state.segments.push(segment.clone());
+                Some(state.clone())
+            })
+            .collect()
+    }
+
+    /// Creates a new scope by add an Segment to the end of this scope.
+    pub fn with_sub_scope(&self, sub_scope: impl Into<SegmentBuf>) -> Self {
+        let mut clone = self.clone();
+        clone.add_sub_scope(sub_scope);
+        clone
+    }
+
+    /// Adds a segment to the end of the scope.
+    pub fn add_sub_scope(&mut self, sub_scope: impl Into<SegmentBuf>) {
+        self.segments.push(sub_scope.into());
+    }
+
+    /// Creates a new scope by add a segment to the front of this scope.
+    pub fn with_super_scope(&self, super_scope: impl Into<SegmentBuf>) -> Self {
+        let mut clone = self.clone();
+        clone.add_super_scope(super_scope);
+        clone
+    }
+
+    /// Adds a segment to the front of the scope.
+    pub fn add_super_scope(&mut self, super_scope: impl Into<SegmentBuf>) {
+        self.segments.insert(0, super_scope.into());
+    }
+}
+
+
+//--- From, FromStr, FromIterator
+
+impl str::FromStr for Scope {
+    type Err = ParseSegmentError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_suffix(Segment::SEPARATOR).unwrap_or(s);
+        let segments = s
+            .split(Segment::SEPARATOR)
+            .map(SegmentBuf::from_str)
+            .collect::<Result<_, _>>()?;
+        Ok(Scope { segments })
+    }
+}
+
+impl From<Vec<SegmentBuf>> for Scope {
+    fn from(segments: Vec<SegmentBuf>) -> Self {
+        Scope { segments }
+    }
+}
+
+impl FromIterator<SegmentBuf> for Scope {
+    fn from_iter<T: IntoIterator<Item = SegmentBuf>>(iter: T) -> Self {
+        let segments = iter.into_iter().collect();
+        Scope { segments }
+    }
+}
+
+
+//--- Extend
+
+impl Extend<SegmentBuf> for Scope {
+    fn extend<T: IntoIterator<Item = SegmentBuf>>(&mut self, iter: T) {
+        self.segments.extend(iter)
+    }
+}
+
+
+//--- IntoIterator
+
+impl IntoIterator for Scope {
+    type IntoIter = <Vec<SegmentBuf> as IntoIterator>::IntoIter;
+    type Item = <Vec<SegmentBuf> as IntoIterator>::Item;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.segments.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Scope {
+    type IntoIter = <&'a Vec<SegmentBuf> as IntoIterator>::IntoIter;
+    type Item = <&'a Vec<SegmentBuf> as IntoIterator>::Item;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.segments.iter()
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.segments
+                .iter()
+                .map(|segment| segment.as_str())
+                .collect::<Vec<_>>()
+                .join(Segment::SEPARATOR.encode_utf8(&mut [0; 4]))
+        )
+    }
+}
+
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_matches() {
+        let full: Scope = format!(
+            "this{sep}is{sep}a{sep}beautiful{sep}scope",
+            sep = Segment::SEPARATOR
+        ).parse().unwrap();
+        let partial: Scope = format!(
+            "this{sep}is{sep}a", sep = Segment::SEPARATOR
+        ).parse().unwrap();
+        let wrong: Scope = format!(
+            "this{sep}is{sep}b", sep = Segment::SEPARATOR
+        ).parse().unwrap();
+
+        assert!(full.matches(&partial));
+        assert!(partial.matches(&full));
+        assert!(!partial.matches(&wrong));
+        assert!(!wrong.matches(&partial));
+        assert!(!full.matches(&wrong));
+        assert!(!wrong.matches(&full));
+    }
+
+    #[test]
+    fn test_starts_with() {
+        let full: Scope = format!(
+            "this{sep}is{sep}a{sep}beautiful{sep}scope",
+            sep = Segment::SEPARATOR
+        ).parse().unwrap();
+        let partial: Scope = format!(
+            "this{sep}is{sep}a", sep = Segment::SEPARATOR
+        ).parse().unwrap();
+        let wrong: Scope = format!(
+            "this{sep}is{sep}b", sep = Segment::SEPARATOR
+        ).parse().unwrap();
+
+        assert!(full.starts_with(&partial));
+        assert!(!partial.starts_with(&full));
+        assert!(!partial.starts_with(&wrong));
+        assert!(!wrong.starts_with(&partial));
+        assert!(!full.starts_with(&wrong));
+        assert!(!wrong.starts_with(&full));
+    }
+}
+

--- a/src/commons/storage/types/segment.rs
+++ b/src/commons/storage/types/segment.rs
@@ -1,0 +1,325 @@
+//! Address segments.
+
+use std::{borrow, error, fmt, mem, ops, str};
+
+
+//------------ SegmentBuf ----------------------------------------------------
+
+/// An owned address segment.
+///
+/// This is a non-empty string that does not contain the segment separator.
+///
+/// This is the owned variant of [`Segment`]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct SegmentBuf(String);
+
+
+//--- FromStr, TryFrom, From
+
+impl str::FromStr for SegmentBuf {
+    type Err = ParseSegmentError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Segment::parse(s)?.to_owned())
+    }
+}
+
+impl TryFrom<String> for SegmentBuf {
+    type Error = ParseSegmentError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let _ = Segment::parse(s.as_str())?;
+        Ok(Self(s))
+    }
+}
+
+impl From<&Segment> for SegmentBuf {
+    fn from(value: &Segment) -> Self {
+        value.to_owned()
+    }
+}
+
+
+//--- Deref, AsRef, Borrow
+
+impl ops::Deref for SegmentBuf {
+    type Target = Segment;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { Segment::from_str_unchecked(&self.0) }
+    }
+}
+impl AsRef<Segment> for SegmentBuf {
+    fn as_ref(&self) -> &Segment {
+        self
+    }
+}
+
+impl borrow::Borrow<Segment> for SegmentBuf {
+    fn borrow(&self) -> &Segment {
+        self
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for SegmentBuf {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+
+//------------ Segment -------------------------------------------------------
+
+/// A slice of an address segment.
+///
+/// This is a non-empty string slice that does not contain the segment
+/// separator.
+///
+/// For the owned variant, see [`SegmentBuf`]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct Segment(str);
+
+impl Segment {
+    /// The segment separator character.
+    ///
+    /// This character will never appear inside a segment.
+    pub const SEPARATOR: char = '/';
+
+    /// Parses a segment from a string slice.
+    ///
+    /// The function fails if the string is empty, starts or ends with
+    /// whitespace, or contains the [`Segment::SEPARATOR`].
+    pub const fn parse(value: &str) -> Result<&Self, ParseSegmentError> {
+        let mut bytes = value.as_bytes();
+
+        if bytes.is_empty() {
+            return Err(ParseSegmentError(ParseErrorEnum::Empty));
+        }
+
+        if bytes[0].is_ascii_whitespace() {
+            return Err(
+                ParseSegmentError(ParseErrorEnum::LeadingWhitespace)
+            )
+        }
+
+        if bytes[bytes.len() - 1].is_ascii_whitespace() {
+            return Err(
+                ParseSegmentError(ParseErrorEnum::TrailingWhitespace)
+            )
+        }
+
+        while let Some((head, tail)) = bytes.split_first() {
+            if *head == Self::SEPARATOR as u8 {
+                return Err(
+                    ParseSegmentError(ParseErrorEnum::ContainsSeparator)
+                )
+            }
+            bytes = tail;
+        }
+
+        Ok(unsafe { Self::from_str_unchecked(value) })
+    }
+
+    /// Parses a string and converts into a valid segment.
+    ///
+    /// Any occurences of `'/'` are replaced with `'+'` and an empty slice
+    /// is replaced by `EMPTY`.
+    ///
+    /// Because this leads to potential name collisions, use of this function
+    /// is strongly discouraged.
+    //
+    //  XXX Remove this function. This needs some migration code, though.
+    pub fn parse_lossy(value: &str) -> SegmentBuf {
+        match Segment::parse(value) {
+            Ok(segment) => segment.to_owned(),
+            Err(error) => {
+                let sanitized = value.trim().replace(Segment::SEPARATOR, "+");
+                let nonempty = sanitized
+                    .is_empty()
+                    .then(|| "EMPTY".to_owned())
+                    .unwrap_or(sanitized);
+                let segment = SegmentBuf(nonempty);
+                warn!(
+                    "{value} is not a valid Segment: {error}\n\
+                     using {segment} instead"
+                );
+                segment
+            }
+        }
+    }
+
+    /// Creates a segment from the given slice or panics.
+    ///
+    /// This function should be used to create segment constants.
+    pub const fn make(s: &str) -> &Self {
+        match Segment::parse(s) {
+            Ok(some) => some,
+            Err(_) => panic!("invalid segment identifier")
+        }
+    }
+
+    /// Creates a segment from a string slice without checking.
+    ///
+    /// # Safety
+    ///
+    /// The string slice must not be empty, must not start or end with ASCII
+    /// white space and must not contain `Self::SEPARATOR`.
+    pub const unsafe fn from_str_unchecked(s: &str) -> &Self {
+        // SAFETY: Self has #repr(transparent)
+        mem::transmute(s)
+    }
+
+    /// Returns a string slice of the segment.
+    pub const fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+
+//--- TryFrom
+
+impl<'a> TryFrom<&'a str> for &'a Segment {
+    type Error = ParseSegmentError;
+
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        Segment::parse(s)
+    }
+}
+
+
+//--- ToOwned
+
+impl ToOwned for Segment {
+    type Owned = SegmentBuf;
+
+    fn to_owned(&self) -> Self::Owned {
+        SegmentBuf(self.0.to_owned())
+    }
+}
+
+
+//--- Display
+
+impl fmt::Display for Segment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+
+
+//------------ ParseSegmentError ---------------------------------------------
+
+/// An error happened while parsing a string into a [`Segment`].
+#[derive(Clone, Copy, Debug)]
+pub struct ParseSegmentError(ParseErrorEnum);
+
+#[derive(Clone, Copy, Debug)]
+enum ParseErrorEnum {
+    Empty,
+    LeadingWhitespace,
+    TrailingWhitespace,
+    ContainsSeparator,
+}
+
+impl fmt::Display for ParseSegmentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::ParseErrorEnum::*;
+
+        f.write_str(
+            match self.0 {
+                Empty => "empty segment",
+                LeadingWhitespace => "segment with leading whitespace",
+                TrailingWhitespace => "segment with trailing whitespace",
+                ContainsSeparator => "segments contains separator"
+            }
+        )
+    }
+}
+
+impl error::Error for ParseSegmentError { }
+
+
+//============ Tests =========================================================
+
+#[cfg(test)]
+mod tests {
+    use super::Segment;
+
+    #[test]
+    fn test_trailing_separator_fails() {
+        assert!(
+            Segment::parse(&format!("test{}", Segment::SEPARATOR)).is_err()
+        );
+    }
+
+    #[test]
+    fn test_trailing_space_fails() {
+        assert!(Segment::parse("test ").is_err());
+    }
+
+    #[test]
+    fn test_trailing_tab_fails() {
+        assert!(Segment::parse("test\t").is_err());
+    }
+
+    #[test]
+    fn test_trailing_newline_fails() {
+        assert!(Segment::parse("test\n").is_err());
+    }
+
+    #[test]
+    fn test_leading_separator_fails() {
+        assert!(
+            Segment::parse(&format!("{}test", Segment::SEPARATOR)).is_err()
+        );
+    }
+
+    #[test]
+    fn test_leading_space_fails() {
+        assert!(Segment::parse(" test").is_err());
+    }
+
+    #[test]
+    fn test_leading_tab_fails() {
+        assert!(Segment::parse("\ttest").is_err());
+    }
+
+    #[test]
+    fn test_leading_newline_fails() {
+        assert!(Segment::parse("\ntest").is_err());
+    }
+
+    #[test]
+    fn test_containing_separator_fails() {
+        assert!(
+            Segment::parse(&format!("te{}st", Segment::SEPARATOR)).is_err()
+        );
+    }
+
+    #[test]
+    fn test_containing_space_succeeds() {
+        assert!(Segment::parse("te st").is_ok());
+    }
+
+    #[test]
+    fn test_containing_tab_succeeds() {
+        assert!(Segment::parse("te\tst").is_ok());
+    }
+
+    #[test]
+    fn test_containing_newline_succeeds() {
+        assert!(Segment::parse("te\nst").is_ok());
+    }
+
+    #[test]
+    fn test_segment_succeeds() {
+        assert!(Segment::parse("test").is_ok())
+    }
+}
+

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,6 +1,5 @@
-use kvx::Namespace;
+use crate::commons::storage::Namespace;
 use crate::commons::actor::Actor;
-use crate::commons::eventsourcing::namespace;
 
 pub const KRILL_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const KRILL_VERSION_MAJOR: &str = env!("CARGO_PKG_VERSION_MAJOR");
@@ -44,17 +43,17 @@ pub fn test_announcements_enabled() -> bool {
 // until const fn's are more versatile for str's, we need to use lazy_static
 // to be able to expand the segment macro at compile time, while running the
 // expanded code, which actually makes it a Segment, at runtime
-pub const TASK_QUEUE_NS: &Namespace = namespace!("tasks");
-pub const CASERVER_NS: &Namespace = namespace!("cas");
-pub const CA_OBJECTS_NS: &Namespace = namespace!("ca_objects");
-pub const KEYS_NS: &Namespace = namespace!("keys");
-pub const PUBSERVER_CONTENT_NS: &Namespace = namespace!("pubd_objects");
-pub const PUBSERVER_NS: &Namespace = namespace!("pubd");
-pub const PROPERTIES_NS: &Namespace = namespace!("properties");
-pub const SIGNERS_NS: &Namespace = namespace!("signers");
-pub const STATUS_NS: &Namespace = namespace!("status");
-pub const TA_PROXY_SERVER_NS: &Namespace = namespace!("ta_proxy");
-pub const TA_SIGNER_SERVER_NS: &Namespace = namespace!("ta_signer");
+pub const TASK_QUEUE_NS: &Namespace = Namespace::make("tasks");
+pub const CASERVER_NS: &Namespace = Namespace::make("cas");
+pub const CA_OBJECTS_NS: &Namespace = Namespace::make("ca_objects");
+pub const KEYS_NS: &Namespace = Namespace::make("keys");
+pub const PUBSERVER_CONTENT_NS: &Namespace = Namespace::make("pubd_objects");
+pub const PUBSERVER_NS: &Namespace = Namespace::make("pubd");
+pub const PROPERTIES_NS: &Namespace = Namespace::make("properties");
+pub const SIGNERS_NS: &Namespace = Namespace::make("signers");
+pub const STATUS_NS: &Namespace = Namespace::make("status");
+pub const TA_PROXY_SERVER_NS: &Namespace = Namespace::make("ta_proxy");
+pub const TA_SIGNER_SERVER_NS: &Namespace = Namespace::make("ta_signer");
 
 pub const PROPERTIES_DFLT_NAME: &str = "main";
 

--- a/src/daemon/auth/crypt.rs
+++ b/src/daemon/auth/crypt.rs
@@ -22,9 +22,9 @@
 // 4: https://github.com/NLnetLabs/krill/issues/382
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use kvx::{namespace, segment, Key, Namespace, Segment};
 use crate::commons::KrillResult;
 use crate::commons::error::{ApiAuthError, Error};
+use crate::commons::storage::{Key, Namespace, Segment};
 use crate::commons::util::ext_serde;
 use crate::daemon::config::Config;
 
@@ -38,8 +38,8 @@ const CLEARTEXT_PREFIX_LEN: usize =
     CHACHA20_NONCE_BYTE_LEN + POLY1305_TAG_BYTE_LEN;
 const UNUSED_AAD: [u8; 0] = [0; 0];
 
-const CRYPT_STATE_NS: &Namespace = namespace!("login_sessions");
-const CRYPT_STATE_KEY: &Segment = segment!("main_key");
+const CRYPT_STATE_NS: &Namespace = Namespace::make("login_sessions");
+const CRYPT_STATE_KEY: &Segment = Segment::make("main_key");
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NonceState {

--- a/src/daemon/ca/publishing.rs
+++ b/src/daemon/ca/publishing.rs
@@ -28,10 +28,8 @@ use crate::{
         },
         crypto::KrillSigner,
         error::Error,
-        eventsourcing::{
-            Key, KeyValueStore, PreSaveEventListener, Scope, Segment,
-            SegmentExt,
-        },
+        eventsourcing::PreSaveEventListener,
+        storage::{Key, KeyValueStore, Scope, Segment},
         KrillResult,
     },
     constants::CA_OBJECTS_NS,
@@ -263,36 +261,32 @@ impl CaObjectsStore {
     /// Perform an action (closure) on a mutable instance of the CaObjects for
     /// a CA. If the CA did not have any CaObjects yet, one will be
     /// created. The closure is executed within a write lock.
-    pub fn with_ca_objects<F>(
+    pub fn with_ca_objects<F, T>(
         &self,
         ca: &CaHandle,
-        mut op: F,
-    ) -> KrillResult<()>
+        op: F,
+    ) -> KrillResult<T>
     where
-        F: FnMut(&mut CaObjects) -> KrillResult<()>,
+        F: Fn(&mut CaObjects) -> KrillResult<T>,
     {
-        self.store
-            .execute(&Scope::global(), |kv| {
-                let key = Self::key(ca);
+        self.store.execute(&Scope::global(), |kv| {
+            let key = Self::key(ca);
 
-                let mut objects: CaObjects = if let Some(value) =
-                    kv.get(&key)?
-                {
-                    serde_json::from_value(value)?
-                } else {
+            let mut objects: CaObjects = match kv.get(&key)? {
+                Some(value) => value,
+                None => {
                     CaObjects::new(ca.clone(), None, HashMap::new(), vec![])
-                };
-
-                match op(&mut objects) {
-                    Err(e) => Ok(Err(e)),
-                    Ok(()) => {
-                        let value = serde_json::to_value(&objects)?;
-                        kv.store(&key, value)?;
-                        Ok(Ok(()))
-                    }
                 }
-            })
-            .map_err(Error::KeyValueError)?
+            };
+
+            match op(&mut objects) {
+                Err(e) => Ok(Err(e)),
+                Ok(t) => {
+                    kv.store(&key, &objects)?;
+                    Ok(Ok(t))
+                }
+            }
+        }).map_err(Error::KeyValueError)?
     }
 
     // Re-issue MFT and CRL for all CAs *if needed*, returns all CAs which
@@ -303,16 +297,13 @@ impl CaObjectsStore {
         ca_handle: &CaHandle,
     ) -> KrillResult<bool> {
         debug!("Re-issue for CA {} using force: {}", ca_handle, force);
-        let mut re_issued = false;
         self.with_ca_objects(ca_handle, |objects| {
-            re_issued = objects.re_issue(
+            objects.re_issue(
                 force,
                 &self.issuance_timing,
                 &self.signer,
-            )?;
-            Ok(())
-        })?;
-        Ok(re_issued)
+            )
+        })
     }
 }
 

--- a/src/daemon/ca/status.rs
+++ b/src/daemon/ca/status.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, str::FromStr, sync::RwLock};
 
-use kvx::Namespace;
 use rpki::ca::{
     idexchange::{CaHandle, ChildHandle, ParentHandle, ServiceUri},
     provisioning::ResourceClassListResponse as Entitlements,
@@ -14,15 +13,13 @@ use crate::commons::{
         ErrorResponse, ParentStatus, ParentStatuses, RepoStatus,
     },
     error::Error,
-    eventsourcing::{
-        segment, Key, KeyValueStore, Scope, Segment, SegmentExt,
-    },
+    storage::{Key, KeyValueStore, Namespace, Scope, Segment},
     util::httpclient,
     KrillResult,
 };
 
-const PARENTS_PREFIX: &Segment = segment!("parents-");
-const CHILDREN_PREFIX: &Segment = segment!("children-");
+const PARENTS_PREFIX: &Segment = Segment::make("parents-");
+const CHILDREN_PREFIX: &Segment = Segment::make("children-");
 const JSON_SUFFIX: &str = ".json";
 
 //------------ CaStatus ------------------------------------------------------
@@ -203,7 +200,7 @@ impl StatusStore {
     ) -> KrillResult<()> {
         let key = Key::new_scoped(
             Scope::from_segment(Segment::parse_lossy(ca.as_str())),
-            segment!("status.json"),
+            const { Segment::make("status.json") },
         ); // ca should always be a valid Segment
 
         let status = self.store.get::<CaStatus>(&key).ok().flatten();
@@ -238,7 +235,7 @@ impl StatusStore {
         // we may need to support multiple repos in future
         Key::new_scoped(
             Scope::from_segment(Segment::parse_lossy(ca.as_str())), /* ca should always be a valid Segment */
-            segment!("repos-main.json"),
+            const { Segment::make("repos-main.json") },
         )
     }
 
@@ -544,7 +541,7 @@ mod tests {
         // using the copied the data - that will be done next and start
         // a migration.
         let testbed_status_key = Key::new_scoped(
-            Scope::from_segment(segment!("testbed")),
+            Scope::from_segment(const { Segment::make("testbed") }),
             Segment::parse("status.json").unwrap(),
         );
         let status_testbed_before_migration: CaStatus =

--- a/src/daemon/config.rs
+++ b/src/daemon/config.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use chrono::Duration;
-use kvx::Namespace;
 use log::{error, LevelFilter};
 use rpki::{
     ca::idexchange::PublisherHandle,
@@ -27,7 +26,7 @@ use crate::{
         api::{PublicationServerUris, Token},
         crypto::{OpenSslSignerConfig, SignSupport},
         error::{Error, KrillIoError},
-        eventsourcing::KeyValueStore,
+        storage::{KeyValueStore, Namespace},
         util::ext_serde,
         KrillResult,
     },

--- a/src/daemon/mq.rs
+++ b/src/daemon/mq.rs
@@ -3,31 +3,22 @@
 //! signed material, or asking a newly added parent for resource
 //! entitlements.
 
-use std::{fmt, str::FromStr};
-
+use std::fmt;
+use std::str::FromStr;
+use rpki::ca::idexchange::{CaHandle, ParentHandle};
+use rpki::ca::provisioning::{ResourceClassName, RevocationRequest};
+use rpki::repository::x509::Time;
 use url::Url;
+use crate::commons::eventsourcing;
+use crate::commons::{Error, KrillResult};
+use crate::commons::api::Timestamp;
+use crate::commons::eventsourcing::Aggregate;
+use crate::commons::queue::{Queue, RunningTask, ScheduleMode};
+use crate::commons::storage::{Key, Segment, SegmentBuf};
+use crate::constants::TASK_QUEUE_NS;
+use crate::daemon::ca::{CertAuth, CertAuthEvent};
+use crate::ta::{ta_handle, TrustAnchorProxy, TrustAnchorProxyEvent};
 
-use kvx::{
-    queue::{Queue, RunningTask, ScheduleMode},
-    segment, Segment, SegmentBuf,
-};
-
-use rpki::{
-    ca::{
-        idexchange::{CaHandle, ParentHandle},
-        provisioning::{ResourceClassName, RevocationRequest},
-    },
-    repository::x509::Time,
-};
-
-use crate::{
-    commons::api::Timestamp,
-    commons::eventsourcing,
-    commons::{eventsourcing::Aggregate, Error, KrillResult},
-    constants::TASK_QUEUE_NS,
-    daemon::ca::{CertAuth, CertAuthEvent},
-    ta::{ta_handle, TrustAnchorProxy, TrustAnchorProxyEvent},
-};
 
 //------------ Task ---------------------------------------------------------
 
@@ -118,10 +109,10 @@ impl Task {
                 ))
             }
             Task::RepublishIfNeeded => {
-                Ok(segment!("all_cas_republish_if_needed").to_owned())
+                Ok(Segment::make("all_cas_republish_if_needed").to_owned())
             }
             Task::RenewObjectsIfNeeded => {
-                Ok(segment!("all_cas_renew_objects_if_needed").to_owned())
+                Ok(Segment::make("all_cas_renew_objects_if_needed").to_owned())
             }
             Task::ResourceClassRemoved {
                 ca_handle: ca,
@@ -144,23 +135,23 @@ impl Task {
                 rcn
             )),
             Task::UpdateSnapshots => {
-                Ok(segment!("update_stored_snapshots").to_owned())
+                Ok(Segment::make("update_stored_snapshots").to_owned())
             }
             Task::RrdpUpdateIfNeeded => {
-                Ok(segment!("update_rrdp_if_needed").to_owned())
+                Ok(Segment::make("update_rrdp_if_needed").to_owned())
             }
             #[cfg(feature = "multi-user")]
             Task::SweepLoginCache => {
-                Ok(segment!("sweep_login_cache").to_owned())
+                Ok(Segment::make("sweep_login_cache").to_owned())
             }
             Task::RenewTestbedTa => {
-                Ok(segment!("renew_testbed_ta").to_owned())
+                Ok(Segment::make("renew_testbed_ta").to_owned())
             }
             Task::SyncTrustAnchorProxySignerIfPossible => {
-                Ok(segment!("sync_ta_proxy_signer").to_owned())
+                Ok(Segment::make("sync_ta_proxy_signer").to_owned())
             }
             Task::QueueStartTasks => {
-                Ok(segment!("queue_start_tasks").to_owned())
+                Ok(Segment::make("queue_start_tasks").to_owned())
             }
         }
         .map_err(|e| Error::Custom(format!("could not create name: {}", e)))
@@ -229,14 +220,14 @@ pub enum TaskResult {
 
 #[derive(Debug)]
 pub struct TaskQueue {
-    q: kvx::KeyValueStore,
+    q: Queue,
 }
 
 impl TaskQueue {
     pub fn new(storage_uri: &Url) -> KrillResult<Self> {
-        kvx::KeyValueStore::new(storage_uri, TASK_QUEUE_NS)
-            .map(|q| TaskQueue { q })
-            .map_err(Error::from)
+        Ok(TaskQueue {
+            q: Queue::create(storage_uri, TASK_QUEUE_NS)?,
+        })
     }
 }
 impl TaskQueue {
@@ -333,7 +324,7 @@ impl TaskQueue {
     }
 
     /// Finish a running task, without rescheduling it.
-    pub fn finish(&self, task: &kvx::Key) -> KrillResult<()> {
+    pub fn finish(&self, task: &Key) -> KrillResult<()> {
         debug!("Finish task: {}", task);
         self.q.finish_running_task(task).map_err(Error::from)
     }
@@ -341,7 +332,7 @@ impl TaskQueue {
     /// Reschedule a running task, without finishing it.
     pub fn reschedule(
         &self,
-        task: &kvx::Key,
+        task: &Key,
         priority: Priority,
     ) -> KrillResult<()> {
         debug!("Reschedule task: {} to: {}", task, priority);

--- a/src/daemon/scheduler.rs
+++ b/src/daemon/scheduler.rs
@@ -3,7 +3,6 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use kvx::Namespace;
 use tokio::time::sleep;
 
 use rpki::ca::{
@@ -19,6 +18,7 @@ use crate::{
         crypto::dispatch::signerinfo::SignerInfo,
         error::FatalError,
         eventsourcing::{Aggregate, AggregateStore, WalStore, WalSupport},
+        storage::{Key, Namespace},
         util::KrillVersion,
     },
     constants::{
@@ -82,7 +82,7 @@ impl Scheduler {
         loop {
             while let Some(running_task) = self.tasks.pop() {
                 // remember the key so we can finish or re-schedule the task.
-                let task_key = kvx::Key::from(&running_task);
+                let task_key = Key::from(&running_task);
 
                 match serde_json::from_value(running_task.value) {
                     Err(e) => {

--- a/src/ta/mod.rs
+++ b/src/ta/mod.rs
@@ -41,7 +41,8 @@ mod tests {
         commons::{
             api::{PublicationServerInfo, RepositoryContact},
             crypto::KrillSignerBuilder,
-            eventsourcing::{namespace, AggregateStore, Namespace},
+            eventsourcing::AggregateStore,
+            storage::Namespace,
         },
         daemon::config::ConfigDefaults,
         test,
@@ -57,14 +58,14 @@ mod tests {
             let ta_signer_store: AggregateStore<TrustAnchorSigner> =
                 AggregateStore::create(
                     storage_uri,
-                    namespace!("ta_signer"),
+                    Namespace::make("ta_signer"),
                     false,
                 )
                 .unwrap();
             let ta_proxy_store: AggregateStore<TrustAnchorProxy> =
                 AggregateStore::create(
                     storage_uri,
-                    namespace!("ta_proxy"),
+                    Namespace::make("ta_proxy"),
                     false,
                 )
                 .unwrap();

--- a/src/upgrades/data_migration.rs
+++ b/src/upgrades/data_migration.rs
@@ -2,7 +2,6 @@
 
 use std::{str::FromStr, sync::Arc};
 
-use kvx::{Namespace, Scope};
 use rpki::crypto::KeyIdentifier;
 use url::Url;
 
@@ -13,8 +12,9 @@ use crate::{
             OpenSslSigner,
         },
         eventsourcing::{
-            Aggregate, AggregateStore, KeyValueStore, WalStore, WalSupport,
+            Aggregate, AggregateStore, WalStore, WalSupport,
         },
+        storage::{KeyValueStore, Namespace, Scope},
     },
     constants::{
         CASERVER_NS, KEYS_NS, PROPERTIES_NS, PUBSERVER_CONTENT_NS,

--- a/src/upgrades/pre_0_10_0/cas_migration.rs
+++ b/src/upgrades/pre_0_10_0/cas_migration.rs
@@ -11,9 +11,8 @@ use crate::upgrades::{
 use crate::{
     commons::{
         api::CertAuthStorableCommand,
-        eventsourcing::{
-            AggregateStore, Key, KeyValueStore, Segment, SegmentExt,
-        },
+        eventsourcing::AggregateStore,
+        storage::{Key, KeyValueStore, Segment},
     },
     constants::{CASERVER_NS, CA_OBJECTS_NS},
     daemon::{
@@ -65,7 +64,7 @@ impl CaObjectsMigration {
             let converted: CaObjects = old_objects.try_into()?;
             self.new_store.store(&key, &converted)?;
             debug!(
-                "Stored updated objects for CA {} in {}",
+                "Stored updated objects for CA {} in {:?}",
                 ca, self.new_store
             );
         }

--- a/src/upgrades/pre_0_10_0/pubd_migration.rs
+++ b/src/upgrades/pre_0_10_0/pubd_migration.rs
@@ -3,10 +3,8 @@ use rpki::{ca::idexchange::MyHandle, repository::x509::Time};
 use crate::{
     commons::{
         api::StorableRepositoryCommand,
-        eventsourcing::{
-            segment, AggregateStore, KeyValueStore, Scope, Segment,
-            StoredCommandBuilder,
-        },
+        eventsourcing::{AggregateStore, StoredCommandBuilder},
+        storage::{KeyValueStore, Scope, Segment},
         util::KrillVersion,
     },
     constants::PUBSERVER_NS,
@@ -60,7 +58,7 @@ impl PublicationServerRepositoryAccessMigration {
 
         if store_migration
             .current_kv_store
-            .has_scope(&Scope::from_segment(segment!("0")))?
+            .has_scope(&Scope::from_segment(const { Segment::make("0") }))?
             && versions.from >= KrillVersion::release(0, 9, 0)
             && versions.from < KrillVersion::candidate(0, 10, 0, 1)
         {

--- a/src/upgrades/pre_0_14_0/cas_migration.rs
+++ b/src/upgrades/pre_0_14_0/cas_migration.rs
@@ -11,7 +11,8 @@ use crate::upgrades::{
 use crate::{
     commons::{
         api::CertAuthStorableCommand,
-        eventsourcing::{AggregateStore, KeyValueStore},
+        eventsourcing::AggregateStore,
+        storage::KeyValueStore,
     },
     constants::CASERVER_NS,
     daemon::{

--- a/src/upgrades/pre_0_14_0/mod.rs
+++ b/src/upgrades/pre_0_14_0/mod.rs
@@ -1,6 +1,5 @@
 use std::{fmt, str::FromStr};
 
-use kvx::Namespace;
 use rpki::{
     ca::{idexchange::MyHandle, publication::Base64},
     repository::{
@@ -19,9 +18,10 @@ use crate::{
             SignerInfo, SignerInfoEvent, SignerInfoInitEvent,
         },
         eventsourcing::{
-            Aggregate, AggregateStore, KeyValueStore, Storable,
+            Aggregate, AggregateStore, Storable,
             StoredCommand, StoredCommandBuilder, WithStorableDetails,
         },
+        storage::{KeyValueStore, Namespace},
     },
     daemon::{
         ca::{CertAuthEvent, CertAuthInitEvent},


### PR DESCRIPTION
This PR imports the code previously in the [kvx](https://github.com/nlnetLabs/kvx) crate into Krill itself as the `commons::storage` module. It also rearranges some of Krill’s eventsourcing and queue code to better integrate with the now internal storage module.

This PR is the very first part of #1238 without integration of PostgreSQL support or any changes to the processing model of Krill. It has been split off that PR to so it can be merged already as #1238 has turned out to be more complicated than expected and may need to cook a bit longer.