### PR TITLE
Fix Clippy not found in CI error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Install Rust
-      uses: hecrj/setup-rust-action@v1
+      uses: hecrj/setup-rust-action@v2
       with:
         rust-version: ${{ matrix.rust }}
     - if: matrix.rust == 'stable' && matrix.args == '--all-features'


### PR DESCRIPTION
<img width="2108" height="623" alt="image" src="https://github.com/user-attachments/assets/b8d94edb-caa4-4564-8670-da67b7df7bdb" />
