### PR TITLE
Actually say what a test bed is.

### DIFF
--- a/doc/manual/source/testbed.rst
+++ b/doc/manual/source/testbed.rst
@@ -8,7 +8,7 @@ Running a Krill Test Bed
    You do not need to run your own Krill Test Bed if you just want to
    try out Krill. You can simply install Krill on a test machine and
    set it up under the public Krill based RPKI testbed that NLnet Labs
-   runs here: https://testbed.krill.cloud/index.html#/testbed
+   runs here: https://testbed.krill.cloud/
 
 According to the Oxford English dictionary a test bed is _`"a piece of equipment used for testing new machines" <https://www.oxfordlearnersdictionaries.com/definition/english/test-bed>`_.
 

--- a/doc/manual/source/testbed.rst
+++ b/doc/manual/source/testbed.rst
@@ -10,7 +10,7 @@ Running a Krill Test Bed
    set it up under the public Krill based RPKI testbed that NLnet Labs
    runs here: https://testbed.krill.cloud/
 
-According to the Oxford English dictionary a test bed is _`"a piece of equipment used for testing new machines" <https://www.oxfordlearnersdictionaries.com/definition/english/test-bed>`_.
+According to the Oxford English dictionary a test bed is *`"a piece of equipment used for testing new machines" <https://www.oxfordlearnersdictionaries.com/definition/english/test-bed>`_*.
 
 Most importantly an RPKI test bed acts as a fake root of an RPKI hierarchy,
 an alternative to the real RPKI hierarchy that allows you to test your use

--- a/doc/manual/source/testbed.rst
+++ b/doc/manual/source/testbed.rst
@@ -1,22 +1,40 @@
 .. _doc_krill_testbed:
 
-Running a Krill Test Environment
-================================
+Running a Krill Test Bed
+========================
 
-You do not need to run your own Krill Test Environment if you just want to
-try out Krill. You can simply install Krill on a test machine and set it
-up under the public Krill based RPKI testbed that NLnet Labs runs here:
-https://testbed.krill.cloud/index.html#/testbed
+.. tip::
+
+   You do not need to run your own Krill Test Bed if you just want to
+   try out Krill. You can simply install Krill on a test machine and
+   set it up under the public Krill based RPKI testbed that NLnet Labs
+   runs here: https://testbed.krill.cloud/index.html#/testbed
+
+According to the Oxford English dictionary a test bed is _`"a piece of equipment used for testing new machines" <https://www.oxfordlearnersdictionaries.com/definition/english/test-bed>`_.
+
+Most importantly an RPKI test bed acts as a fake root of an RPKI hierarchy,
+an alternative to the real RPKI hierarchy that allows you to test your use
+of RPKI software, whether relying party or child certificate authority,
+without actually interacting with the real global RPKI hierarchy, i.e. it's
+a safe space to play.
+
+Test Bed mode allows Krill to operate as such a fake root. In order to be
+actually useful it also offers additional services similar to those provided
+by the RIRs in their RPKI service offerings, including:
+
+  - A Trust Anchor including serving a corresponding Trust Anchor Locator.
+  - A root level RPKI Certificate Authority (CA) in the RPKI hierarchy (immediately under the TA).
+  - A publication server for storing objects published under the CA.
+  - A public web interface for 3rd parties to register their CA as a child of this root CA.
 
 Read more about this in our `blog <https://blog.nlnetlabs.nl/testing-the-waters-with-krill/>`_.
 
-But of course, you are perfectly welcome to run your own Test environment
-as well. That way you have total control over your test environment. This
-may be particularly useful for training purposes, and for testing code integration
-using the API or the RFC 8181 Publication Protocol or RFC 6492 Provisioning
-Protocol.
+By running a Krill Test Bed you have total control over your test environment as
+your test objects . This may be particularly useful for training purposes, and for
+testing code integration using the API or the :RFC:8181 Publication Protocol or
+:RFC:6492 Provisioning Protocol.
 
-Here we will document how we set up a simple testbed. This is not a strict guide.
+This page documents how to set up such a testbed. This is not a strict guide.
 You may want to do things differently and that would be fine, but we hope that
 this provides a useful walkthrough.
 


### PR DESCRIPTION
Update the test bed documentation to actually say what a test bed is in high level terms before diving in to the technical details. I made this PR because when I went to read the test bed documentation I felt that it didn't actually tell me early enough what it is about but rather dives straight into technical details, and I missed a higher level introduction to what a test bed actually is.

I also replaced references to Test Environment as I feel that term is misleading. The page describes how to run a test bed which is not required to setup a test environment that includes Krill, you can run Krill safely as the docs say by using it with a public test bed such as we offer or equivalent test modes offered by RIRs (which I assume exist but don't recall if that's really the case, and thus didn't mention in my doc update)

This PR also fixes the link to the public test bed as I discovered it results in a HTTP 404 error!

As I've been busy with DNS for a while and not with RPKI, please check that I haven't said anything factually incorrect in this PR.