### PR TITLE
Keep RefreshAnnouncementsInfo task as a dummy.

### DIFF
--- a/src/server/mq.rs
+++ b/src/server/mq.rs
@@ -86,11 +86,11 @@ pub enum Task {
 
     RrdpUpdateIfNeeded,
 
-    // This task is deprecated - the authorizer takes care of this itself.
-    // The mask may, however, still be in the task queue and currently the
-    // scheduler panics on unknown tasks, so we need to keep it for now and
-    // just not do anything.
+    // The following tasks are deprecated. They may, however, still be in the
+    // task queue and currently the scheduler panics on unknown tasks, so we
+    // need to keep it for now and just not do anything.
     SweepLoginCache,
+    RefreshAnnouncementsInfo,
 }
 
 impl Task {
@@ -157,6 +157,9 @@ impl Task {
             Task::SweepLoginCache => {
                 Ok(Segment::make("sweep_login_cache").to_owned())
             }
+            Task::RefreshAnnouncementsInfo => {
+                Ok(Segment::make("refresh_bgp_announcements_info").to_owned())
+            }
         }
         .map_err(|e| Error::Custom(format!("could not create name: {}", e)))
     }
@@ -208,6 +211,9 @@ impl fmt::Display for Task {
                 )
             }
             Task::SweepLoginCache => write!(f, "sweep up expired logins"),
+            Task::RefreshAnnouncementsInfo => {
+                write!(f, "refresh BGP announcements info")
+            }
         }
     }
 }

--- a/src/server/scheduler.rs
+++ b/src/server/scheduler.rs
@@ -162,12 +162,6 @@ impl Scheduler {
                 self.renew_objects_if_needed().await
             }
 
-            Task::SweepLoginCache => {
-                // Don’t do anything. The authorizer now takes care of
-                // sweeping itself.
-                Ok(TaskResult::Done)
-            }
-
             Task::UpdateSnapshots => self.update_snapshots(),
 
             Task::RrdpUpdateIfNeeded => self.update_rrdp_if_needed(),
@@ -197,6 +191,11 @@ impl Scheduler {
             } => {
                 self.unexpected_key(ca, ca_version, rcn, revocation_request)
                     .await
+            }
+
+            Task::SweepLoginCache | Task::RefreshAnnouncementsInfo => {
+                // Don’t do anything. These are deprecated.
+                Ok(TaskResult::Done)
             }
         }
     }


### PR DESCRIPTION
This PR brings the `RefreshAnnouncementsInfo` task back which was used to trigger download of the RIS files. While we don’t need the task any more, it may still be in the task queue which would cause Krill to refuse to start.