### PR TITLE
Make TA messaging clearer

### DIFF
--- a/doc/manual/source/trust-anchor.rst
+++ b/doc/manual/source/trust-anchor.rst
@@ -521,6 +521,36 @@ Upload the Signer Response
   krillta proxy signer process-response --response ./response.json
 
 
+Reissuing TA Certificates
+-------------------------
+
+Reissue the signer. This takes the same arguments as init. Any changes to
+ta_timing are also reflected here:
+
+.. code-block:: bash
+
+  krillta signer -c ta.conf reissue --proxy-id proxy-id.json \ 
+                                    --proxy-repository-contact proxy-request.json \
+                                    --tal-rsync rsync://abcd.example.org/ta/ta.tal \ 
+                                    ...
+
+
+Get the TA Signer 'info' JSON file and save it:
+
+.. code-block:: bash
+
+  krillta signer -f json show > ./signer-info.json
+
+
+Then 'update' the signer associated with the TA Proxy:
+
+.. code-block:: bash
+
+  krillta proxy signer update --info ./signer-info.json
+
+At this point you should see that both /ta/ta.tal and /ta/ta.cer are updated.
+
+
 Auditing
 ^^^^^^^^
 

--- a/src/api/ta.rs
+++ b/src/api/ta.rs
@@ -504,7 +504,7 @@ impl fmt::Display for ApiTrustAnchorSignedRequest {
         match &self.request.child_requests.len() {
             0 => writeln!(f, "There are no child requests")?,
             1 => writeln!(f, "There is one child request")?,
-            n => writeln!(f, "There are {} child requests", n)?,
+            n => writeln!(f, "There are {n} child requests")?,
         };
         writeln!(f)?;
 

--- a/src/api/ta.rs
+++ b/src/api/ta.rs
@@ -501,6 +501,9 @@ impl fmt::Display for ApiTrustAnchorSignedRequest {
         writeln!(f, "-------------------------------")?;
         writeln!(f)?;
 
+        writeln!(f, "There are {} child requests:", &self.request.child_requests.len())?;
+        writeln!(f)?;
+
         for request in &self.request.child_requests {
             writeln!(f, "-------------------------------")?;
             writeln!(f, "          child request")?;
@@ -520,7 +523,8 @@ impl fmt::Display for ApiTrustAnchorSignedRequest {
             writeln!(f)?;
         }
 
-        if let Some(renew_time) = self.renew_time {
+        if let Some(renew_time) = self.renew_time && 
+            self.request.child_requests.is_empty() {
             writeln!(
                 f, "Certificates will be reissued {} weeks before expiry.", 
                 self.issued_certificate_reissue_weeks_before

--- a/src/api/ta.rs
+++ b/src/api/ta.rs
@@ -523,23 +523,24 @@ impl fmt::Display for ApiTrustAnchorSignedRequest {
             writeln!(f)?;
         }
 
-        if let Some(renew_time) = self.renew_time && 
-            self.request.child_requests.is_empty() {
-            writeln!(
-                f, "Certificates will be reissued {} weeks before expiry.", 
-                self.issued_certificate_reissue_weeks_before
-            )?;
-            writeln!(f, "The current certificate expires on {}.", 
-                renew_time.to_rfc3339()
-            )?; 
-            if let Some(weeks) = TimeDelta::try_weeks(
-                self.issued_certificate_reissue_weeks_before
-            ) {
-                let t = renew_time - weeks;
+        if self.request.child_requests.is_empty() {
+            if let Some(renew_time) = self.renew_time {
                 writeln!(
-                    f, "The certificate is eligible for renewal on {}.",
-                    t.to_rfc3339()
+                    f, "Certificates will be reissued {} weeks before expiry.", 
+                    self.issued_certificate_reissue_weeks_before
+                )?;
+                writeln!(f, "The current certificate expires on {}.", 
+                    renew_time.to_rfc3339()
                 )?; 
+                if let Some(weeks) = TimeDelta::try_weeks(
+                    self.issued_certificate_reissue_weeks_before
+                ) {
+                    let t = renew_time - weeks;
+                    writeln!(
+                        f, "The certificate is eligible for renewal on {}.",
+                        t.to_rfc3339()
+                    )?; 
+                }
             }
         }
 

--- a/src/api/ta.rs
+++ b/src/api/ta.rs
@@ -501,7 +501,11 @@ impl fmt::Display for ApiTrustAnchorSignedRequest {
         writeln!(f, "-------------------------------")?;
         writeln!(f)?;
 
-        writeln!(f, "There are {} child requests:", &self.request.child_requests.len())?;
+        match &self.request.child_requests.len() {
+            0 => writeln!(f, "There are no child requests")?,
+            1 => writeln!(f, "There is one child request")?,
+            n => writeln!(f, "There are {} child requests", n)?,
+        };
         writeln!(f)?;
 
         for request in &self.request.child_requests {

--- a/src/server/taproxy.rs
+++ b/src/server/taproxy.rs
@@ -514,15 +514,14 @@ impl TrustAnchorProxy {
                         requests: details.open_requests.clone(),
                     });
                 }
+            }
 
-                if let Ok(cert) = IdCert::try_from(&details.id) {
-                    let v = cert.validity();
-                    if let Some(rt) = renew_time {
-                        renew_time = Some(cmp::min(rt, v.not_after()));
-                    }
-                    else {
-                        renew_time = Some(v.not_after());
-                    }
+            if let Some(info) = &self.signer {
+                let v = info.ta_cert_details.cert.validity;
+                if let Some(rt) = renew_time {
+                    renew_time = Some(cmp::min(rt, v.not_after()));
+                } else {
+                    renew_time = Some(v.not_after());
                 }
             }
 

--- a/src/server/taproxy.rs
+++ b/src/server/taproxy.rs
@@ -10,7 +10,6 @@ use chrono::Duration;
 use log::{log_enabled, trace};
 use rpki::{
     ca::{
-        idcert::IdCert,
         idexchange::{self, CaHandle, ChildHandle, MyHandle},
         provisioning::{ResourceClassEntitlements, SigningCert},
     },

--- a/tests/functional_old_data.rs
+++ b/tests/functional_old_data.rs
@@ -54,7 +54,8 @@ async fn functional_old_data() {
     eprintln!(">>>> Make TA proxy signer request.");
     let request = 
         server.client().ta_proxy_signer_make_request().await.unwrap();
-    assert_eq!(request.renew_time.unwrap().year(), 2039);
+    assert_eq!(request.ta_renew_time.unwrap().year(), 2026);
+    assert_eq!(request.renew_times[0].1.year(), 2039);
 
     eprintln!(">>>> Sign TA proxy signer request.");
     let response = signer.process(request.into(), None).unwrap();


### PR DESCRIPTION
Result with a child request:
```
$ krillta proxy signer make-request
-------------------------------
nonce: 2a04a5c2-74e0-4316-9d18-786c5fe0e64b
-------------------------------

There is one child request

-------------------------------
          child request
-------------------------------
child:         online
entitlements:  asn: 'AS0-AS4294967295', ipv4: '0.0.0.0/0', ipv6: '::/0'
key:           F038768DAD7A1CF068D28B32CDDF9525BDCF410F    (re-)issue


NOTE: Use the JSON output for the signer.
```

Result without a child request:
```
$ krillta proxy signer make-request
-------------------------------
nonce: 18da5ef5-20d2-4167-93a1-435ba475f29f
-------------------------------

There are no child requests

Certificates will be reissued 80 weeks before expiry.
The current certificate expires on 2039-12-05T12:47:15+00:00.
The certificate is eligible for renewal on 2038-05-24T12:47:15+00:00.

NOTE: Use the JSON output for the signer.
```