### PR TITLE
Ignore .locks scope when upgrading stores.

### DIFF
--- a/src/upgrades/data_migration.rs
+++ b/src/upgrades/data_migration.rs
@@ -220,7 +220,15 @@ fn copy_data_for_migration(
         if !source_kv_store.is_empty()? {
             let target_kv_store =
                 KeyValueStore::create(target_storage, namespace)?;
-            target_kv_store.import(&source_kv_store)?;
+            target_kv_store.import(
+                &source_kv_store,
+                |scope| {
+                    match scope.first_segment() {
+                        Some(segment) => segment.as_str() != ".locks",
+                        None => true
+                    }
+                }
+            )?;
         }
     }
 

--- a/src/upgrades/mod.rs
+++ b/src/upgrades/mod.rs
@@ -396,6 +396,13 @@ pub trait UpgradeAggregateStorePre0_14 {
                 continue;
             }
 
+            // Skip a scope [`.locks`]. This is the old locks directory.
+            if let Some(segment) = scope.first_segment() {
+                if segment.as_str() == ".locks" {
+                    continue
+                }
+            }
+
             // Getting the Handle should never fail, but if it does then we
             // should bail out asap.
             let handle =


### PR DESCRIPTION
This PR skips any scope with `.locks` as its first segment when upgrading any stores. This is an artifact of moving the lock directory from the top level of each store to the top level of the storage space.