### PR TITLE
Move login cache sweep from scheduler into its own spawned task.

### DIFF
--- a/src/daemon/http/auth/session.rs
+++ b/src/daemon/http/auth/session.rs
@@ -1,12 +1,16 @@
+//! A cache for login session.
+
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use base64::engine::general_purpose::STANDARD as BASE64_ENGINE;
 use base64::engine::Engine as _;
 use log::{debug, trace, warn};
 use serde::{Deserialize, Serialize};
 use serde::de::DeserializeOwned;
+use tokio::runtime;
+use tokio::sync::RwLock;
 use crate::api::admin::Token;
 use crate::commons::KrillResult;
 use crate::commons::error::{ApiAuthError, Error};
@@ -14,9 +18,22 @@ use super::crypt;
 use super::crypt::{CryptState, NonceState};
 
 
+//------------ Constants -----------------------------------------------------
+
+/// The time in seconds an item will remain in the cache.
 const MAX_CACHE_SECS: u64 = 30;
 
-#[derive(Debug, Serialize, Deserialize)]
+
+//------------ ClientSession -------------------------------------------------
+
+/// The data of a client session.
+///
+/// This information will be serialized and encrypted and then sent to the
+/// client which has to include it in subsequent requests.
+///
+/// The type argument `S` contains additional data that an authentication
+/// provider wishes to include in the session. It needs to be serializable.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClientSession<S> {
     pub start_time: u64,
     pub expires_in: Option<Duration>,
