### PR TITLE
Mark types that are used for storing state.

### DIFF
--- a/src/api/admin.rs
+++ b/src/api/admin.rs
@@ -163,6 +163,8 @@ pub struct PublishedFile {
 //------------ PublicationServerInfo -----------------------------------------
 
 /// Details of a publication server.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PublicationServerInfo {
     /// The public key used by the publication server.
@@ -189,6 +191,8 @@ pub struct ApiRepositoryContact {
 //------------ RepositoryContact ---------------------------------------------
 
 /// A contact with a remote repository.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RepositoryContact {
     /// Information about the remote repository.
@@ -269,6 +273,8 @@ impl fmt::Display for ParentCaReq {
 //------------ ParentServerInfo ----------------------------------------------
 
 /// Information about the server of the parent CA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ParentServerInfo {
     /// The URI where the CA needs to send its RFC6492 messages
@@ -310,6 +316,8 @@ impl fmt::Display for ParentServerInfo {
 /// a data migration of past events, and because theoretically we may
 /// need other options in future if there is an alternative to RFC 6492
 /// one day.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 #[serde(rename_all = "snake_case")]
@@ -368,6 +376,8 @@ impl fmt::Display for ParentCaContact {
 /// The protocol to use when contacting a parent.
 ///
 /// This type is used when saving and presenting the command history.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StorableParentContact {
@@ -410,6 +420,8 @@ impl fmt::Display for CertAuthInit {
 //------------ AddChildRequest -----------------------------------------------
 
 /// Information necessary to request adding a child CA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AddChildRequest {
     /// The handle to identify the child with.
@@ -449,16 +461,6 @@ pub struct UpdateChildRequest {
     /// Changes to the names of a resource class.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub resource_class_name_mapping: Option<ResourceClassNameMapping>,
-}
-
-/// A mapping from the name of a resource class in parent and child.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct ResourceClassNameMapping {
-    /// The name of the resource class at the parent.
-    pub name_in_parent: ResourceClassName,
-
-    /// The name of the resource class at the child.
-    pub name_for_child: ResourceClassName,
 }
 
 impl UpdateChildRequest {
@@ -528,6 +530,20 @@ impl fmt::Display for UpdateChildRequest {
         }
         Ok(())
     }
+}
+
+//------------ ResourceClassNameMapping --------------------------------------
+
+/// A mapping from the name of a resource class in parent and child.
+//
+//  *Warning:* This type is used in stored state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ResourceClassNameMapping {
+    /// The name of the resource class at the parent.
+    pub name_in_parent: ResourceClassName,
+
+    /// The name of the resource class at the child.
+    pub name_for_child: ResourceClassName,
 }
 
 

--- a/src/api/aspa.rs
+++ b/src/api/aspa.rs
@@ -14,15 +14,21 @@ use serde::{Deserialize, Serialize};
 //------------- Type Aliases -------------------------------------------------
 
 /// The type of a customer ASN.
+//
+//  *Warning:* This type is used in stored state.
 pub type CustomerAsn = Asn;
 
 /// The type of a provider ASN.
+//
+//  *Warning:* This type is used in stored state.
 pub type ProviderAsn = Asn;
 
 
 //------------ AspaDefinitionUpdates -----------------------------------------
 
 /// Information for an ASPA definition update.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AspaDefinitionUpdates {
     /// Definitions to add or replace.
@@ -87,6 +93,8 @@ impl fmt::Display for AspaDefinitionList {
 //------------ AspaDefinition ------------------------------------------------
 
 /// The definition of an ASPA record.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AspaDefinition {
     /// The customer ASN.
@@ -225,6 +233,8 @@ impl FromStr for AspaDefinition {
 //------------ AspaProvidersUpdate -------------------------------------------
 
 /// An update to the provider ASN list of an ASPA definition.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AspaProvidersUpdate {
     /// A list of ASNs to be added to the provider ASNs.

--- a/src/api/bgpsec.rs
+++ b/src/api/bgpsec.rs
@@ -38,6 +38,8 @@ impl Eq for BgpSecDefinition {}
 //------------ BgpSecAsnKey ------------------------------------------------
 
 /// A BGPsec router key for a specific ASN.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct BgpSecAsnKey {
     /// The autonomous system that uses the router key.

--- a/src/api/ca.rs
+++ b/src/api/ca.rs
@@ -42,7 +42,9 @@ use super::roa::{RoaPayload, RoaPayloadJsonMapKey};
 
 //------------ IdCertInfo ----------------------------------------------------
 
-/// A encoded ID certificate and SHA256 hash of the encoding.
+/// An encoded ID certificate and SHA256 hash of the encoding.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct IdCertInfo {
     /// The public key of the ID certificate.
@@ -130,6 +132,8 @@ impl fmt::Display for IdCertPem<'_> {
 //------------ ChildState ----------------------------------------------------
 
 /// The suspension status of a child CA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(
     Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize,
 )]
@@ -197,6 +201,8 @@ impl fmt::Display for ChildCaInfo {
 pub struct Received;
 
 /// A certificate that was received from a parent CA.
+//
+//  *Warning:* This type is used in stored state.
 pub type ReceivedCert = CertInfo<Received>;
 
 
@@ -207,6 +213,8 @@ pub type ReceivedCert = CertInfo<Received>;
 pub struct Issued;
 
 /// A certificate which has been issued to a child CA.
+//
+//  *Warning:* This type is used in stored state.
 pub type IssuedCertificate = CertInfo<Issued>;
 
 
@@ -217,6 +225,8 @@ pub type IssuedCertificate = CertInfo<Issued>;
 pub struct Suspended;
 
 /// An certificate which has been suspended because the child is inactive.
+//
+//  *Warning:* This type is used in stored state.
 pub type SuspendedCert = CertInfo<Suspended>;
 
 
@@ -227,6 +237,8 @@ pub type SuspendedCert = CertInfo<Suspended>;
 pub struct Unsuspended;
 
 /// A certificate that has been unsuspended and needs to be re-activated.
+//
+//  *Warning:* This type is used in stored state.
 pub type UnsuspendedCert = CertInfo<Unsuspended>;
 
 
@@ -239,6 +251,8 @@ pub type UnsuspendedCert = CertInfo<Unsuspended>;
 ///
 /// This type is generic over a marker type `T` indicating the status of the
 /// certificate.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CertInfo<T> {
     /// Where this certificate is published by the parent
@@ -615,6 +629,8 @@ impl fmt::Display for ObjectName {
 //------------ Revocation ----------------------------------------------------
 
 /// Information for an entry on a CRL.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Revocation {
     /// The serial number of the certificate to be revoked.
@@ -675,6 +691,8 @@ impl From<&Aspa> for Revocation {
 //------------ Revocations ---------------------------------------------------
 
 /// The list of revocation entries of a CRL.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Revocations(Vec<Revocation>);
 
@@ -2093,6 +2111,8 @@ pub struct BgpStats {
 //------------ RtaName -------------------------------------------------------
 
 /// The name of an RTA.
+//
+//  *Warning:* This type is used in stored state.
 pub type RtaName = String;
 
 

--- a/src/api/roa.rs
+++ b/src/api/roa.rs
@@ -41,6 +41,8 @@ use super::ca::Revocation;
 /// accordance with best practices (avoid fate sharing in case a prefix is
 /// suddenly no longer held), but aggregation will be done if a
 /// (configurable) threshold is exceeded.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct RoaPayload {
     /// The autonomous system authorized to originate routes.
@@ -229,6 +231,8 @@ impl fmt::Debug for RoaPayload {
 //------------ RoaPayloadJsonMapKey ------------------------------------------
 
 /// A [`RoaPayload`] that serializes as a string.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialOrd, PartialEq)]
 pub struct RoaPayloadJsonMapKey(RoaPayload);
 
@@ -302,6 +306,8 @@ impl<'de> Deserialize<'de> for RoaPayloadJsonMapKey {
 /// Existing ROAs may contain other information that the Krill system is
 /// responsible for, rather than the API (update) user. For example: which ROA
 /// object(s) the intended configuration appears on.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct RoaConfiguration {
     /// The ROA payload definition.
@@ -390,6 +396,8 @@ impl fmt::Display for RoaConfiguration {
 //------------ RoaInfo -------------------------------------------------------
 
 /// Information about a ROA *object.*
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RoaInfo {
     /// The route or routes authorized by this ROA
@@ -507,6 +515,8 @@ impl fmt::Display for ConfiguredRoas {
 /// Multiple updates are sent as a single delta, because it's important that
 /// all authorizations for a given prefix are published together in order to
 /// avoid invalidating announcements.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RoaConfigurationUpdates {
     /// The ROA configurations to be added.
@@ -630,6 +640,8 @@ impl fmt::Display for RoaConfigurationUpdates {
 /// A prefix that knows which family it belongs to.
 ///
 /// This type serializes into the string representation of the prefix.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub enum TypedPrefix {
     /// An IPv4 prefix.
@@ -808,6 +820,8 @@ impl Serialize for TypedPrefix {
 //------------ Ipv4Prefix ----------------------------------------------------
 
 /// An IPv4 prefix.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Ipv4Prefix(Prefix);
 
@@ -844,6 +858,8 @@ impl From<Ipv4Prefix> for Prefix {
 //------------ Ipv6Prefix ----------------------------------------------------
 
 /// An IPv6 prefix.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
 pub struct Ipv6Prefix(Prefix);
 

--- a/src/api/rta.rs
+++ b/src/api/rta.rs
@@ -67,6 +67,8 @@ impl fmt::Display for RtaContentRequest {
 /// Resource Tagged Attestations
 ///
 /// See: <https://tools.ietf.org/id/draft-michaelson-rpki-rta-01.html>
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
 pub struct ResourceTaggedAttestation {
     #[serde(

--- a/src/api/ta.rs
+++ b/src/api/ta.rs
@@ -11,7 +11,6 @@ use rpki::{
     ca::{
         idexchange::{ChildHandle, RecipientHandle, SenderHandle},
         provisioning,
-        provisioning::ResourceClassName,
         publication::Base64,
         sigmsg::SignedMessage,
     },
@@ -32,6 +31,7 @@ use crate::api::admin::PublishedFile;
 use crate::api::ca::{
     IdCertInfo, IssuedCertificate, ObjectName, ReceivedCert, Revocations,
 };
+use crate::server::ca::UsedKeyState;
 use crate::server::ca::publishing::{
     ManifestBuilder, ObjectSetRevision, PublishedCrl,
     PublishedManifest, PublishedObject, 
@@ -423,6 +423,7 @@ impl std::fmt::Display for Nonce {
 
 //------------ TrustAnchorProxySignerExchange ------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorProxySignerExchange {
     pub time: Time,
@@ -432,6 +433,7 @@ pub struct TrustAnchorProxySignerExchange {
 
 //------------ TrustAnchorSignedMessage ------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorSignedMessage {
     message: Base64,
@@ -476,6 +478,8 @@ impl From<SignedMessage> for TrustAnchorSignedMessage {
 
 /// A [`TrustAnchorSignerRequest`] and its signed message as base64 for
 /// (re-)validation.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorSignedRequest {
     signed: TrustAnchorSignedMessage,
@@ -525,6 +529,8 @@ impl fmt::Display for TrustAnchorSignedRequest {
 /// a key. If there are no requests for a child, then it is
 /// assumed that the current issued certificate(s) to the child
 /// should not change.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorSignerRequest {
     pub nonce: Nonce, // should be matched in response (replay protection)
@@ -585,6 +591,8 @@ impl fmt::Display for TrustAnchorSignerRequest {
 //------------ TrustAnchorChildRequests ------------------------------------
 
 /// Requests for Trust Anchor Child.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorChildRequests {
     pub child: ChildHandle,
@@ -596,6 +604,8 @@ pub struct TrustAnchorChildRequests {
 
 /// A [`TrustAnchorSignerResponse`] and its signed message as base64 for
 /// (re-)validation.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorSignedResponse {
     signed: TrustAnchorSignedMessage,
@@ -643,6 +653,7 @@ impl fmt::Display for TrustAnchorSignedResponse {
 
 //------------ TrustAnchorSignerResponse -----------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorSignerResponse {
     pub nonce: Nonce, // should match the request (replay protection)
@@ -736,20 +747,6 @@ impl TrustAnchorChild {
 }
 
 
-//------------ UsedKeyState ------------------------------------------------
-
-/// Tracks the state of a key used by a child CA. This is needed because
-/// RFC 6492 dictates that keys cannot be re-used across resource classes.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[allow(clippy::large_enum_variant)]
-#[serde(rename_all = "snake_case")]
-pub enum UsedKeyState {
-    #[serde(alias = "current")]
-    InUse(ResourceClassName), /* Multiple keys are possible during a key
-                               * rollover. */
-    Revoked,
-}
-
 //------------ ProvisioningRequest -----------------------------------------
 
 //  *Warning:* This type is used in stored state.
@@ -801,6 +798,7 @@ impl std::fmt::Display for ProvisioningRequest {
 
 //------------ ProvisioningResponse ----------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum ProvisioningResponse {

--- a/src/api/ta.rs
+++ b/src/api/ta.rs
@@ -49,6 +49,8 @@ use crate::server::ca::publishing::{
 /// The Trust Anchor Signer can make changes to this set based on the
 /// requests it gets from the proxy. It can then return a response to the
 /// proxy that allow it to update the state with that same change.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorObjects {
     // The revision of the set, meaning its number and the
@@ -272,6 +274,7 @@ impl fmt::Display for TrustAnchorObjects {
 
 //------------ TaCertDetails -------------------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TaCertDetails {
     pub cert: ReceivedCert,
@@ -341,6 +344,7 @@ impl std::fmt::Display for TrustAnchorLocator {
 
 //------------ TrustAnchorSignerInfo ---------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorSignerInfo {
     // The ID of the associated signer.
@@ -395,6 +399,7 @@ impl fmt::Display for TrustAnchorSignerInfo {
 
 //------------ Nonce -------------------------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Nonce(Arc<str>);
 
@@ -702,6 +707,7 @@ impl fmt::Display for TrustAnchorSignerResponse {
 
 //------------ TrustAnchorChild --------------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TrustAnchorChild {
     pub handle: ChildHandle,
@@ -746,6 +752,7 @@ pub enum UsedKeyState {
 
 //------------ ProvisioningRequest -----------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum ProvisioningRequest {

--- a/src/commons/crypto/signing/dispatch/signerinfo.rs
+++ b/src/commons/crypto/signing/dispatch/signerinfo.rs
@@ -26,13 +26,12 @@ use crate::{
 use crate::api::history::CommandSummary;
 
 
-//------------ SignerInfoInitCommand
-//------------ ------------------------------------------------------------------------------
+//------------ SignerInfoInitCommand -----------------------------------------
 
 type SignerInfoInitCommand = SentInitCommand<SignerInfoInitCommandDetails>;
 
-//------------ SignerInfoInitCommandDetails
-//------------ --------------------------------------------------------------------
+
+//------------ SignerInfoInitCommandDetails ----------------------------------
 
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SignerInfoInitCommandDetails {
@@ -75,9 +74,10 @@ impl InitCommandDetails for SignerInfoInitCommandDetails {
     }
 }
 
-//------------ InitSignerInfoEvent
-//------------ -----------------------------------------------------------------------------
 
+//------------ SignerInfoInitEvent -------------------------------------------
+
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SignerInfoInitEvent {
     pub signer_name: String,
@@ -97,9 +97,10 @@ impl fmt::Display for SignerInfoInitEvent {
     }
 }
 
-//------------ SignerInfoEvent
-//------------ ---------------------------------------------------------------------------------
 
+//------------ SignerInfoEvent -----------------------------------------------
+
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub enum SignerInfoEvent {
     KeyAdded(KeyIdentifier, String),
@@ -149,11 +150,15 @@ impl fmt::Display for SignerInfoEvent {
     }
 }
 
-//------------ SignerInfoCommand
-//------------ ----------------------------------------------------------------------------------
+
+//------------ SignerInfoCommand ---------------------------------------------
 
 type SignerInfoCommand = SentCommand<SignerInfoCommandDetails>;
 
+
+//------------ SignerInfoCommandDetails --------------------------------------
+
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub enum SignerInfoCommandDetails {
     Init,
@@ -273,9 +278,10 @@ impl SignerInfoCommand {
     }
 }
 
-//------------ SignerInfo
-//------------ -----------------------------------------------------------------------------------------
 
+//------------ SignerIdentity ------------------------------------------------
+
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SignerIdentity {
     /// An X.509 Subject Public Key Info public key that can be used to
@@ -287,8 +293,13 @@ pub struct SignerIdentity {
     private_key_internal_id: String,
 }
 
+
+//------------ SignerInfo ----------------------------------------------------
+
 /// SignerInfo defines the set of keys created in a particular signer backend
 /// and the identity of that backend.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Deserialize, Serialize)]
 pub struct SignerInfo {
     /// The id is needed when generating events.
@@ -416,6 +427,9 @@ impl Aggregate for SignerInfo {
         })
     }
 }
+
+
+//------------ SignerMapper --------------------------------------------------
 
 pub struct SignerMapper {
     store: AggregateStore<SignerInfo>,
@@ -649,3 +663,4 @@ impl SignerMapper {
         )))
     }
 }
+

--- a/src/commons/crypto/signing/misc.rs
+++ b/src/commons/crypto/signing/misc.rs
@@ -30,6 +30,7 @@ pub type CaRepository = uri::Rsync;
 pub type RpkiManifest = uri::Rsync;
 pub type RpkiNotify = uri::Https;
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CsrInfo {
     ca_repository: CaRepository,

--- a/src/commons/version.rs
+++ b/src/commons/version.rs
@@ -8,7 +8,7 @@ use clap::crate_version;
 //------------ KrillVersion --------------------------------------------------
 
 /// Defines a Krill version.
-
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct KrillVersion {
     major: u64,
@@ -207,6 +207,8 @@ impl<'de> Deserialize<'de> for KrillVersion {
     }
 }
 
+
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum KrillVersionReleaseType {
     Release,

--- a/src/server/ca/aspa.rs
+++ b/src/server/ca/aspa.rs
@@ -31,6 +31,8 @@ use super::keys::CertifiedKey;
 /// customer ASN. The customer ASN will be held by a single resource class 
 /// only, but at least in theory the CA could issue ASPA objects in each
 /// resource class that holds the ASN.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AspaDefinitions {
     /// The definitions for each customer ASN.
@@ -204,6 +206,8 @@ impl AspaDefinitions {
 ///
 /// Each ASPA object is described by an [`AspaInfo`]. There can at most by
 /// one ASPA object per customer ASN.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AspaObjects(HashMap<CustomerAsn, AspaInfo>);
 
@@ -357,6 +361,8 @@ impl AspaObjects {
 //------------ AspaInfo ----------------------------------------------------
 
 /// Information about a single ASPA obejct.
+///
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AspaInfo {
     /// The customer ASN and all Provider ASNs
@@ -413,6 +419,8 @@ impl AspaInfo {
 //------------ AspaObjectsUpdates --------------------------------------------
 
 /// The updates to the ASPA objects of a resource class.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AspaObjectsUpdates {
     /// Newly added or updated ASPA objects.

--- a/src/server/ca/bgpsec.rs
+++ b/src/server/ca/bgpsec.rs
@@ -30,6 +30,8 @@ use super::keys::CertifiedKey;
 ///
 /// Actual BGPsec certificates will be issued under the relevant
 /// resource classes.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BgpSecDefinitions(HashMap<BgpSecAsnKey, StoredBgpSecCsr>);
 
@@ -177,6 +179,8 @@ impl BgpSecDefinitions {
 /// The original CSR is stored as a base64 structure in order to avoid
 /// issues if (when?) our CSR parsing should become more strict in a
 /// future release.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StoredBgpSecCsr {
     /// The time we first processed this CSR.
@@ -206,6 +210,8 @@ impl StoredBgpSecCsr {
 //------------ BgpSecCertificates --------------------------------------------
 
 /// The BGPsec certificates issued under a resource class in a CA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BgpSecCertificates(HashMap<BgpSecAsnKey, BgpSecCertInfo>);
 
@@ -363,6 +369,8 @@ impl BgpSecCertificates {
 //------------ BgpSecCertInfo ------------------------------------------------
 
 /// An issued BGPsec certificate under a resource class
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BgpSecCertInfo {
     /// The ASN of the autonomous system that uses this router key.
@@ -413,6 +421,8 @@ impl BgpSecCertInfo {
 //------------ BgpSecCertificateUpdates --------------------------------------
 
 /// Updates to the published BGPsec router key certificates.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BgpSecCertificateUpdates {
     /// The certificates to be added or updated.

--- a/src/server/ca/certauth.rs
+++ b/src/server/ca/certauth.rs
@@ -72,6 +72,8 @@ use super::rta::{PreparedRta, Rtas, SignedRta};
 /// Configurations for published objects such as ROAs or ASPA objects are
 /// kept at the level of the CA, and actual RPKI objects are then issued
 /// under the resource class that has matching resources.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CertAuth {
     /// The local handle of the CA.
@@ -2710,6 +2712,8 @@ impl CertAuth {
 //------------ Rfc8183Id ---------------------------------------------------
 
 /// An identity used for communication with a parent CA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Rfc8183Id {
     /// The ID certificate to use.

--- a/src/server/ca/child.rs
+++ b/src/server/ca/child.rs
@@ -21,6 +21,8 @@ use crate::config::IssuanceTimingConfig;
 ///
 /// This is needed because RFC 6492 dictates that keys cannot be re-used
 /// across resource classes.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 #[serde(rename_all = "snake_case")]
@@ -36,13 +38,15 @@ pub enum UsedKeyState {
 }
 
 
-//------------ ChildInfo -----------------------------------------------------
+//------------ ChildDetails --------------------------------------------------
 
 /// Information about a child CA needed by a parent CA.
 ///
 /// Note that the actual [`IssuedCertificate`] corresponding to the
 /// [`KeyIdentifier`] and [`ResourceClassName`] are kept in the parent's
 /// resource class.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ChildDetails {
     /// The state of the child.
@@ -166,6 +170,8 @@ impl ChildDetails {
 //------------ ChildCertificates -------------------------------------------
 
 /// The collection of certificates issued under a resource class.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ChildCertificates {
     /// The certificates for active CAs.
@@ -367,6 +373,8 @@ impl ChildCertificates {
 //------------ ChildCertificateUpdates -------------------------------------
 
 /// Describes an update to the set of ROAs under a ResourceClass.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ChildCertificateUpdates {
     /// Issued certificates that have been added.

--- a/src/server/ca/commands.rs
+++ b/src/server/ca/commands.rs
@@ -21,7 +21,7 @@ use crate::api::aspa::{
 };
 use crate::api::bgpsec::BgpSecDefinitionUpdates;
 use crate::api::ca::{
-    IdCertInfo, ReceivedCert,  ResourceSetSummary,RtaName
+    IdCertInfo, ReceivedCert,  ResourceSetSummary, RtaName
 };
 use crate::api::history::CommandSummary;
 use crate::api::import::ImportChild;
@@ -298,8 +298,9 @@ impl fmt::Display for CertAuthCommandDetails {
 }
 
 
-//------------ StorableCaCommand --------------------------------------------
+//------------ CertAuthStorableCommand --------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 #[serde(rename_all = "snake_case")]
@@ -977,8 +978,9 @@ impl fmt::Display for CertAuthStorableCommand {
 }
 
 
-//------------ StorableCaCommand --------------------------------------------
+//------------ StorableRcEntitlement ----------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StorableRcEntitlement {
     pub resource_class_name: ResourceClassName,

--- a/src/server/ca/events.rs
+++ b/src/server/ca/events.rs
@@ -31,6 +31,8 @@ use super::rta::{PreparedRta, SignedRta};
 //------------ CertAuthInitEvent ---------------------------------------------
 
 /// The init event of the `CertAuth` aggregate.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CertAuthInitEvent {
     /// The ID certificate used by the CA for communication.
@@ -63,6 +65,8 @@ impl fmt::Display for CertAuthInitEvent {
 //------------ CertAuthEvent ------------------------------------------------
 
 /// The events of the `CertAuth` aggregate.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 #[serde(rename_all = "snake_case")]

--- a/src/server/ca/keys.rs
+++ b/src/server/ca/keys.rs
@@ -25,6 +25,8 @@ use super::events::CertAuthEvent;
 ///
 /// This means that the key has received an incoming certificate and has at
 /// least a manifest and CRL.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CertifiedKey {
     /// The key identifier.
@@ -234,6 +236,8 @@ pub type CurrentKey = CertifiedKey;
 /// This key should usually have an open [`IssuanceRequest`], and will be
 /// moved to a 'new' or 'current' [`CertifiedKey`] when a certificate is
 /// received.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PendingKey {
     /// The key identifier of the key.
@@ -299,6 +303,8 @@ impl OldKey {
 ///
 /// The type guards that keys are created, activated, rolled and retired
 /// properly.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 #[serde(rename_all = "snake_case")]

--- a/src/server/ca/mod.rs
+++ b/src/server/ca/mod.rs
@@ -24,5 +24,6 @@ pub use self::status::CaStatus;
 // away.
 
 pub use self::certauth::CertAuth; // mq and scheduler
+pub use self::child::UsedKeyState; // api::ta
 pub use self::events::CertAuthEvent; // mq
 

--- a/src/server/ca/publishing.rs
+++ b/src/server/ca/publishing.rs
@@ -311,6 +311,8 @@ impl CaObjectsStore {
 //------------CaObjects ------------------------------------------------------
 
 /// All the published objects of a CA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CaObjects {
     /// The handle of the CA.
@@ -618,6 +620,8 @@ impl CaObjects {
 //------------ DeprecatedRepository ------------------------------------------
 
 /// A previously used repository that hasn’t been successfully cleaned out.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct DeprecatedRepository {
     /// The repository contact.
@@ -661,6 +665,8 @@ impl DeprecatedRepository {
 //------------ ResourceClassObjects ------------------------------------------
 
 /// The objects for a resource class.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ResourceClassObjects {
     keys: ResourceClassKeyState,
@@ -931,6 +937,7 @@ impl ResourceClassObjects {
 
 //------------ ResourceClassKeyState -----------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResourceClassKeyState {
@@ -990,6 +997,7 @@ impl ResourceClassKeyState {
 
 //------------ CurrentKeyState -----------------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CurrentKeyState {
     current_set: KeyObjectSet,
@@ -1003,6 +1011,7 @@ impl CurrentKeyState {
 
 //------------ StagingKeyState -----------------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StagingKeyState {
     staging_set: KeyObjectSet,
@@ -1021,6 +1030,7 @@ impl StagingKeyState {
 
 //------------ OldKeyState ---------------------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct OldKeyState {
     current_set: KeyObjectSet,
@@ -1039,6 +1049,8 @@ impl OldKeyState {
 //------------ KeyObjectSet ------------------------------------------------
 
 /// Maintains the set of objects published for a key.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct KeyObjectSet {
     /// The latest received certificate for the owning key.
@@ -1406,6 +1418,8 @@ impl KeyObjectSet {
 //------------ ObjectSetRevision ---------------------------------------------
 
 /// The current revision information for a key object set.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ObjectSetRevision {
     /// The manifest and CRL number.
@@ -1479,6 +1493,8 @@ pub type PublishedCert = IssuedCertificate;
 ///
 /// The concrete type of object is provided through the marker type `T`. This
 /// is only used to make sure we add objects in the right place.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PublishedItem<T> {
     /// The name of the object.
@@ -1537,9 +1553,12 @@ impl<T> PublishedItem<T> {
 //------------ PublishedManifest ---------------------------------------------
 
 /// A published manifest.
+//
+//  *Warning:* This type is used in stored state.
+pub type PublishedManifest = PublishedItem<PublishedItemManifest>;
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PublishedItemManifest;
-pub type PublishedManifest = PublishedItem<PublishedItemManifest>;
 
 impl From<Manifest> for PublishedManifest {
     fn from(mft: Manifest) -> Self {
@@ -1556,9 +1575,12 @@ impl From<Manifest> for PublishedManifest {
 //------------ PublishedCrl --------------------------------------------------
 
 /// A published CRL.
+//
+//  *Warning:* This type is used in stored state.
+pub type PublishedCrl = PublishedItem<PublishedItemCrl>;
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PublishedItemCrl;
-pub type PublishedCrl = PublishedItem<PublishedItemCrl>;
 
 impl PublishedCrl {
     pub fn build(
@@ -1600,9 +1622,12 @@ impl From<Crl> for PublishedCrl {
 //------------ PublishedObject -----------------------------------------------
 
 /// A generic published object.
+//
+//  *Warning:* This type is used in stored state.
+pub type PublishedObject = PublishedItem<PublishedItemOther>;
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PublishedItemOther;
-pub type PublishedObject = PublishedItem<PublishedItemOther>;
 
 impl PublishedObject {
     /// Creates a published ROA.

--- a/src/server/ca/rc.rs
+++ b/src/server/ca/rc.rs
@@ -46,6 +46,8 @@ use super::roa::{Roas, RoaUpdates, Routes};
 /// Furthermore a resource class manages the key life cycle, and certificates
 /// for each key, as well as objects that need to be issued by the 'current'
 /// key for this class.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ResourceClass {
     /// The name of the resource class.
@@ -1041,5 +1043,6 @@ impl ResourceClass {
 
 //------------ DropReason ----------------------------------------------------
 
+//  *Warning:* This type is used in stored state.
 pub type DropReason = String;
 

--- a/src/server/ca/roa.rs
+++ b/src/server/ca/roa.rs
@@ -28,6 +28,8 @@ use super::keys::CertifiedKey;
 //------------ Routes --------------------------------------------------------
 
 /// The current configured route authorizations of a CA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Routes {
     /// The route authorization keyed by ROA payload.
@@ -234,6 +236,8 @@ impl Routes {
 //------------ RouteInfo -----------------------------------------------------
 
 /// Meta-information about a configured route authorization.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RouteInfo {
     /// The time the authorization was first added by the user.
@@ -273,6 +277,8 @@ impl Default for RouteInfo {
 ///
 /// We currently don’t use grouping. It is here in case we want to give
 /// users more options in the future.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct RoaAggregateKey {
     /// The origin ASN.
@@ -419,6 +425,8 @@ impl Serialize for RoaAggregateKey {
 //------------ Roas --------------------------------------------------------
 
 /// ROA configurations held by a resource class in a CA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Roas {
     /// The simple ROAs held by the resource class.
@@ -891,6 +899,8 @@ enum RoaMode {
 //------------ RoaUpdates --------------------------------------------------
 
 /// Describes an update to the set of ROAs under a ResourceClass.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RoaUpdates {
     #[serde(

--- a/src/server/ca/rta.rs
+++ b/src/server/ca/rta.rs
@@ -15,6 +15,8 @@ use crate::commons::error::Error;
 //------------ Rtas ---------------------------------------------------------
 
 /// The set of RTAs held by a CA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Rtas {
     /// The RTAs keyed by their name.
@@ -85,6 +87,8 @@ impl Rtas {
 //------------ RtaState -----------------------------------------------------
 
 /// The state of an RTA.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 enum RtaState {
     /// The RTA is currently being prepared.
@@ -98,6 +102,8 @@ enum RtaState {
 //------------ PreparedRta --------------------------------------------------
 
 /// An RTA currently being prepared.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PreparedRta {
     /// The resources contained in the RTA.
@@ -151,6 +157,8 @@ impl PreparedRta {
 //------------ SignedRta -----------------------------------------------------
 
 /// An RTA having been signed.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SignedRta {
     /// The resources of the RTA.

--- a/src/server/properties/mod.rs
+++ b/src/server/properties/mod.rs
@@ -38,11 +38,14 @@ use crate::{
 use crate::api::history::CommandSummary;
 
 
-//------------ PropertiesInitCommand ---------------------------------------
+//------------ PropertiesInitCommand -----------------------------------------
+
 pub type PropertiesInitCommand =
     SentInitCommand<PropertiesInitCommandDetails>;
 
-//------------ PropertiesInitCommandDetails --------------------------------
+
+//------------ PropertiesInitCommandDetails ----------------------------------
+
 #[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PropertiesInitCommandDetails {
     pub krill_version: KrillVersion,
@@ -62,10 +65,14 @@ impl InitCommandDetails for PropertiesInitCommandDetails {
     }
 }
 
-//------------ PropertiesCommand -------------------------------------------
+
+//------------ PropertiesCommand ---------------------------------------------
+
 pub type PropertiesCommand = SentCommand<PropertiesCommandDetails>;
 
-//------------ PropertiesCommandDetails ------------------------------------
+
+//------------ PropertiesCommandDetails --------------------------------------
+
 #[derive(Clone, Debug)]
 pub enum PropertiesCommandDetails {
     UpgradeTo { krill_version: KrillVersion },
@@ -77,7 +84,10 @@ impl fmt::Display for PropertiesCommandDetails {
     }
 }
 
-//------------ StorablePropertiesCommand -----------------------------------
+
+//------------ StorablePropertiesCommand -------------------------------------
+
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
@@ -141,7 +151,10 @@ impl eventsourcing::WithStorableDetails for StorablePropertiesCommand {
     }
 }
 
-//------------ PropertiesEvent ---------------------------------------------
+
+//------------ PropertiesEvent -----------------------------------------------
+
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "type")]
@@ -164,7 +177,10 @@ impl fmt::Display for PropertiesEvent {
     }
 }
 
-//------------ PropertiesInitEvent -----------------------------------------
+
+//------------ PropertiesInitEvent -------------------------------------------
+
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PropertiesInitEvent {
     krill_version: KrillVersion,
@@ -178,9 +194,12 @@ impl fmt::Display for PropertiesInitEvent {
     }
 }
 
-//------------ Properties --------------------------------------------------
+
+//------------ Properties ----------------------------------------------------
 
 /// Runtime properties used by the server
+///
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Properties {
     handle: MyHandle,
@@ -263,7 +282,7 @@ impl Aggregate for Properties {
     }
 }
 
-//------------ PropertiesManager -------------------------------------------
+//------------ PropertiesManager ---------------------------------------------
 
 /// Convenience manager for the single Properties instance used by Krill
 pub struct PropertiesManager {
@@ -331,7 +350,9 @@ impl PropertiesManager {
     }
 }
 
-//--------- Tests
+
+//============ Tests =========================================================
+
 #[cfg(test)]
 mod tests {
     use crate::commons::test;
@@ -376,3 +397,4 @@ mod tests {
         })
     }
 }
+

--- a/src/server/pubd/access.rs
+++ b/src/server/pubd/access.rs
@@ -255,6 +255,8 @@ impl RepositoryAccessProxy {
 ///
 /// The server is capable of handling publishers (both embedded, and remote),
 /// and publishing to RRDP and disk, and/ signing responses.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RepositoryAccess {
     /// The instance handle of the server.
@@ -575,6 +577,8 @@ impl From<RepositoryAccessCommandDetails> for StorableRepositoryCommand {
 //------------ StorableRepositoryCommand -----------------------------------
 
 /// The storeable part of the repository access command.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 #[serde(rename_all = "snake_case", tag = "type")]
@@ -639,6 +643,8 @@ impl fmt::Display for StorableRepositoryCommand {
 //------------ RepositoryAccessInitEvent -------------------------------------
 
 /// The event initializing the repository access aggregate.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RepositoryAccessInitEvent {
     /// The identity certificate of the repository.
@@ -684,6 +690,8 @@ impl fmt::Display for RepositoryAccessInitEvent {
 //------------ RepositoryAccessEvent -----------------------------------------
 
 /// The events of the repository access aggregate.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
 #[serde(rename_all = "snake_case", tag = "type")]

--- a/src/server/pubd/content.rs
+++ b/src/server/pubd/content.rs
@@ -19,7 +19,7 @@ use crate::commons::eventsourcing::{
 use crate::constants::PUBSERVER_CONTENT_NS;
 use crate::config::{Config, RrdpUpdatesConfig};
 use super::rrdp::{
-    CurrentObjects, DeltaElements, RrdpServer,RrdpSession, RrdpSessionReset,
+    CurrentObjects, DeltaElements, RrdpServer, RrdpSession, RrdpSessionReset,
     RrdpUpdated, RrdpUpdateNeeded,
 };
 use super::rsync::RsyncdStore;
@@ -268,6 +268,8 @@ impl RepositoryContentProxy {
 /// Access to the repository is managed by an event sourced component which
 /// handles the publication protocol, and which can enforce restrictions,
 /// such as the base uri for publishers.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RepositoryContent {
     /// The revision of aggregate in the WAL store.
@@ -712,6 +714,7 @@ impl fmt::Display for RepositoryContentCommand {
 
 //------------ RepositoryContentChange -------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum RepositoryContentChange {

--- a/src/server/pubd/publishers.rs
+++ b/src/server/pubd/publishers.rs
@@ -6,6 +6,8 @@ use crate::api::ca::IdCertInfo;
 //------------ Publisher -----------------------------------------------------
 
 /// This type defines Publisher CAs that are allowed to publish.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Publisher {
     /// Used by remote RFC8181 publishers

--- a/src/server/pubd/rrdp.rs
+++ b/src/server/pubd/rrdp.rs
@@ -47,6 +47,8 @@ const WITHDRAW: Name = Name::unqualified(b"withdraw");
 ///
 /// This isn’t the actual server but creates the data to be served by an
 /// HTTP server.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RrdpServer {
     /// The base URI for RRDP files.
@@ -894,6 +896,7 @@ pub enum RrdpUpdateNeeded {
 
 //------------ RrdpSessionReset ----------------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RrdpSessionReset {
     pub last_update: Time,
@@ -904,6 +907,7 @@ pub struct RrdpSessionReset {
 
 //------------ RrdpUpdated ---------------------------------------------------
 
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RrdpUpdated {
     pub time: Time,
@@ -918,6 +922,8 @@ pub struct RrdpUpdated {
 ///
 /// A session is identified by a UUID. By default, a new session will be
 /// created with a random V4 UUID.
+///
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct RrdpSession(Uuid);
 
@@ -983,6 +989,8 @@ impl Serialize for RrdpSession {
 //------------ SnapshotData --------------------------------------------------
 
 /// The data needed to create an RRDP Snapshot.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SnapshotData {
     /// A random value to make the URI unique.
@@ -1185,6 +1193,8 @@ impl SnapshotData {
 //------------ CurrentObjects ------------------------------------------------
 
 /// The current set of published objects.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CurrentObjects(HashMap<CurrentObjectUri, Base64>);
 
@@ -1444,6 +1454,8 @@ where K: Into<CurrentObjectUri> {
 ///
 /// This type can still be cloned cheaply since it holds an arc to an
 /// allocated string.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct CurrentObjectUri(Arc<str>);
 
@@ -1497,6 +1509,8 @@ impl TryFrom<CurrentObjectUri> for uri::Rsync {
 ///
 /// The component will make the URIs unguessable and prevent cache poisoning
 /// (through CDNs caching a 404 not found).
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RrdpFileRandom(String);
 
@@ -1513,6 +1527,8 @@ impl Default for RrdpFileRandom {
 //------------ DeltaData -----------------------------------------------------
 
 /// The data needed to create an RRDP delta XML file.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct DeltaData {
     /// A random value to make the URI unique.
@@ -1666,6 +1682,8 @@ impl DeltaData {
 //------------ DeltaElements -------------------------------------------------
 
 /// The elements of an RRDP delta.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct DeltaElements {
     /// The objects to be published.
@@ -1783,10 +1801,15 @@ impl From<publication::PublishDelta> for DeltaElements {
     }
 }
 
+
+//------------ StagedElements ------------------------------------------------
+
 /// This type is used to combine staged delta elements for publishers.
 ///
 /// It uses a map with object URIs as key, because this is the unique key that
 /// identifies objects in the publication protocol.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct StagedElements(HashMap<uri::Rsync, DeltaElement>);
 
@@ -1977,6 +2000,8 @@ impl From<StagedElements> for DeltaElements {
 ///
 /// Note that the difference with the publication protocol is the absence of
 /// the tag.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PublishElement {
     /// The URI identifying the object to be published.
@@ -2000,6 +2025,8 @@ impl From<publication::Publish> for PublishElement {
 ///
 /// Note that the difference with the publication protocol is the absence of
 /// the tag.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct UpdateElement {
     /// The URI identifying the object to be updated.
@@ -2035,6 +2062,8 @@ impl From<publication::Update> for UpdateElement {
 /// A withdraw element as used in the RRDP protocol.
 ///
 /// Note that the difference with the publication protocol is the absence of
+//
+//  *Warning:* This type is used in stored state.
 /// the tag.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct WithdrawElement {
@@ -2056,6 +2085,8 @@ impl From<publication::Withdraw> for WithdrawElement {
 //------------ DeltaElement --------------------------------------------------
 
 /// An element in an RRDP delta.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum DeltaElement {
     Publish(PublishElement),

--- a/src/server/pubd/rsync.rs
+++ b/src/server/pubd/rsync.rs
@@ -11,6 +11,7 @@ use crate::commons::error::{Error, KrillIoError};
 use crate::constants::REPOSITORY_RSYNC_DIR;
 use super::rrdp::SnapshotData;
 
+
 //------------ RsyncdStore ---------------------------------------------------
 
 /// Manages content to be published with rsyncd.
@@ -27,6 +28,8 @@ use super::rrdp::SnapshotData;
 /// things to disk. We can then have the RRDP component server RRDP over
 /// HTTPs and let krill-sync do the writing with all the caveats that that
 /// involves.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RsyncdStore {
     /// The base URI for our store.

--- a/src/server/taproxy.rs
+++ b/src/server/taproxy.rs
@@ -35,9 +35,10 @@ use crate::api::ta::{
     Nonce, ProvisioningRequest, ProvisioningResponse, TaCertDetails, 
     TrustAnchorChild, TrustAnchorChildRequests, TrustAnchorObjects, 
     TrustAnchorSignedRequest, TrustAnchorSignedResponse,
-    TrustAnchorSignerInfo, TrustAnchorSignerRequest, UsedKeyState,
+    TrustAnchorSignerInfo, TrustAnchorSignerRequest,
 };
 use crate::constants::ta_resource_class_name;
+use crate::server::ca::UsedKeyState;
 use crate::tasigner::TaTimingConfig;
 
 

--- a/src/server/taproxy.rs
+++ b/src/server/taproxy.rs
@@ -63,6 +63,8 @@ use crate::tasigner::TaTimingConfig;
 /// is inline with how the current RIR Trust Anchors are being managed at the
 /// moment. That said, we may add support for claiming (and changing) a
 /// specific set of resources in future.
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TrustAnchorProxy {
     // event-sourcing support
@@ -99,466 +101,6 @@ pub struct TrustAnchorProxy {
     // is an open request. We first need to process the response, before we
     // can accept new requests from any child.
     open_signer_request: Option<Nonce>,
-}
-
-//------------ TrustAnchorProxy: Commands and Events -----------------------
-
-pub type TrustAnchorProxyInitCommand =
-    eventsourcing::SentInitCommand<TrustAnchorProxyInitCommandDetails>;
-
-impl TrustAnchorProxyInitCommand {
-    pub fn make(
-        id: MyHandle,
-        signer: Arc<KrillSigner>,
-        actor: &Actor,
-    ) -> Self {
-        TrustAnchorProxyInitCommand::new(
-            id,
-            TrustAnchorProxyInitCommandDetails { signer },
-            actor,
-        )
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct TrustAnchorProxyInitCommandDetails {
-    signer: Arc<KrillSigner>,
-}
-
-impl fmt::Display for TrustAnchorProxyInitCommandDetails {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.store().fmt(f)
-    }
-}
-
-impl InitCommandDetails for TrustAnchorProxyInitCommandDetails {
-    type StorableDetails = TrustAnchorProxyCommandDetails;
-
-    fn store(&self) -> Self::StorableDetails {
-        TrustAnchorProxyCommandDetails::make_init()
-    }
-}
-
-pub type TrustAnchorProxyCommand =
-    eventsourcing::SentCommand<TrustAnchorProxyCommandDetails>;
-
-// Initialisation
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct TrustAnchorProxyInitEvent {
-    pub id: IdCertInfo,
-}
-
-impl InitEvent for TrustAnchorProxyInitEvent {}
-
-impl fmt::Display for TrustAnchorProxyInitEvent {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // note that this is a summary, full details are stored in the init
-        // event.
-        write!(f, "Trust Anchor Proxy was initialised.")
-    }
-}
-
-// Events
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[allow(clippy::large_enum_variant)]
-pub enum TrustAnchorProxyEvent {
-    // Publication Support
-    RepositoryAdded(RepositoryContact),
-
-    // Proxy -> Signer interactions
-    SignerAdded(TrustAnchorSignerInfo),
-    SignerUpdated(TrustAnchorSignerInfo),
-    SignerRequestMade(Nonce),
-    SignerResponseReceived(TrustAnchorSignedResponse),
-
-    // Children
-    ChildAdded(TrustAnchorChild),
-    ChildRequestAdded(ChildHandle, ProvisioningRequest),
-    ChildResponseGiven(ChildHandle, KeyIdentifier),
-}
-
-impl Event for TrustAnchorProxyEvent {}
-
-impl fmt::Display for TrustAnchorProxyEvent {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // note that this is a summary, full details are stored in the json.
-        match self {
-            // Publication Support
-            TrustAnchorProxyEvent::RepositoryAdded(repository) => {
-                write!(
-                    f,
-                    "Added repository with service uri: {}",
-                    repository.server_info.service_uri
-                )
-            }
-
-            // Proxy -> Signer interactions
-            TrustAnchorProxyEvent::SignerAdded(signer) => {
-                write!(
-                    f,
-                    "Added signer with ID certificate hash: {}",
-                    signer.id.hash
-                )
-            }
-            TrustAnchorProxyEvent::SignerUpdated(signer) => {
-                write!(
-                    f,
-                    "Updated signer with ID certificate hash: {}",
-                    signer.id.hash
-                )
-            }
-            TrustAnchorProxyEvent::SignerRequestMade(nonce) => {
-                write!(f, "Created signer request with nonce '{}'", nonce)
-            }
-            TrustAnchorProxyEvent::SignerResponseReceived(response) => {
-                write!(
-                    f,
-                    "Received signer response with nonce '{}'",
-                    response.content().nonce
-                )
-            }
-
-            // Children
-            TrustAnchorProxyEvent::ChildAdded(child) => {
-                write!(
-                    f,
-                    "Added child: {}, with resources: {}",
-                    child.handle, child.resources
-                )
-            }
-            TrustAnchorProxyEvent::ChildRequestAdded(
-                child_handle,
-                request,
-            ) => {
-                write!(
-                    f,
-                    "Added request for child {}: {}",
-                    child_handle, request
-                )
-            }
-            TrustAnchorProxyEvent::ChildResponseGiven(child_handle, key) => {
-                write!(
-                    f,
-                    "Given response to child {} for key: {}",
-                    child_handle, key
-                )
-            }
-        }
-    }
-}
-
-// Commands
-
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[allow(clippy::large_enum_variant)]
-pub enum TrustAnchorProxyCommandDetails {
-    // Create new instance - cannot be sent to an existing instance
-    Init,
-
-    // Publication Support
-    AddRepository(RepositoryContact),
-
-    // Proxy -> Signer interactions
-    AddSigner(TrustAnchorSignerInfo),
-    UpdateSigner(TrustAnchorSignerInfo),
-    MakeSignerRequest,
-    ProcessSignerResponse(TrustAnchorSignedResponse),
-
-    // Children
-    AddChild(AddChildRequest),
-    AddChildRequest(ChildHandle, ProvisioningRequest),
-    GiveChildResponse(ChildHandle, KeyIdentifier),
-}
-
-impl fmt::Display for TrustAnchorProxyCommandDetails {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // note that this is a summary, full details are stored in the json.
-        match self {
-            TrustAnchorProxyCommandDetails::Init => {
-                write!(f, "Initialise TA proxy")
-            }
-            // Publication Support
-            TrustAnchorProxyCommandDetails::AddRepository(repository) => {
-                write!(
-                    f,
-                    "Add repository at: {}",
-                    repository.server_info.service_uri
-                )
-            }
-
-            // Proxy -> Signer interactions
-            TrustAnchorProxyCommandDetails::AddSigner(signer) => {
-                write!(
-                    f,
-                    "Add signer with id certificate hash: {}",
-                    signer.id.hash
-                )
-            }
-            TrustAnchorProxyCommandDetails::UpdateSigner(signer) => {
-                write!(
-                    f,
-                    "Update signer with id certificate hash: {}",
-                    signer.id.hash
-                )
-            }
-            TrustAnchorProxyCommandDetails::MakeSignerRequest => {
-                write!(f, "Create new publish request for signer")
-            }
-            TrustAnchorProxyCommandDetails::ProcessSignerResponse(
-                response,
-            ) => {
-                write!(
-                    f,
-                    "Process signer response. Nonce: {}. Next Update (before): {}",
-                    response.content().nonce,
-                    response.content().objects.revision().next_update().to_rfc3339()
-                )
-            }
-
-            // Children
-            TrustAnchorProxyCommandDetails::AddChild(child) => {
-                write!(f, "Add child: {}", child)
-            }
-            TrustAnchorProxyCommandDetails::AddChildRequest(
-                child_handle,
-                request,
-            ) => {
-                write!(
-                    f,
-                    "Add request for child {}: {}",
-                    child_handle, request
-                )
-            }
-            TrustAnchorProxyCommandDetails::GiveChildResponse(
-                child_handle,
-                key,
-            ) => {
-                write!(
-                    f,
-                    "Give (and remove) response to child {} for key {}",
-                    child_handle, key
-                )
-            }
-        }
-    }
-}
-
-impl eventsourcing::WithStorableDetails for TrustAnchorProxyCommandDetails {
-    fn summary(&self) -> crate::api::history::CommandSummary {
-        match self {
-            // Initialisation
-            TrustAnchorProxyCommandDetails::Init => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-proxy-init",
-                    self,
-                )
-            }
-            // Publication Support
-            TrustAnchorProxyCommandDetails::AddRepository(repository) => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-proxy-repo-add",
-                    self,
-                )
-                .service_uri(&repository.server_info.service_uri)
-            }
-
-            // Proxy -> Signer interactions
-            TrustAnchorProxyCommandDetails::AddSigner(signer) => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-proxy-signer-add",
-                    self,
-                )
-                .id_cert_hash(&signer.id.hash)
-            }
-            TrustAnchorProxyCommandDetails::UpdateSigner(signer) => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-proxy-signer-update",
-                    self,
-                )
-                .id_cert_hash(&signer.id.hash)
-            }
-            TrustAnchorProxyCommandDetails::MakeSignerRequest => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-proxy-pub-req",
-                    self,
-                )
-            }
-            TrustAnchorProxyCommandDetails::ProcessSignerResponse(
-                response,
-            ) => crate::api::history::CommandSummary::new(
-                "cmd-ta-proxy-pub-res",
-                self,
-            )
-            .arg("nonce", &response.content().nonce)
-            .arg(
-                "manifest number",
-                response.content().objects.revision().number(),
-            )
-            .arg(
-                "this update",
-                response
-                    .content()
-                    .objects
-                    .revision()
-                    .this_update()
-                    .to_rfc3339(),
-            )
-            .arg(
-                "next update",
-                response
-                    .content()
-                    .objects
-                    .revision()
-                    .next_update()
-                    .to_rfc3339(),
-            ),
-
-            // Children
-            TrustAnchorProxyCommandDetails::AddChild(child) => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-proxy-child-add", self,
-                ).child(&child.handle)
-            }
-            TrustAnchorProxyCommandDetails::AddChildRequest(
-                child_handle,
-                _request,
-            ) => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-proxy-child-req",
-                    self,
-                ).child(child_handle)
-            }
-            TrustAnchorProxyCommandDetails::GiveChildResponse(
-                child_handle,
-                _response,
-            ) => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-proxy-child-res",
-                    self,
-                ).child(child_handle)
-            }
-        }
-    }
-
-    fn make_init() -> Self {
-        Self::Init
-    }
-}
-
-impl TrustAnchorProxyCommand {
-    pub fn add_repo(
-        id: &CaHandle,
-        repository: RepositoryContact,
-        actor: &Actor,
-    ) -> Self {
-        TrustAnchorProxyCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorProxyCommandDetails::AddRepository(repository),
-            actor,
-        )
-    }
-
-    pub fn add_signer(
-        id: &CaHandle,
-        signer: TrustAnchorSignerInfo,
-        actor: &Actor,
-    ) -> Self {
-        TrustAnchorProxyCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorProxyCommandDetails::AddSigner(signer),
-            actor,
-        )
-    }
-
-    pub fn update_signer(
-        id: &CaHandle,
-        signer: TrustAnchorSignerInfo,
-        actor: &Actor,
-    ) -> Self {
-        TrustAnchorProxyCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorProxyCommandDetails::UpdateSigner(signer),
-            actor,
-        )
-    }
-
-    pub fn make_signer_request(
-        id: &CaHandle,
-        actor: &Actor,
-    ) -> Self {
-        TrustAnchorProxyCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorProxyCommandDetails::MakeSignerRequest,
-            actor,
-        )
-    }
-
-    pub fn process_signer_response(
-        id: &CaHandle,
-        response: TrustAnchorSignedResponse,
-        actor: &Actor,
-    ) -> Self {
-        TrustAnchorProxyCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorProxyCommandDetails::ProcessSignerResponse(response),
-            actor,
-        )
-    }
-
-    pub fn add_child(
-        id: &CaHandle,
-        child: AddChildRequest,
-        actor: &Actor,
-    ) -> Self {
-        TrustAnchorProxyCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorProxyCommandDetails::AddChild(child),
-            actor,
-        )
-    }
-
-    pub fn add_child_request(
-        id: &CaHandle,
-        child: ChildHandle,
-        request: ProvisioningRequest,
-        actor: &Actor,
-    ) -> Self {
-        TrustAnchorProxyCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorProxyCommandDetails::AddChildRequest(child, request),
-            actor,
-        )
-    }
-
-    pub fn give_child_response(
-        id: &CaHandle,
-        child: ChildHandle,
-        key: KeyIdentifier,
-        actor: &Actor,
-    ) -> Self {
-        TrustAnchorProxyCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorProxyCommandDetails::GiveChildResponse(child, key),
-            actor,
-        )
-    }
-}
-
-impl eventsourcing::CommandDetails for TrustAnchorProxyCommandDetails {
-    type Event = TrustAnchorProxyEvent;
-    type StorableDetails = Self;
-
-    fn store(&self) -> Self::StorableDetails {
-        self.clone()
-    }
 }
 
 impl eventsourcing::Aggregate for TrustAnchorProxy {
@@ -1184,6 +726,480 @@ impl TrustAnchorProxy {
         self.child_details.get(child_handle).ok_or_else(|| {
             Error::CaChildUnknown(self.handle.clone(), child_handle.clone())
         })
+    }
+}
+
+
+//------------ TrustAnchorProxyInitCommand -----------------------------------
+
+pub type TrustAnchorProxyInitCommand =
+    eventsourcing::SentInitCommand<TrustAnchorProxyInitCommandDetails>;
+
+impl TrustAnchorProxyInitCommand {
+    pub fn make(
+        id: MyHandle,
+        signer: Arc<KrillSigner>,
+        actor: &Actor,
+    ) -> Self {
+        TrustAnchorProxyInitCommand::new(
+            id,
+            TrustAnchorProxyInitCommandDetails { signer },
+            actor,
+        )
+    }
+}
+
+
+//------------ TrustAnchorProxyInitCommandDetails ----------------------------
+
+#[derive(Clone, Debug)]
+pub struct TrustAnchorProxyInitCommandDetails {
+    signer: Arc<KrillSigner>,
+}
+
+impl fmt::Display for TrustAnchorProxyInitCommandDetails {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.store().fmt(f)
+    }
+}
+
+impl InitCommandDetails for TrustAnchorProxyInitCommandDetails {
+    type StorableDetails = TrustAnchorProxyCommandDetails;
+
+    fn store(&self) -> Self::StorableDetails {
+        TrustAnchorProxyCommandDetails::make_init()
+    }
+}
+
+
+//------------ TrustAnchorProxyInitEvent -------------------------------------
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TrustAnchorProxyInitEvent {
+    pub id: IdCertInfo,
+}
+
+impl InitEvent for TrustAnchorProxyInitEvent {}
+
+impl fmt::Display for TrustAnchorProxyInitEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // note that this is a summary, full details are stored in the init
+        // event.
+        write!(f, "Trust Anchor Proxy was initialised.")
+    }
+}
+
+
+//------------ TrustAnchorProxyEvent -----------------------------------------
+
+//  *Warning:* This type is used in stored state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum TrustAnchorProxyEvent {
+    // Publication Support
+    RepositoryAdded(RepositoryContact),
+
+    // Proxy -> Signer interactions
+    SignerAdded(TrustAnchorSignerInfo),
+    SignerUpdated(TrustAnchorSignerInfo),
+    SignerRequestMade(Nonce),
+    SignerResponseReceived(TrustAnchorSignedResponse),
+
+    // Children
+    ChildAdded(TrustAnchorChild),
+    ChildRequestAdded(ChildHandle, ProvisioningRequest),
+    ChildResponseGiven(ChildHandle, KeyIdentifier),
+}
+
+impl Event for TrustAnchorProxyEvent {}
+
+impl fmt::Display for TrustAnchorProxyEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // note that this is a summary, full details are stored in the json.
+        match self {
+            // Publication Support
+            TrustAnchorProxyEvent::RepositoryAdded(repository) => {
+                write!(
+                    f,
+                    "Added repository with service uri: {}",
+                    repository.server_info.service_uri
+                )
+            }
+
+            // Proxy -> Signer interactions
+            TrustAnchorProxyEvent::SignerAdded(signer) => {
+                write!(
+                    f,
+                    "Added signer with ID certificate hash: {}",
+                    signer.id.hash
+                )
+            }
+            TrustAnchorProxyEvent::SignerUpdated(signer) => {
+                write!(
+                    f,
+                    "Updated signer with ID certificate hash: {}",
+                    signer.id.hash
+                )
+            }
+            TrustAnchorProxyEvent::SignerRequestMade(nonce) => {
+                write!(f, "Created signer request with nonce '{}'", nonce)
+            }
+            TrustAnchorProxyEvent::SignerResponseReceived(response) => {
+                write!(
+                    f,
+                    "Received signer response with nonce '{}'",
+                    response.content().nonce
+                )
+            }
+
+            // Children
+            TrustAnchorProxyEvent::ChildAdded(child) => {
+                write!(
+                    f,
+                    "Added child: {}, with resources: {}",
+                    child.handle, child.resources
+                )
+            }
+            TrustAnchorProxyEvent::ChildRequestAdded(
+                child_handle,
+                request,
+            ) => {
+                write!(
+                    f,
+                    "Added request for child {}: {}",
+                    child_handle, request
+                )
+            }
+            TrustAnchorProxyEvent::ChildResponseGiven(child_handle, key) => {
+                write!(
+                    f,
+                    "Given response to child {} for key: {}",
+                    child_handle, key
+                )
+            }
+        }
+    }
+}
+
+
+//------------ TrustAnchorProxyCommand ---------------------------------------
+
+pub type TrustAnchorProxyCommand =
+    eventsourcing::SentCommand<TrustAnchorProxyCommandDetails>;
+
+impl TrustAnchorProxyCommand {
+    pub fn add_repo(
+        id: &CaHandle,
+        repository: RepositoryContact,
+        actor: &Actor,
+    ) -> Self {
+        TrustAnchorProxyCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorProxyCommandDetails::AddRepository(repository),
+            actor,
+        )
+    }
+
+    pub fn add_signer(
+        id: &CaHandle,
+        signer: TrustAnchorSignerInfo,
+        actor: &Actor,
+    ) -> Self {
+        TrustAnchorProxyCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorProxyCommandDetails::AddSigner(signer),
+            actor,
+        )
+    }
+
+    pub fn update_signer(
+        id: &CaHandle,
+        signer: TrustAnchorSignerInfo,
+        actor: &Actor,
+    ) -> Self {
+        TrustAnchorProxyCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorProxyCommandDetails::UpdateSigner(signer),
+            actor,
+        )
+    }
+
+    pub fn make_signer_request(
+        id: &CaHandle,
+        actor: &Actor,
+    ) -> Self {
+        TrustAnchorProxyCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorProxyCommandDetails::MakeSignerRequest,
+            actor,
+        )
+    }
+
+    pub fn process_signer_response(
+        id: &CaHandle,
+        response: TrustAnchorSignedResponse,
+        actor: &Actor,
+    ) -> Self {
+        TrustAnchorProxyCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorProxyCommandDetails::ProcessSignerResponse(response),
+            actor,
+        )
+    }
+
+    pub fn add_child(
+        id: &CaHandle,
+        child: AddChildRequest,
+        actor: &Actor,
+    ) -> Self {
+        TrustAnchorProxyCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorProxyCommandDetails::AddChild(child),
+            actor,
+        )
+    }
+
+    pub fn add_child_request(
+        id: &CaHandle,
+        child: ChildHandle,
+        request: ProvisioningRequest,
+        actor: &Actor,
+    ) -> Self {
+        TrustAnchorProxyCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorProxyCommandDetails::AddChildRequest(child, request),
+            actor,
+        )
+    }
+
+    pub fn give_child_response(
+        id: &CaHandle,
+        child: ChildHandle,
+        key: KeyIdentifier,
+        actor: &Actor,
+    ) -> Self {
+        TrustAnchorProxyCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorProxyCommandDetails::GiveChildResponse(child, key),
+            actor,
+        )
+    }
+}
+
+
+//------------ TrustAnchorProxyCommandDetails --------------------------------
+
+//  *Warning:* This type is used in stored state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum TrustAnchorProxyCommandDetails {
+    // Create new instance - cannot be sent to an existing instance
+    Init,
+
+    // Publication Support
+    AddRepository(RepositoryContact),
+
+    // Proxy -> Signer interactions
+    AddSigner(TrustAnchorSignerInfo),
+    UpdateSigner(TrustAnchorSignerInfo),
+    MakeSignerRequest,
+    ProcessSignerResponse(TrustAnchorSignedResponse),
+
+    // Children
+    AddChild(AddChildRequest),
+    AddChildRequest(ChildHandle, ProvisioningRequest),
+    GiveChildResponse(ChildHandle, KeyIdentifier),
+}
+
+impl fmt::Display for TrustAnchorProxyCommandDetails {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // note that this is a summary, full details are stored in the json.
+        match self {
+            TrustAnchorProxyCommandDetails::Init => {
+                write!(f, "Initialise TA proxy")
+            }
+            // Publication Support
+            TrustAnchorProxyCommandDetails::AddRepository(repository) => {
+                write!(
+                    f,
+                    "Add repository at: {}",
+                    repository.server_info.service_uri
+                )
+            }
+
+            // Proxy -> Signer interactions
+            TrustAnchorProxyCommandDetails::AddSigner(signer) => {
+                write!(
+                    f,
+                    "Add signer with id certificate hash: {}",
+                    signer.id.hash
+                )
+            }
+            TrustAnchorProxyCommandDetails::UpdateSigner(signer) => {
+                write!(
+                    f,
+                    "Update signer with id certificate hash: {}",
+                    signer.id.hash
+                )
+            }
+            TrustAnchorProxyCommandDetails::MakeSignerRequest => {
+                write!(f, "Create new publish request for signer")
+            }
+            TrustAnchorProxyCommandDetails::ProcessSignerResponse(
+                response,
+            ) => {
+                write!(
+                    f,
+                    "Process signer response. Nonce: {}. Next Update (before): {}",
+                    response.content().nonce,
+                    response.content().objects.revision().next_update().to_rfc3339()
+                )
+            }
+
+            // Children
+            TrustAnchorProxyCommandDetails::AddChild(child) => {
+                write!(f, "Add child: {}", child)
+            }
+            TrustAnchorProxyCommandDetails::AddChildRequest(
+                child_handle,
+                request,
+            ) => {
+                write!(
+                    f,
+                    "Add request for child {}: {}",
+                    child_handle, request
+                )
+            }
+            TrustAnchorProxyCommandDetails::GiveChildResponse(
+                child_handle,
+                key,
+            ) => {
+                write!(
+                    f,
+                    "Give (and remove) response to child {} for key {}",
+                    child_handle, key
+                )
+            }
+        }
+    }
+}
+
+impl eventsourcing::WithStorableDetails for TrustAnchorProxyCommandDetails {
+    fn summary(&self) -> crate::api::history::CommandSummary {
+        match self {
+            // Initialisation
+            TrustAnchorProxyCommandDetails::Init => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-proxy-init",
+                    self,
+                )
+            }
+            // Publication Support
+            TrustAnchorProxyCommandDetails::AddRepository(repository) => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-proxy-repo-add",
+                    self,
+                )
+                .service_uri(&repository.server_info.service_uri)
+            }
+
+            // Proxy -> Signer interactions
+            TrustAnchorProxyCommandDetails::AddSigner(signer) => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-proxy-signer-add",
+                    self,
+                )
+                .id_cert_hash(&signer.id.hash)
+            }
+            TrustAnchorProxyCommandDetails::UpdateSigner(signer) => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-proxy-signer-update",
+                    self,
+                )
+                .id_cert_hash(&signer.id.hash)
+            }
+            TrustAnchorProxyCommandDetails::MakeSignerRequest => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-proxy-pub-req",
+                    self,
+                )
+            }
+            TrustAnchorProxyCommandDetails::ProcessSignerResponse(
+                response,
+            ) => crate::api::history::CommandSummary::new(
+                "cmd-ta-proxy-pub-res",
+                self,
+            )
+            .arg("nonce", &response.content().nonce)
+            .arg(
+                "manifest number",
+                response.content().objects.revision().number(),
+            )
+            .arg(
+                "this update",
+                response
+                    .content()
+                    .objects
+                    .revision()
+                    .this_update()
+                    .to_rfc3339(),
+            )
+            .arg(
+                "next update",
+                response
+                    .content()
+                    .objects
+                    .revision()
+                    .next_update()
+                    .to_rfc3339(),
+            ),
+
+            // Children
+            TrustAnchorProxyCommandDetails::AddChild(child) => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-proxy-child-add", self,
+                ).child(&child.handle)
+            }
+            TrustAnchorProxyCommandDetails::AddChildRequest(
+                child_handle,
+                _request,
+            ) => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-proxy-child-req",
+                    self,
+                ).child(child_handle)
+            }
+            TrustAnchorProxyCommandDetails::GiveChildResponse(
+                child_handle,
+                _response,
+            ) => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-proxy-child-res",
+                    self,
+                ).child(child_handle)
+            }
+        }
+    }
+
+    fn make_init() -> Self {
+        Self::Init
+    }
+}
+
+impl eventsourcing::CommandDetails for TrustAnchorProxyCommandDetails {
+    type Event = TrustAnchorProxyEvent;
+    type StorableDetails = Self;
+
+    fn store(&self) -> Self::StorableDetails {
+        self.clone()
     }
 }
 

--- a/src/tasigner/signer.rs
+++ b/src/tasigner/signer.rs
@@ -670,11 +670,7 @@ impl fmt::Display for TrustAnchorSignerCommandDetails {
 pub enum TrustAnchorSignerStorableCommand {
     Init,
     TrustAnchorSignerRequest(TrustAnchorSignedRequest),
-    TrustAnchorSignerReissueRequest {
-        repo_info: RepoInfo,
-        tal_https: Vec<uri::Https>,
-        tal_rsync: uri::Rsync,
-    }
+    TrustAnchorSignerReissueRequest(TrustAnchorReissueRequest),
 }
 
 impl From<&TrustAnchorSignerCommandDetails>
@@ -691,11 +687,13 @@ impl From<&TrustAnchorSignerCommandDetails>
             TrustAnchorSignerCommandDetails::TrustAnchorSignerReissueRequest { 
                 repo_info, tal_https, tal_rsync, ..
             } => {
-                Self::TrustAnchorSignerReissueRequest {
-                    repo_info: repo_info.clone(),
-                    tal_https: tal_https.clone(),
-                    tal_rsync: tal_rsync.clone(),
-                }
+                Self::TrustAnchorSignerReissueRequest(
+                    TrustAnchorReissueRequest {
+                        repo_info: repo_info.clone(),
+                        tal_https: tal_https.clone(),
+                        tal_rsync: tal_rsync.clone(),
+                    }
+                )
             }
         }
     }
@@ -719,11 +717,13 @@ impl eventsourcing::WithStorableDetails for TrustAnchorSignerStorableCommand {
                     self,
                 ).arg("nonce", &request.content().nonce)
             }
-            Self::TrustAnchorSignerReissueRequest {
-                repo_info: _,
-                tal_https: _,
-                tal_rsync: _,
-            } => {
+            Self::TrustAnchorSignerReissueRequest(
+                TrustAnchorReissueRequest {
+                    repo_info: _,
+                    tal_https: _,
+                    tal_rsync: _,
+                }
+            ) => {
                 crate::api::history::CommandSummary::new(
                     "cmd-ta-signer-reissue", 
                     self
@@ -762,6 +762,17 @@ impl fmt::Display for TrustAnchorSignerStorableCommand {
             }
         }
     }
+}
+
+
+//------------ TrustAnchorReissueRequest -------------------------------------
+
+//  *Warning:* This type is used in stored state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TrustAnchorReissueRequest {
+    repo_info: RepoInfo,
+    tal_https: Vec<uri::Https>,
+    tal_rsync: uri::Rsync,
 }
 
 

--- a/src/tasigner/signer.rs
+++ b/src/tasigner/signer.rs
@@ -48,11 +48,12 @@ use crate::api::ta::{
 use crate::constants::ta_resource_class_name;
 
 
-//------------ TrustAnchorSigner -------------------------------------------
+//------------ TrustAnchorSigner ---------------------------------------------
 
 /// The Trust Anchor Signer signs requests sent to it by its associated
 /// proxy, as long as it can verify that the proxy signed that request.
-
+//
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TrustAnchorSigner {
     // event-sourcing support
@@ -73,269 +74,6 @@ pub struct TrustAnchorSigner {
 
     // Proxy Signer Exchanges
     exchanges: TrustAnchorProxySignerExchanges,
-}
-
-//------------ TrustAnchorSigner: Commands and Events ----------------------
-
-pub type TrustAnchorSignerInitCommand =
-    eventsourcing::SentInitCommand<TrustAnchorSignerInitCommandDetails>;
-
-#[derive(Clone, Debug)]
-pub struct TrustAnchorSignerInitCommandDetails {
-    pub proxy_id: IdCertInfo,
-    pub repo_info: RepoInfo,
-    pub tal_https: Vec<uri::Https>,
-    pub tal_rsync: uri::Rsync,
-    pub private_key_pem: Option<String>,
-    pub ta_mft_nr_override: Option<u64>,
-    pub timing: TaTimingConfig,
-    pub signer: Arc<KrillSigner>,
-}
-
-impl fmt::Display for TrustAnchorSignerInitCommandDetails {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.store().fmt(f)
-    }
-}
-
-impl InitCommandDetails for TrustAnchorSignerInitCommandDetails {
-    type StorableDetails = TrustAnchorSignerStorableCommand;
-
-    fn store(&self) -> Self::StorableDetails {
-        TrustAnchorSignerStorableCommand::make_init()
-    }
-}
-
-
-pub type TrustAnchorSignerCommand =
-    eventsourcing::SentCommand<TrustAnchorSignerCommandDetails>;
-
-// Initialisation
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct TrustAnchorSignerInitEvent {
-    id: IdCertInfo,
-    proxy_id: IdCertInfo,
-    ta_cert_details: TaCertDetails,
-    objects: TrustAnchorObjects,
-}
-
-impl InitEvent for TrustAnchorSignerInitEvent {}
-
-impl fmt::Display for TrustAnchorSignerInitEvent {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // note that this is a summary, full details are stored in the init
-        // event.
-        write!(f, "Trust Anchor Signer was initialised.")
-    }
-}
-
-// Events
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum TrustAnchorSignerEvent {
-    ProxySignerExchangeDone(TrustAnchorProxySignerExchange),
-    SignerReissueDone(TaCertDetails)
-}
-
-impl Event for TrustAnchorSignerEvent {}
-
-impl fmt::Display for TrustAnchorSignerEvent {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            TrustAnchorSignerEvent::ProxySignerExchangeDone(exchange) => {
-                write!(
-                    f,
-                    "Proxy signer exchange done on {} for nonce: {}",
-                    exchange.time.to_rfc3339(),
-                    exchange.request.content().nonce
-                )
-            },
-            TrustAnchorSignerEvent::SignerReissueDone(ta_cert_details) => {
-                write!(
-                    f,
-                    "Signer reissue done with serial {}",
-                    ta_cert_details.cert.serial
-                )
-            }
-        }
-    }
-}
-
-// Commands
-#[derive(Clone, Debug)]
-pub enum TrustAnchorSignerCommandDetails {
-    TrustAnchorSignerRequest {
-        signed_request: TrustAnchorSignedRequest,
-        ta_timing_config: TaTimingConfig,
-        ta_mft_number_override: Option<u64>,
-        signer: Arc<KrillSigner>,
-    },
-    TrustAnchorSignerReissueRequest {
-        repo_info: RepoInfo,
-        tal_https: Vec<uri::Https>,
-        tal_rsync: uri::Rsync,
-        timing: TaTimingConfig,
-        signer: Arc<KrillSigner>,
-    },
-}
-
-impl eventsourcing::CommandDetails for TrustAnchorSignerCommandDetails {
-    type Event = TrustAnchorSignerEvent;
-    type StorableDetails = TrustAnchorSignerStorableCommand;
-
-    fn store(&self) -> Self::StorableDetails {
-        self.into()
-    }
-}
-
-impl fmt::Display for TrustAnchorSignerCommandDetails {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        TrustAnchorSignerStorableCommand::from(self).fmt(f)
-    }
-}
-
-impl TrustAnchorSignerCommand {
-    pub fn make_process_request_command(
-        id: &CaHandle,
-        signed_request: TrustAnchorSignedRequest,
-        ta_timing_config: TaTimingConfig,
-        ta_mft_number_override: Option<u64>,
-        signer: Arc<KrillSigner>,
-        actor: &Actor,
-    ) -> TrustAnchorSignerCommand {
-        TrustAnchorSignerCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorSignerCommandDetails::TrustAnchorSignerRequest {
-                signed_request,
-                ta_timing_config,
-                ta_mft_number_override,
-                signer,
-            },
-            actor,
-        )
-    }
-
-    pub fn make_reissue_command(
-        id: &CaHandle,
-        repo_info: RepoInfo,
-        tal_https: Vec<uri::Https>,
-        tal_rsync: uri::Rsync,
-        ta_timing_config: TaTimingConfig,
-        signer: Arc<KrillSigner>,
-        actor: &Actor,
-    ) -> TrustAnchorSignerCommand {
-        TrustAnchorSignerCommand::new(
-            id.clone(),
-            None,
-            TrustAnchorSignerCommandDetails::TrustAnchorSignerReissueRequest {
-                repo_info,
-                tal_https,
-                tal_rsync,
-                timing: ta_timing_config,
-                signer,
-            }, 
-            actor
-        )
-    }
-}
-
-// Storable Commands (KrillSigner cannot be de-/serialized)
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum TrustAnchorSignerStorableCommand {
-    Init,
-    TrustAnchorSignerRequest(TrustAnchorSignedRequest),
-    TrustAnchorSignerReissueRequest {
-        repo_info: RepoInfo,
-        tal_https: Vec<uri::Https>,
-        tal_rsync: uri::Rsync,
-    }
-}
-
-impl From<&TrustAnchorSignerCommandDetails>
-    for TrustAnchorSignerStorableCommand
-{
-    fn from(details: &TrustAnchorSignerCommandDetails) -> Self {
-        match details {
-            TrustAnchorSignerCommandDetails::TrustAnchorSignerRequest {
-                signed_request,
-                ..
-            } => TrustAnchorSignerStorableCommand::TrustAnchorSignerRequest(
-                signed_request.clone(),
-            ),
-            TrustAnchorSignerCommandDetails::TrustAnchorSignerReissueRequest { 
-                repo_info, tal_https, tal_rsync, ..
-            } => {
-                Self::TrustAnchorSignerReissueRequest {
-                    repo_info: repo_info.clone(),
-                    tal_https: tal_https.clone(),
-                    tal_rsync: tal_rsync.clone(),
-                }
-            }
-        }
-    }
-}
-
-
-impl eventsourcing::WithStorableDetails for TrustAnchorSignerStorableCommand {
-    fn summary(&self) -> crate::api::history::CommandSummary {
-        match self {
-            TrustAnchorSignerStorableCommand::Init => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-signer-init",
-                    self,
-                )
-            }
-            Self::TrustAnchorSignerRequest(
-                request,
-            ) => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-signer-process-request",
-                    self,
-                ).arg("nonce", &request.content().nonce)
-            }
-            Self::TrustAnchorSignerReissueRequest {
-                repo_info: _,
-                tal_https: _,
-                tal_rsync: _,
-            } => {
-                crate::api::history::CommandSummary::new(
-                    "cmd-ta-signer-reissue", 
-                    self
-                )
-                // XXX This should probably include the stored values.
-            }
-        }
-    }
-
-    fn make_init() -> Self {
-        Self::Init
-    }
-}
-
-impl fmt::Display for TrustAnchorSignerStorableCommand {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // note that this is a summary, full details are stored in the json.
-        match self {
-            TrustAnchorSignerStorableCommand::Init => {
-                write!(f, "Initialise TA signer")
-            }
-            TrustAnchorSignerStorableCommand::TrustAnchorSignerRequest(
-                req,
-            ) => {
-                write!(
-                    f,
-                    "Process signer request with nonce: {}",
-                    req.content().nonce
-                )
-            },
-            Self::TrustAnchorSignerReissueRequest {
-                ..
-            } => {
-                write!(f, "Reissue the TA signer")
-                // XXX This should probably print all the values.
-            }
-        }
-    }
 }
 
 impl eventsourcing::Aggregate for TrustAnchorSigner {
@@ -802,6 +540,290 @@ impl TrustAnchorSigner {
     }
 }
 
+
+//------------ TrustAnchorSignerInitCommand ----------------------------------
+
+pub type TrustAnchorSignerInitCommand =
+    eventsourcing::SentInitCommand<TrustAnchorSignerInitCommandDetails>;
+
+
+//------------ TrustAnchorSignerInitCommandDetails ---------------------------
+
+#[derive(Clone, Debug)]
+pub struct TrustAnchorSignerInitCommandDetails {
+    pub proxy_id: IdCertInfo,
+    pub repo_info: RepoInfo,
+    pub tal_https: Vec<uri::Https>,
+    pub tal_rsync: uri::Rsync,
+    pub private_key_pem: Option<String>,
+    pub ta_mft_nr_override: Option<u64>,
+    pub timing: TaTimingConfig,
+    pub signer: Arc<KrillSigner>,
+}
+
+impl fmt::Display for TrustAnchorSignerInitCommandDetails {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.store().fmt(f)
+    }
+}
+
+impl InitCommandDetails for TrustAnchorSignerInitCommandDetails {
+    type StorableDetails = TrustAnchorSignerStorableCommand;
+
+    fn store(&self) -> Self::StorableDetails {
+        TrustAnchorSignerStorableCommand::make_init()
+    }
+}
+
+
+//------------ TrustAnchorSignerCommand --------------------------------------
+
+pub type TrustAnchorSignerCommand =
+    eventsourcing::SentCommand<TrustAnchorSignerCommandDetails>;
+
+impl TrustAnchorSignerCommand {
+    pub fn make_process_request_command(
+        id: &CaHandle,
+        signed_request: TrustAnchorSignedRequest,
+        ta_timing_config: TaTimingConfig,
+        ta_mft_number_override: Option<u64>,
+        signer: Arc<KrillSigner>,
+        actor: &Actor,
+    ) -> TrustAnchorSignerCommand {
+        TrustAnchorSignerCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorSignerCommandDetails::TrustAnchorSignerRequest {
+                signed_request,
+                ta_timing_config,
+                ta_mft_number_override,
+                signer,
+            },
+            actor,
+        )
+    }
+
+    pub fn make_reissue_command(
+        id: &CaHandle,
+        repo_info: RepoInfo,
+        tal_https: Vec<uri::Https>,
+        tal_rsync: uri::Rsync,
+        ta_timing_config: TaTimingConfig,
+        signer: Arc<KrillSigner>,
+        actor: &Actor,
+    ) -> TrustAnchorSignerCommand {
+        TrustAnchorSignerCommand::new(
+            id.clone(),
+            None,
+            TrustAnchorSignerCommandDetails::TrustAnchorSignerReissueRequest {
+                repo_info,
+                tal_https,
+                tal_rsync,
+                timing: ta_timing_config,
+                signer,
+            }, 
+            actor
+        )
+    }
+}
+
+
+//------------ TrustAnchorSignerCommandDetails -------------------------------
+
+#[derive(Clone, Debug)]
+pub enum TrustAnchorSignerCommandDetails {
+    TrustAnchorSignerRequest {
+        signed_request: TrustAnchorSignedRequest,
+        ta_timing_config: TaTimingConfig,
+        ta_mft_number_override: Option<u64>,
+        signer: Arc<KrillSigner>,
+    },
+    TrustAnchorSignerReissueRequest {
+        repo_info: RepoInfo,
+        tal_https: Vec<uri::Https>,
+        tal_rsync: uri::Rsync,
+        timing: TaTimingConfig,
+        signer: Arc<KrillSigner>,
+    },
+}
+
+impl eventsourcing::CommandDetails for TrustAnchorSignerCommandDetails {
+    type Event = TrustAnchorSignerEvent;
+    type StorableDetails = TrustAnchorSignerStorableCommand;
+
+    fn store(&self) -> Self::StorableDetails {
+        self.into()
+    }
+}
+
+impl fmt::Display for TrustAnchorSignerCommandDetails {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        TrustAnchorSignerStorableCommand::from(self).fmt(f)
+    }
+}
+
+
+//------------ TrustAnchorSignerStorableCommand ------------------------------
+
+//  *Warning:* This type is used in stored state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum TrustAnchorSignerStorableCommand {
+    Init,
+    TrustAnchorSignerRequest(TrustAnchorSignedRequest),
+    TrustAnchorSignerReissueRequest {
+        repo_info: RepoInfo,
+        tal_https: Vec<uri::Https>,
+        tal_rsync: uri::Rsync,
+    }
+}
+
+impl From<&TrustAnchorSignerCommandDetails>
+    for TrustAnchorSignerStorableCommand
+{
+    fn from(details: &TrustAnchorSignerCommandDetails) -> Self {
+        match details {
+            TrustAnchorSignerCommandDetails::TrustAnchorSignerRequest {
+                signed_request,
+                ..
+            } => TrustAnchorSignerStorableCommand::TrustAnchorSignerRequest(
+                signed_request.clone(),
+            ),
+            TrustAnchorSignerCommandDetails::TrustAnchorSignerReissueRequest { 
+                repo_info, tal_https, tal_rsync, ..
+            } => {
+                Self::TrustAnchorSignerReissueRequest {
+                    repo_info: repo_info.clone(),
+                    tal_https: tal_https.clone(),
+                    tal_rsync: tal_rsync.clone(),
+                }
+            }
+        }
+    }
+}
+
+
+impl eventsourcing::WithStorableDetails for TrustAnchorSignerStorableCommand {
+    fn summary(&self) -> crate::api::history::CommandSummary {
+        match self {
+            TrustAnchorSignerStorableCommand::Init => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-signer-init",
+                    self,
+                )
+            }
+            Self::TrustAnchorSignerRequest(
+                request,
+            ) => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-signer-process-request",
+                    self,
+                ).arg("nonce", &request.content().nonce)
+            }
+            Self::TrustAnchorSignerReissueRequest {
+                repo_info: _,
+                tal_https: _,
+                tal_rsync: _,
+            } => {
+                crate::api::history::CommandSummary::new(
+                    "cmd-ta-signer-reissue", 
+                    self
+                )
+                // XXX This should probably include the stored values.
+            }
+        }
+    }
+
+    fn make_init() -> Self {
+        Self::Init
+    }
+}
+
+impl fmt::Display for TrustAnchorSignerStorableCommand {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // note that this is a summary, full details are stored in the json.
+        match self {
+            TrustAnchorSignerStorableCommand::Init => {
+                write!(f, "Initialise TA signer")
+            }
+            TrustAnchorSignerStorableCommand::TrustAnchorSignerRequest(
+                req,
+            ) => {
+                write!(
+                    f,
+                    "Process signer request with nonce: {}",
+                    req.content().nonce
+                )
+            },
+            Self::TrustAnchorSignerReissueRequest {
+                ..
+            } => {
+                write!(f, "Reissue the TA signer")
+                // XXX This should probably print all the values.
+            }
+        }
+    }
+}
+
+
+//------------ TrustAnchorSignerInitEvent ------------------------------------
+
+//  *Warning:* This type is used in stored state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TrustAnchorSignerInitEvent {
+    id: IdCertInfo,
+    proxy_id: IdCertInfo,
+    ta_cert_details: TaCertDetails,
+    objects: TrustAnchorObjects,
+}
+
+impl InitEvent for TrustAnchorSignerInitEvent {}
+
+impl fmt::Display for TrustAnchorSignerInitEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // note that this is a summary, full details are stored in the init
+        // event.
+        write!(f, "Trust Anchor Signer was initialised.")
+    }
+}
+
+
+//------------ TrustAnchorSignerEvent ----------------------------------------
+
+//  *Warning:* This type is used in stored state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum TrustAnchorSignerEvent {
+    ProxySignerExchangeDone(TrustAnchorProxySignerExchange),
+    SignerReissueDone(TaCertDetails)
+}
+
+impl Event for TrustAnchorSignerEvent {}
+
+impl fmt::Display for TrustAnchorSignerEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            TrustAnchorSignerEvent::ProxySignerExchangeDone(exchange) => {
+                write!(
+                    f,
+                    "Proxy signer exchange done on {} for nonce: {}",
+                    exchange.time.to_rfc3339(),
+                    exchange.request.content().nonce
+                )
+            },
+            TrustAnchorSignerEvent::SignerReissueDone(ta_cert_details) => {
+                write!(
+                    f,
+                    "Signer reissue done with serial {}",
+                    ta_cert_details.cert.serial
+                )
+            }
+        }
+    }
+}
+
+
+//------------ TrustAnchorProxySignerExchanges -------------------------------
+
+//  *Warning:* This type is used in stored state.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TrustAnchorProxySignerExchanges(
     Vec<TrustAnchorProxySignerExchange>,

--- a/src/upgrades/data_migration.rs
+++ b/src/upgrades/data_migration.rs
@@ -262,3 +262,4 @@ pub mod tests {
         migrate(config, target_store).unwrap();
     }
 }
+


### PR DESCRIPTION
This PR sticks a warning on all types that are used when serializing Krill’s state. This hopefully will serve as a reminder that they cannot be changed without considering migrations.