### PR TITLE
Upgrade to edition 2024.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Note: some of these values are also used when building Debian packages below.
 name = "krill"
 version = "0.15.0-dev"
-edition = "2021"
+edition = "2024"
 rust-version = "1.85"
 authors = ["NLnet Labs <rpki-team@nlnetlabs.nl>"]
 description = "Resource Public Key Infrastructure (RPKI) daemon"

--- a/Changelog.md
+++ b/Changelog.md
@@ -50,6 +50,7 @@ Other changes
   ([#1249])
 * Added packaging support for Ubuntu Noble; removed packaging support for
   Ubuntu Xenial and Bionic, and Debian Stretch. ([#1239])
+* The minimum supported Rust version is now 1.85. ([#1288])
 
 [#1215]: https://github.com/NLnetLabs/krill/pull/1215
 [#1226]: https://github.com/NLnetLabs/krill/pull/1226
@@ -61,7 +62,8 @@ Other changes
 [#1249]: https://github.com/NLnetLabs/krill/pull/1249
 [#1255]: https://github.com/NLnetLabs/krill/pull/1255
 [#1266]: https://github.com/NLnetLabs/krill/pull/1266
-[#1281]: https://github.com/NLnetLabs/krill/pull/1255
+[#1281]: https://github.com/NLnetLabs/krill/pull/1281
+[#1288]: https://github.com/NLnetLabs/krill/pull/1288
 
 
 ## 0.14.5 ‘Who dis? New Phone’

--- a/src/bin/krillc.rs
+++ b/src/bin/krillc.rs
@@ -14,8 +14,11 @@ async fn main() {
     let client = KrillClient::new(
         options.general.server, options.general.token
     );
+
     if options.general.api {
-        env::set_var(constants::KRILL_CLI_API_ENV, "1")
+        // Safety: There shouldn’t be anything else going on at this point.
+        //         XXX That said, we need to replace this mechanism.
+        unsafe { env::set_var(constants::KRILL_CLI_API_ENV, "1"); }
     }
     let report = options.command.run(&client).await;
     let status = report.report(options.general.format);

--- a/src/cli/ta/options/proxy.rs
+++ b/src/cli/ta/options/proxy.rs
@@ -40,7 +40,8 @@ impl Command {
             self.general.server, self.general.token
         );
         if self.general.api {
-            env::set_var(constants::KRILL_CLI_API_ENV, "1")
+            // Safety: We are still single thread at this point.
+            unsafe { env::set_var(constants::KRILL_CLI_API_ENV, "1") }
         }
         self.command.run(&client).await
     }

--- a/src/commons/storage/types/namespace.rs
+++ b/src/commons/storage/types/namespace.rs
@@ -121,7 +121,7 @@ impl Namespace {
     /// and must not be longer than 255 characters.
     pub const unsafe fn from_str_unchecked(s: &str) -> &Self {
         // SAFETY: Self has #repr(transparent)
-        mem::transmute(s)
+        unsafe { mem::transmute(s) }
     }
 
     /// Returns a string slice of the namespace.

--- a/src/commons/storage/types/segment.rs
+++ b/src/commons/storage/types/segment.rs
@@ -174,7 +174,7 @@ impl Segment {
     /// white space and must not contain `Self::SEPARATOR`.
     pub const unsafe fn from_str_unchecked(s: &str) -> &Self {
         // SAFETY: Self has #repr(transparent)
-        mem::transmute(s)
+        unsafe { mem::transmute(s) }
     }
 
     /// Returns a string slice of the segment.

--- a/src/config.rs
+++ b/src/config.rs
@@ -2068,7 +2068,9 @@ mod tests {
     fn should_parse_default_config_file() {
         // Config for auth token is required! If there is nothing in the conf
         // file, then an environment variable must be set.
-        env::set_var(KRILL_ENV_ADMIN_TOKEN, "secret");
+        //
+        // Safety: Not really.
+        unsafe { env::set_var(KRILL_ENV_ADMIN_TOKEN, "secret"); }
 
         let c = Config::read_config("./defaults/krill.conf").unwrap();
         let expected_socket_addresses: Vec<SocketAddr> =
@@ -2081,7 +2083,9 @@ mod tests {
     fn should_parse_testbed_config_file() {
         // Config for auth token is required! If there is nothing in the conf
         // file, then an environment variable must be set.
-        env::set_var(KRILL_ENV_ADMIN_TOKEN, "secret");
+        //
+        // Safety: Not really.
+        unsafe { env::set_var(KRILL_ENV_ADMIN_TOKEN, "secret"); }
 
         let c = Config::read_config("./defaults/krill-testbed.conf").unwrap();
 
@@ -2133,7 +2137,9 @@ mod tests {
 
         // Krill requires an auth token to be defined, give it one in the
         // environment
-        env::set_var(KRILL_ENV_ADMIN_TOKEN, "secret");
+        //
+        // Safety: Not really.
+        unsafe {env::set_var(KRILL_ENV_ADMIN_TOKEN, "secret"); }
 
         // Define sets of log targets aka components of Krill that we want to
         // test log settings for, based on the rules & exceptions that
@@ -2234,61 +2240,6 @@ mod tests {
                         config_level,
                         if should_be_enabled { "enabled" } else { "disabled" },
                         component
-                    );
-                }
-            }
-        }
-
-        //
-        // Test that Oso logging at levels below Info is only enabled if the
-        // Oso POLAR_LOG=1 environment variable is set
-        //
-        let component = "oso";
-        for set_polar_log_env_var in &[true, false] {
-            // setup env vars
-            if *set_polar_log_env_var {
-                env::set_var("POLAR_LOG", "1");
-            } else {
-                env::remove_var("POLAR_LOG");
-            }
-
-            // for each Krill config log level we want to test
-            for config_level in &["debug", "trace"] {
-                // build a logger for that config
-                let log = void_logger_from_krill_config(&format!(
-                    r#"log_level = "{config_level}""#
-                ));
-
-                // for each level of interest that messages could be logged at
-                for log_msg_level in &[LL::Debug, LL::Trace] {
-                    // determine if logging should be enabled or not
-                    let should_be_enabled =
-                        should_logging_be_enabled_at_this_krill_config_log_level(log_msg_level, config_level)
-                            && *set_polar_log_env_var;
-
-                    // verify that logging is enabled or not as expected
-                    assert_eq!(
-                        should_be_enabled,
-                        log.enabled(&for_target_at_level(
-                            component,
-                            *log_msg_level
-                        )),
-                        // output an easy to understand test failure
-                        // description
-                        r#"Logging at level {} with log_level={} should be {} for component {} and env var POLAR_LOG is {}"#,
-                        log_msg_level,
-                        config_level,
-                        if should_be_enabled {
-                            "enabled"
-                        } else {
-                            "disabled"
-                        },
-                        component,
-                        if *set_polar_log_env_var {
-                            "set"
-                        } else {
-                            "not set"
-                        }
                     );
                 }
             }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -96,10 +96,14 @@ pub const KRILL_HTTPS_ROOT_CERTS_ENV: &str = "KRILL_HTTPS_ROOT_CERTS";
 
 // XXX The following functions should probably live somewhere else. But
 //     where?
+//
+//     The use of environment variables here is very unsafe and we should
+//     probably replace this with something else.
 
 /// Sets the environment variable to enable test mode.
 pub fn enable_test_mode() {
-    std::env::set_var(KRILL_ENV_TEST, "1");
+    // Safety: See note above.
+    unsafe { std::env::set_var(KRILL_ENV_TEST, "1") };
 }
 
 /// Returns whether the environment variable to enable test mode is set.
@@ -109,7 +113,8 @@ pub fn test_mode_enabled() -> bool {
 
 /// Sets the environment variable to enable test announcements.
 pub fn enable_test_announcements() {
-    std::env::set_var(KRILL_ENV_TEST_ANN, "1");
+    // Safety: See note above.
+    unsafe { std::env::set_var(KRILL_ENV_TEST_ANN, "1"); }
 }
 
 /// Returns whether the environment variable for test announcements is set.


### PR DESCRIPTION
This PR upgrades to edition 2024.

This surfaces an interesting issue as `std::env::set_var` is unsafe. Krill relies on various environment variables which are read throughout operation and set to convey them to those points. This should be replaces by reading those variables up front and conveying information by other means.