@@ -24,25 +41,8 @@ pub struct ClientSession<S> {
     pub secrets: S,
 }
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum SessionStatus {
-    Active,
-    NeedsRefresh,
-    Expired,
-}
-
-impl<S: Clone> Clone for ClientSession<S> {
-    fn clone(&self) -> Self {
-        Self {
-            start_time: self.start_time,
-            expires_in: self.expires_in,
-            user_id: self.user_id.clone(),
-            secrets: self.secrets.clone(),
-        }
-    }
-}
-
 impl<S> ClientSession<S> {
+    /// Returns the status of the session.
     pub fn status(&self) -> SessionStatus {
         if let Some(expires_in) = &self.expires_in {
             match SystemTime::now().duration_since(UNIX_EPOCH) {
@@ -52,27 +52,28 @@ impl<S> ClientSession<S> {
 
                     let status = if cur_age_secs > max_age_secs {
                         SessionStatus::Expired
-                    } else if cur_age_secs
+                    }
+                    else if cur_age_secs
                         > (max_age_secs.checked_div(2).unwrap())
                     {
                         SessionStatus::NeedsRefresh
-                    } else {
+                    }
+                    else {
                         SessionStatus::Active
                     };
 
                     trace!(
-                        "Login session status check: user_id={}, status={:?}, max age={} secs, cur age={} secs",
-                        &self.user_id,
-                        &status,
-                        max_age_secs,
-                        cur_age_secs
+                        "Login session status check: user_id={}, \
+                         status={:?}, max age={} secs, cur age={} secs",
+                        &self.user_id, &status, max_age_secs, cur_age_secs
                     );
 
                     return status;
                 }
                 Err(err) => {
                     warn!(
-                        "Login session status check: unable to determine the current time: {}",
+                        "Login session status check: unable to determine \
+                         the current time: {}",
                         err
                     );
                 }
@@ -83,24 +84,51 @@ impl<S> ClientSession<S> {
     }
 }
 
-struct CachedSession<S> {
-    pub evict_after: u64,
-    pub session: ClientSession<S>,
+
+//------------ SessionStatus -------------------------------------------------
+
+/// The status of a client session.
+#[derive(Debug, Eq, PartialEq)]
+pub enum SessionStatus {
+    /// The session is still active and has not yet expired.
+    Active,
+
+    /// The session is still active but needs refresh.
+    NeedsRefresh,
+
+    /// The session has expired.
+    Expired,
 }
 
-pub type EncryptFn = fn(&[u8], &[u8], &NonceState) -> KrillResult<Vec<u8>>;
-pub type DecryptFn = fn(&[u8], &[u8]) -> Result<Vec<u8>, ApiAuthError>;
 
-/// A short term cache to reduce the impact of session token decryption and
-/// deserialization (e.g. for multiple requests in a short space of time by
-/// the Lagosta UI client) while keeping potentially sensitive data in-memory
-/// for as short as possible. This cache is NOT responsible for enforcing
-/// token expiration, that is handled separately by the AuthProvider.
+//------------ LoginSessionCache ---------------------------------------------
+
+/// A short term cache for login session.
+///
+/// The main purpose of the cache is to reduce the impact of session token
+/// decryption and deserialization (e.g. for multiple requests in a short
+/// space of time by the same client) while keeping potentially sensitive
+/// data in-memory for as short as possible.
+///
+/// The cache takes care of encrypting client sessions into session tokens
+/// and decrypting them back. It is, however, _not_ responsible for enforcing
+/// token expiration – that is handled separately by the authentication
+/// provider.
+///
+/// The cache is swept by an async task that is to be spawned onto a Tokio
+/// runtime via the [`spawn_sweep`][Self::spawn_sweep] method.
 pub struct LoginSessionCache<S> {
-    cache: RwLock<HashMap<Token, CachedSession<S>>>,
+    /// The actual cache.
+    cache: Arc<RwLock<HashMap<Token, CachedSession<S>>>>,
+
+    /// The function to encrypt a session into a token.
     encrypt_fn: EncryptFn,
+
+    /// The function to decrypt a token into a session.
     decrypt_fn: DecryptFn,
-    ttl_secs: u64,
+
+    /// The time-to-live for cache entries.
+    ttl: Duration,
 }
 
 impl<S> Default for LoginSessionCache<S> {
@@ -110,67 +138,21 @@ impl<S> Default for LoginSessionCache<S> {
 }
 
 impl<S> LoginSessionCache<S> {
+    /// Creates a new login session cache.
     pub fn new() -> Self {
         LoginSessionCache {
-            cache: RwLock::new(HashMap::new()),
+            cache: Arc::new(RwLock::new(HashMap::new())),
             encrypt_fn: crypt::encrypt,
             decrypt_fn: crypt::decrypt,
-            ttl_secs: MAX_CACHE_SECS,
+            ttl: Duration::from_secs(MAX_CACHE_SECS),
         }
     }
 
-    fn time_now_secs_since_epoch() -> KrillResult<u64> {
-        Ok(SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|err| {
-                Error::Custom(format!(
-                    "Unable to determine the current time: {}",
-                    err
-                ))
-            })?
-            .as_secs())
-    }
-
-    fn lookup_session(&self, token: &Token) -> Option<ClientSession<S>>
-    where S: Clone {
-        match self.cache.read() {
-            Ok(readable_cache) => {
-                if let Some(cache_item) = readable_cache.get(token) {
-                    return Some(cache_item.session.clone());
-                }
-            }
-            Err(err) => warn!("Unexpected session cache miss: {}", err),
-        }
-
-        None
-    }
-
-    fn cache_session(&self, token: &Token, session: ClientSession<S>) {
-        match self.cache.write() {
-            Ok(mut writeable_cache) => {
-                match Self::time_now_secs_since_epoch() {
-                    Ok(now) => {
-                        writeable_cache.insert(
-                            token.clone(),
-                            CachedSession {
-                                evict_after: now + self.ttl_secs,
-                                session,
-                            },
-                        );
-                    }
-                    Err(err) => warn!(
-                        "Unable to cache decrypted session token: {}",
-                        err
-                    ),
-                }
-            }
-            Err(err) => {
-                warn!("Unable to cache decrypted session token: {}", err)
-            }
-        }
-    }
-
-    pub fn encode(
+    /// Creates a client session, stores it in the cache and returns it.
+    ///
+    /// Upon success, the method returns the encrypted session token which
+    /// can be given to the client as is.
+    pub async fn encode(
         &self,
         user_id: Arc<str>,
         secrets: S,
@@ -203,21 +185,59 @@ impl<S> LoginSessionCache<S> {
         )?;
         let token = Token::from(BASE64_ENGINE.encode(encrypted_bytes));
 
-        self.cache_session(&token, session);
+        self.cache_session(&token, session).await;
         Ok(token)
     }
 
-    pub fn decode(
-        &self,
-        token: Token,
-        key: &CryptState,
-        add_to_cache: bool,
+    /// Returns the current number of seconds since the Unix epoch.
+    fn time_now_secs_since_epoch() -> KrillResult<u64> {
+        Ok(SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|err| {
+                Error::Custom(format!(
+                    "Unable to determine the current time: {}",
+                    err
+                ))
+            })?
+            .as_secs())
+    }
+
+    /// Stores the given session in the cache.
+    async fn cache_session(&self, token: &Token, session: ClientSession<S>) {
+        match SystemTime::now().checked_add(self.ttl) {
+            Some(evict_after) => {
+                self.cache.write().await.insert(
+                    token.clone(),
+                    CachedSession { evict_after, session },
+                );
+            }
+            None => {
+                warn!(
+                    "Unable to cache decrypted session token: \
+                     eviction time out of system time bounds."
+                )
+            }
+        }
+    }
+
+    /// Decodes the given session token into a client session.
+    ///
+    /// Returns a copy of the client session.
+    /// 
+    /// If the session is still in the cache, will just copy that, otherwise
+    /// will decrypt and deserialize the token.
+    ///
+    /// If `add_to_cache` is `true`, the session will be added to the cache
+    /// again if it had to be decrypted.
+    pub async fn decode(
+        &self, token: Token, key: &CryptState, add_to_cache: bool,
     ) -> Result<ClientSession<S>, ApiAuthError>
     where S: Clone + DeserializeOwned {
-        if let Some(session) = self.lookup_session(&token) {
+        if let Some(session) = self.lookup_session(&token).await {
             trace!("Session cache hit for session id {}", &session.user_id);
             return Ok(session);
-        } else {
+        }
+        else {
             trace!("Session cache miss, deserializing...");
         }
 
@@ -232,17 +252,16 @@ impl<S> LoginSessionCache<S> {
 
         let unencrypted_bytes = (self.decrypt_fn)(&key.key, &bytes)?;
 
-        let session =
-            serde_json::from_slice::<ClientSession<S>>(&unencrypted_bytes)
-                .map_err(|err| {
-                    debug!(
-                        "Invalid bearer token: cannot deserialize: {}",
-                        err
-                    );
-                    ApiAuthError::ApiInvalidCredentials(
-                        "Invalid bearer token".to_string(),
-                    )
-                })?;
+        let session = serde_json::from_slice::<ClientSession<S>>(
+            &unencrypted_bytes
+        ).map_err(|err| {
+            debug!(
+                "Invalid bearer token: cannot deserialize: {}", err
+            );
+            ApiAuthError::ApiInvalidCredentials(
+                "Invalid bearer token".to_string(),
+            )
+        })?;
 
         trace!(
             "Session cache miss, deserialized session id {}",
@@ -250,61 +269,118 @@ impl<S> LoginSessionCache<S> {
         );
 
         if add_to_cache {
-            self.cache_session(&token, session.clone());
+            self.cache_session(&token, session.clone()).await;
         }
 
         Ok(session)
     }
 
-    pub fn remove(&self, token: &Token) {
-        match self.cache.write() {
-            Ok(mut writeable_cache) => {
-                writeable_cache.remove(token);
-            }
-            Err(err) => warn!("Unable to purge cached session: {}", err),
-        }
+    /// Looks up the session for the given token in the cache.
+    async fn lookup_session(&self, token: &Token) -> Option<ClientSession<S>>
+    where S: Clone {
+        self.cache.read().await.get(token).map(|item| {
+            item.session.clone()
+        })
     }
 
-    pub fn size(&self) -> usize {
-        match self.cache.read() {
-            Ok(readable_cache) => readable_cache.len(),
-            Err(err) => {
-                warn!("Unable to query session cache size: {}", err);
-                0
-            }
-        }
+    /// Removes the given token from the cache.
+    ///
+    /// If the token isn’t in the cache, does nothing.
+    pub async fn remove(&self, token: &Token) {
+        self.cache.write().await.remove(token);
     }
 
-    pub fn sweep(&self) -> KrillResult<()> {
-        let mut cache = self.cache.write().map_err(|err| {
-            Error::Custom(format!("Unable to purge session cache: {}", err))
-        })?;
+    /// Returns the current size of the cache.
+    pub async fn size(&self) -> usize {
+        self.cache.read().await.len()
+    }
 
-        let size_before = cache.len();
+    /// Spawns a tokio task regularly removing expired entries.
+    ///
+    /// This task will be spawned onto the provided runtime. It runs every
+    /// sixty seconds and removes all cache entries that have been added more
+    /// than thirty seconds ago.
+    pub fn spawn_sweep(&self, runtime: &runtime::Handle)
+    where S: Send + Sync + 'static {
+        self.spawn_sweep_with_duration(runtime, Duration::from_secs(60));
+    }
 
-        // Only retain cache items that have been cached for less than the
-        // maximum time allowed.
-        let now = Self::time_now_secs_since_epoch()?;
-        cache.retain(|_, v| v.evict_after > now);
+    /// Spawns a sweeper task waiting the given duration between sweeps.
+    ///
+    /// This is here in its own method for speeding up the test below.
+    fn spawn_sweep_with_duration(
+        &self, runtime: &runtime::Handle, duration: Duration,
+    )
+    where S: Send + Sync + 'static {
+        let cache_weak = Arc::downgrade(&self.cache);
+        runtime.spawn(async move {
+            loop {
+                tokio::time::sleep(duration).await;
 
-        let size_after = cache.len();
+                let Some(cache) = cache_weak.upgrade() else {
+                    // The cache is gone, no reason to stay around.
+                    break;
+                };
 
-        if size_after != size_before {
-            debug!(
-                "Login session cache purge: size before={}, size after={}",
-                size_before, size_after
-            );
-        }
+                debug!(
+                    "Login session sweep at {}",
+                    SystemTime::now().duration_since(
+                        SystemTime::UNIX_EPOCH
+                    ).map(|x| x.as_secs()).unwrap_or(0),
+                );
 
-        Ok(())
+                let mut cache = cache.write().await;
+
+                let size_before = cache.len();
+
+                // Only retain cache items that have been cached for less
+                // than the maximum time allowed.
+                let now = SystemTime::now();
+                cache.retain(|_, v| v.evict_after > now);
+
+                let size_after = cache.len();
+
+                if size_after != size_before {
+                    debug!(
+                        "Login session cache purge: \
+                         size before={}, size after={}",
+                        size_before, size_after
+                    );
+                }
+            }
+        });
     }
 }
 
 
+//------------ CachedSession -------------------------------------------------
+
+/// A client session as stored in the session cache.
+struct CachedSession<S> {
+    /// The time when the session should be evicted.
+    evict_after: SystemTime,
+
+    /// The actual client session.
+    session: ClientSession<S>,
+}
+
+//------------ Type Aliases --------------------------------------------------
+
+/// The function to encrypt a session.
+type EncryptFn = fn(&[u8], &[u8], &NonceState) -> KrillResult<Vec<u8>>;
+
+/// The function to decrypt a session.
+type DecryptFn = fn(&[u8], &[u8]) -> Result<Vec<u8>, ApiAuthError>;
+
+
+//============ Tests =========================================================
+
 mod tests {
-    #[test]
-    fn basic_login_session_cache_test() {
+    #[tokio::test]
+    async fn basic_login_session_cache_test() {
         use super::*;
+
+        let _  = stderrlog::new().verbosity(99).init();
 
         let key_bytes: [u8; 32] = [0; 32];
         let key: CryptState = CryptState::from_key_bytes(key_bytes).unwrap();
@@ -315,64 +391,70 @@ mod tests {
             m
         }
 
-        // Create a new cache whose items are elligible for eviction after one
-        // second and which does no actual encryption or decryption.
+        // Create a new cache whose items are elligible for eviction after
+        // three seconds and which does no actual encryption or decryption.
         let mut cache = LoginSessionCache::new();
-        cache.ttl_secs = 1;
+        cache.ttl = Duration::from_secs(5);
         cache.encrypt_fn = |_, v, _| Ok(v.to_vec());
         cache.decrypt_fn = |_, v| Ok(v.to_vec());
         let cache = cache;
 
-        // Add an item to the cache and verify that the cache now has 1 item
-        let item1_token = cache
-            .encode("some id".into(), HashMap::new(), &key, None)
-            .unwrap();
-        assert_eq!(cache.size(), 1);
+        // Start the sweeper to sweep every five seconds.
+        cache.spawn_sweep_with_duration(
+            &tokio::runtime::Handle::current(),
+            Duration::from_secs(5),
+        );
 
-        let item1 = cache.decode(item1_token, &key, true).unwrap();
+        // Second 0: add item to the cache. It should expire at second 3.
+        let item1_token = cache.encode(
+            "some id".into(), HashMap::new(), &key, None
+        ).await.unwrap();
+
+        // Verify that the item is present and correct.
+        assert_eq!(cache.size().await, 1);
+        let item1 = cache.decode(item1_token, &key, true).await.unwrap();
         assert_eq!(item1.user_id.as_ref(), "some id");
         assert_eq!(item1.expires_in, None);
         assert_eq!(item1.secrets, HashMap::new());
 
-        // Wait until after the cached item should have expired but as the
-        // cache has not yet been swept the item should still be in
-        // the cache
-        std::thread::sleep(Duration::from_secs(2));
-        assert_eq!(cache.size(), 1);
+        tokio::time::sleep(Duration::from_secs(4)).await;
 
-        // Add another item to the cache
+        // Second 4: first item has expired but has not been removed from the
+        // cache.
+        assert_eq!(cache.size().await, 1);
+
+        // Still second 4: add second item. It should expire at second 7.
         let some_secrets = one_attr_map("some secret key", "some secret val");
-        let item2_token = cache
-            .encode(
-                "other id".into(),
-                some_secrets,
-                &key,
-                Some(Duration::from_secs(10)),
-            )
-            .unwrap();
-        assert_eq!(cache.size(), 2);
+        let item2_token = cache.encode(
+            "other id".into(), some_secrets, &key,
+            Some(Duration::from_secs(5)),
+        ).await.unwrap();
+        assert_eq!(cache.size().await, 2);
 
-        // Sweep the cache and confirm that the expired cache item has been
-        // removed but the newest cache item remains.
-        cache.sweep().unwrap();
-        assert_eq!(cache.size(), 1);
+        tokio::time::sleep(Duration::from_secs(2)).await;
 
-        // Wait until after the remaining cached item should have expired but
-        // as the cache has not yet been swept the item should still
-        // be present.
-        std::thread::sleep(Duration::from_secs(2));
-        assert_eq!(cache.size(), 1);
+        // Second 6. The cache was swept so the first item should have gone
+        // but the second one should still be here.
+        assert_eq!(cache.size().await, 1);
 
-        let item2 = cache.decode(item2_token, &key, true).unwrap();
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        // Second 8. The second item has also expired but not yet been swept
+        // out of the cache.
+        assert_eq!(cache.size().await, 1);
+
+        let item2 = cache.decode(item2_token, &key, true).await.unwrap();
         assert_eq!(item2.user_id.as_ref(), "other id");
-        assert_eq!(item2.expires_in, Some(Duration::from_secs(10)));
+        assert_eq!(item2.expires_in, Some(Duration::from_secs(5)));
         assert_eq!(
             item2.secrets,
             one_attr_map("some secret key", "some secret val")
         );
 
-        // Sweep the cache and confirm that cache is now empty.
-        cache.sweep().unwrap();
-        assert_eq!(cache.size(), 0);
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Second 11: the cache has been swept again and should be empty.
+        assert_eq!(cache.size().await, 0);
     }
 }
+

--- a/src/daemon/http/metrics.rs
+++ b/src/daemon/http/metrics.rs
@@ -52,7 +52,7 @@ pub async fn metrics(req: Request) -> Result<HttpResponse, Request> {
             "auth_session_cache_size",
             "total number of cached login session tokens",
         ),
-        server.login_session_cache_size(),
+        server.login_session_cache_size().await,
     );
 
     if let Ok(cas_stats) = server.cas_stats().await {

--- a/src/daemon/mq.rs
+++ b/src/daemon/mq.rs
@@ -86,7 +86,10 @@ pub enum Task {
 
     RrdpUpdateIfNeeded,
 
-    #[cfg(feature = "multi-user")]
+    // This task is deprecated - the authorizer takes care of this itself.
+    // The mask may, however, still be in the task queue and currently the
+    // scheduler panics on unknown tasks, so we need to keep it for now and
+    // just not do anything.
     SweepLoginCache,
 }
 
@@ -142,10 +145,6 @@ impl Task {
             Task::RrdpUpdateIfNeeded => {
                 Ok(Segment::make("update_rrdp_if_needed").to_owned())
             }
-            #[cfg(feature = "multi-user")]
-            Task::SweepLoginCache => {
-                Ok(Segment::make("sweep_login_cache").to_owned())
-            }
             Task::RenewTestbedTa => {
                 Ok(Segment::make("renew_testbed_ta").to_owned())
             }
@@ -154,6 +153,9 @@ impl Task {
             }
             Task::QueueStartTasks => {
                 Ok(Segment::make("queue_start_tasks").to_owned())
+            }
+            Task::SweepLoginCache => {
+                Ok(Segment::make("sweep_login_cache").to_owned())
             }
         }
         .map_err(|e| Error::Custom(format!("could not create name: {}", e)))
@@ -193,9 +195,6 @@ impl fmt::Display for Task {
             Task::RrdpUpdateIfNeeded => {
                 write!(f, "create new RRDP delta, if needed")
             }
-
-            #[cfg(feature = "multi-user")]
-            Task::SweepLoginCache => write!(f, "sweep up expired logins"),
             Task::ResourceClassRemoved { ca_handle: ca, .. } => {
                 write!(f, "resource class removed for '{}' ", ca)
             }
@@ -208,6 +207,7 @@ impl fmt::Display for Task {
                     ca, rcn
                 )
             }
+            Task::SweepLoginCache => write!(f, "sweep up expired logins"),
         }
     }
 }


### PR DESCRIPTION
This PR moves sweeping the login session cache from being driven of the scheduler (and thus using persistent tasks) into a Tokio task that is spawned onto the runtime at the start of the daemon.

The PR is one step in separating Krill server core logic from the HTTP API logic.