### PR TITLE
Be more flexible on `relations` existing in the bgp-api JSON

### DIFF
--- a/src/server/bgp.rs
+++ b/src/server/bgp.rs
@@ -1056,7 +1056,7 @@ mod test {
             true, "test".to_string(), Duration::default()
         );
 
-        let ipv4s = "1.1.1.1/32, 2.2.2.2/32, 3.3.3.3/32, 4.4.4.4/32";
+        let ipv4s = "1.1.1.1/32, 3.3.3.3/32, 4.4.4.4/32";
         let set = ResourceSet::from_strs("", ipv4s, "").unwrap();
         
         let ranges = IpRange::from_resource_set(&set);

--- a/test-resources/bgp/bgp-api.json
+++ b/test-resources/bgp/bgp-api.json
@@ -455,16 +455,6 @@
       }
    },
    "test/api/v1/prefix/1.1.1.1/32/search": "",
-   "test/api/v1/prefix/2.2.2.2/32/search": {
-      "type": "longest-match",
-      "prefix": "0.0.0.0/0",
-      "result": {
-         "prefix": null,
-         "type": "empty-match",
-         "meta": [],
-         "members": []
-      }
-   },
    "test/api/v1/prefix/3.3.3.3/32/search": {
       "type": "longest-match",
       "prefix": "3.3.3.3/32",


### PR DESCRIPTION
This resolves an issue mentioned on [Discord](https://discord.com/channels/818584154278199396/818587059073318912/1423115914005582025) where it would return no announcement info even though there is announcement info (but it is available, but there is no information about its relations).