### PR TITLE
Add support for RHEL 10

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   package:
     # See: https://github.com/NLnetLabs/ploutos
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@rocky-linux-10
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   package:
     # See: https://github.com/NLnetLabs/ploutos
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v7
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@rocky-linux-10
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/doc/manual/source/install-and-run.rst
+++ b/doc/manual/source/install-and-run.rst
@@ -196,7 +196,7 @@ public rsyncd and HTTPS web server available.
    .. group-tab:: RHEL
 
        To install a Routinator package, you need Red Hat Enterprise Linux
-       (RHEL) 8 or 9, or compatible operating system such as Rocky Linux.
+       (RHEL) 8, 9 or 10, or compatible operating system such as Rocky Linux.
        Packages are available for the ``amd64``/``x86_64`` architecture only.
 
        To use this repository, create a file named

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -11,8 +11,9 @@ image:
   - "debian:buster" # debian/10
   - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12
-  - "rockylinux:8" # compatible with EOL centos:8
-  - "rockylinux:9"
+  - "almalinux:8" # compatible with EOL centos:8
+  - "almalinux:9"
+  - "almalinux:10"
 target:
   - "x86_64"
 include:
@@ -28,11 +29,14 @@ include:
   # the archive that we produce below which is in turn based by default on the container image used to build. We
   # therefore in this case need to specify that the O/S we are building for has a different name than the Docker
   # image we are building it in.
-  - image: "rockylinux:8"
+  - image: "almalinux:8"
     os: "centos:8"
     rpm_systemd_service_unit_file: "pkg/common/krill-ubuntu-focal.krill.service"
 
-  - image: "rockylinux:9"
+  - image: "almalinux:9"
+    rpm_systemd_service_unit_file: "pkg/common/krill-ubuntu-focal.krill.service"
+
+  - image: "almalinux:10"
     rpm_systemd_service_unit_file: "pkg/common/krill-ubuntu-focal.krill.service"
 
   # package for the Raspberry Pi 4b as an ARMv7 cross compiled variant of the Debian Bullseye upon which

--- a/pkg/rules/packages-to-test.yml
+++ b/pkg/rules/packages-to-test.yml
@@ -11,8 +11,8 @@ image:
   - "debian:buster" # debian/10
   - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12
-  - "rockylinux:8" # compatible with EOL centos:8
-  - "rockylinux:9"
+  - "almalinux:8" # compatible with EOL centos:8
+  - "almalinux:9"
 target:
   - "x86_64"
 mode:
@@ -31,11 +31,11 @@ include:
   # the archive that we produce below which is in turn based by default on the container image used to build. We
   # therefore in this case need to specify that the O/S we are building for has a different name than the Docker
   # image we are building it in.
-  - image: "rockylinux:8"
+  - image: "almalinux:8"
     os: "centos:8"
     rpm_systemd_service_unit_file: "pkg/common/krill-ubuntu-focal.krill.service"
 
-  - image: "rockylinux:9"
+  - image: "almalinux:9"
     rpm_systemd_service_unit_file: "pkg/common/krill-ubuntu-focal.krill.service"
 
   # package for the Raspberry Pi 4b as an ARMv7 cross compiled variant of the Debian Bullseye upon which
@@ -67,7 +67,7 @@ include:
 
 # Exclude upgrade testing on Ubuntu Noble as no prior released versions exist to upgrade from.
 exclude:
-  - image: "rockylinux:9"
+  - image: "almalinux:9"
     mode: "upgrade-from-published"
   - image: "ubuntu:noble"
     mode: "upgrade-from-published"


### PR DESCRIPTION
Because we missed out on RHEL 9 last time round, let's make sure to not release a new version without support for the latest OS version.