### PR TITLE
Code improvements suggested by Clippy 1.87.

### DIFF
--- a/src/cli/options/bgpsec.rs
+++ b/src/cli/options/bgpsec.rs
@@ -17,6 +17,7 @@ use super::ca;
 //------------ Command -------------------------------------------------------
 
 #[derive(clap::Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Command {
     /// Show current BGPsec router keys
     List(List),

--- a/src/cli/ta/options/mod.rs
+++ b/src/cli/ta/options/mod.rs
@@ -17,6 +17,7 @@ use clap::Parser;
     version,
     about = "Manage the Krill trust anchor proxy and signer.",
 )]
+#[allow(clippy::large_enum_variant)]
 pub enum Command {
     /// Manage the Trust Anchor Proxy
     Proxy(proxy::Command),

--- a/src/cli/ta/options/proxy.rs
+++ b/src/cli/ta/options/proxy.rs
@@ -50,6 +50,7 @@ impl Command {
 //------------ Subcommand ----------------------------------------------------
 
 #[derive(clap::Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Subcommand {
     /// Initialise the proxy
     Init(Init),
@@ -318,6 +319,7 @@ impl fmt::Display for TasrMsg {
 //------------ Children ------------------------------------------------------
 
 #[derive(clap::Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum Children {
     /// Add a child
     Add(ChildrenAdd),
@@ -440,6 +442,7 @@ impl FromStr for CertAuthInfoFile {
 //------------ CertAuthInfoFileError------------------------------------------
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum CertAuthInfoFileError {
     Io(String, io::Error),
     Parse(String, serde_json::Error),

--- a/src/cli/ta/options/signer.rs
+++ b/src/cli/ta/options/signer.rs
@@ -305,6 +305,7 @@ impl FromStr for PrivateKeyFile {
 //------------ ConfigFileError -----------------------------------------------
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum ConfigFileError {
     Parse(String, ConfigError),
     Create(SignerClientError),

--- a/src/commons/error.rs
+++ b/src/commons/error.rs
@@ -1386,7 +1386,7 @@ mod tests {
 
         let krill_io_err = KrillIoError::new(
             "Trouble reading 'foo'".to_string(),
-            io::Error::new(io::ErrorKind::Other, "can't read file"),
+            io::Error::other("can't read file"),
         );
 
         verify(

--- a/src/commons/file.rs
+++ b/src/commons/file.rs
@@ -119,8 +119,7 @@ pub fn load_json<O: DeserializeOwned>(
                 "Could not load json for file: {}",
                 full_path.to_string_lossy()
             ),
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 format!("could not deserialize json: {}", e),
             ),
         )

--- a/src/daemon/http/tls.rs
+++ b/src/daemon/http/tls.rs
@@ -338,7 +338,7 @@ impl TlsConfigError {
     ) -> Self {
         Self {
             kind,
-            err: io::Error::new(io::ErrorKind::Other, err),
+            err: io::Error::other(err),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! The _Krill_ library crate.
 
+// XXX Temporary allow for `commons::error::Error` until we refactor that.
+#![allow(clippy::result_large_err)]
+
 pub mod api;
 pub mod cli;
 pub mod commons;


### PR DESCRIPTION
This PR implements some of the suggestions made by Clippy 1.87.

Some of the suggestions have been ignored by way of allow attributes. In particular, we allow the large size of `commons::error::Error` for now, but this will need to be fixed in another PR.