### PR TITLE
Make Krill not panic on startup

### DIFF
--- a/src/daemon/start.rs
+++ b/src/daemon/start.rs
@@ -234,14 +234,6 @@ fn single_http_listener(
             "Failed to configure TCP socket '{addr}': {err}"
         )));
     }
-    let listener = match TokioTcpListener::from_std(listener) {
-        Ok(listener) => listener,
-        Err(err) => {
-            return Err(Error::Custom(format!(
-                "Failed to prepare TCP socket '{addr}': {err}"
-            )));
-        }
-    };
 
     let tls = if server.config().https_mode().is_disable_https() {
         None
@@ -271,6 +263,15 @@ fn single_http_listener(
 
     join.spawn_on(
         async move {
+            let listener = match TokioTcpListener::from_std(listener) {
+                Ok(listener) => listener,
+                Err(err) => {
+                    error!(
+                        "Failed to prepare TCP socket '{addr}': {err}"
+                    );
+                    return;
+                }
+            };
             loop {
                 // Break here already if `signal_exit` is true.
                 if *signal_exit.borrow_and_update() {
@@ -388,15 +389,6 @@ fn single_unix_listener(
             path.display(), err,
         )));
     }
-    let listener = match TokioUnixListener::from_std(listener) {
-        Ok(listener) => listener,
-        Err(err) => {
-            return Err(Error::Custom(format!(
-                "Failed to prepare Unix socket '{}': {}",
-                path.display(), err,
-            )));
-        }
-    };
 
     let conn_builder = conn::auto::Builder::new(TokioExecutor::new());
     let graceful = GracefulShutdown::new();
@@ -410,6 +402,16 @@ fn single_unix_listener(
 
     join.spawn_on(
         async move {
+            let listener = match TokioUnixListener::from_std(listener) {
+                Ok(listener) => listener,
+                Err(err) => {
+                    error!(
+                        "Failed to prepare Unix socket '{}': {}",
+                        path.display(), err,
+                    );
+                    return;
+                }
+            };
             loop {
                 // Break here already if `signal_exit` is true.
                 if *signal_exit.borrow_and_update() {


### PR DESCRIPTION
Previously:

```
(.venv) koen@beta:~/Code/krill/target/debug$ ./krill -c krill.conf 
2026-04-07 15:37:49 [INFO] [krill::config] Krill uses configuration file: krill.conf
2026-04-07 15:37:49 [INFO] [krill::daemon::start] Starting Krill v0.17.0-dev
2026-04-07 15:37:49 [DEBUG] [krill::upgrades] Signers were set up before. No need to migrate keys.
2026-04-07 15:37:49 [INFO] [krill::server::runtime] Created thread pool with 20 threads
2026-04-07 15:37:49 [INFO] [krill::server::runtime] Krill uses service uri: https://localhost:3000/
2026-04-07 15:37:49 [INFO] [krill::commons::crypto::signing::dispatch::krillsigner] Configuring signer 'Default OpenSSL signer' (type: OpenSSL, default: true, one_off: true)
2026-04-07 15:37:57 [DEBUG] [krill::server::mq] add task: queue_start_tasks with priority: 2026-04-07T13:37:57+00:00

thread 'main' (139920) panicked at src/daemon/start.rs:237:26:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```