### PR TITLE
Link to RPKI docs from the Krill docs landing page.

### DIFF
--- a/doc/manual/source/index.rst
+++ b/doc/manual/source/index.rst
@@ -3,7 +3,7 @@
 Krill |version|
 ===============
 
-Krill is a free, open source Resource Public Key Infrastructure (RPKI)
+Krill is a free, open source Resource Public Key Infrastructure (`RPKI <https://rpki.readthedocs.io/>`_)
 daemon, featuring a Certificate Authority (CA) and publication server,
 written by `NLnet Labs <https://nlnetlabs.nl>`_.
 


### PR DESCRIPTION
While it's unlikely that anyone reading the [Krill docs](https://krill.docs.nlnetlabs.nl/) is unaware of what RPKI is, they may not have read the [RPKI docs](https://rpki.readthedocs.io/) that we also maintain and may find them useful, or may just want a refresher, or may have been sent to the Krill docs having no idea what RPKI is.

This PR links right from the start of the documentation at the first mention of RPKI to the [RPKI docs](https://rpki.readthedocs.io/). I was surprised to find that as you read through the docs from the beginning that no such link exists, and even though I am familiar with RPKI I wanted to check some things in those docs and was looking for a link.

Maybe we should even add a link on the left under `REFERENCE` to the RPKI docs?