### PR TITLE
Initialize properties store to distinguish 0.14 from 0.15.

### DIFF
--- a/src/daemon/start.rs
+++ b/src/daemon/start.rs
@@ -11,6 +11,7 @@ use tokio::sync::oneshot;
 use tokio_rustls::TlsAcceptor;
 use crate::commons::file;
 use crate::commons::error::Error;
+use crate::commons::version::KrillVersion;
 use crate::config::Config;
 use crate::constants::KRILL_ENV_UPGRADE_ONLY;
 use crate::server::properties::PropertiesManager;
@@ -72,6 +73,11 @@ pub async fn start_krill_daemon(
                 e
             ))
         })?;
+    }
+
+    // Added in 0.15.0: Initialize the property manager if it isn’t yet.
+    if !properties_manager.is_initialized() {
+        properties_manager.init(KrillVersion::code_version())?;
     }
 
     // Create the Krill manager, this will create the necessary data


### PR DESCRIPTION
This PR adds a step to the start of the Krill daemon that initializes the property store with the current version if it hasn’t been initialized earlier. It also assumes that an uninitialized property store with no per-store version information indicates that the data is from version 0.14.0 and migrates the stores lock directories accordingly. 