### PR TITLE
Remove old Debian versions from packaging

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   package:
     # See: https://github.com/NLnetLabs/ploutos
-    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v9
+    uses: NLnetLabs/ploutos/.github/workflows/pkg-rust.yml@v10
     secrets:
       DOCKER_HUB_ID: ${{ secrets.DOCKER_HUB_ID }}
       DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,13 +256,6 @@ depends = "$auto, passwd, libssl3"
 [package.metadata.deb.variants.ubuntu-resolute]
 depends = "$auto, passwd, libssl3"
 
-# Cross compilation variants:
-# Note: we have to specifiy dependencies manually because we don't run cargo-deb
-# on the target platform and so it cannot determine the dependencies correctly
-# for us.
-[package.metadata.deb.variants.debian-bullseye-armv7-unknown-linux-gnueabihf]
-depends = "adduser, passwd, libc6 (>= 2.28), libssl1.1"
-
 # END DEBIAN PACKAGING
 # ------------------------------------------------------------------------------
 

--- a/doc/manual/source/install-and-run.rst
+++ b/doc/manual/source/install-and-run.rst
@@ -29,11 +29,9 @@ public rsyncd and HTTPS web server available.
 
          -  Debian Trixie 13
          -  Debian Bookworm 12
-         -  Debian Bullseye 11
 
        Packages for the ``amd64``/``x86_64`` architecture are available for
-       all listed versions. In addition, we offer ``armhf`` architecture
-       packages for Debian/Raspbian Bullseye.
+       all listed versions. 
 
        First update the ``apt`` package index:
 

--- a/pkg/rules/packages-to-build.yml
+++ b/pkg/rules/packages-to-build.yml
@@ -8,7 +8,6 @@ image:
   - "ubuntu:jammy" # ubuntu/22.04
   - "ubuntu:noble" # ubuntu/24.04
   - "ubuntu:resolute" # ubuntu/26.04
-  - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12
   - "debian:trixie" # debian/13
   - "almalinux:8" # compatible with EOL centos:8
@@ -41,18 +40,3 @@ include:
   - image: "almalinux:10"
     rpm_systemd_service_unit_file: "pkg/common/krill-ubuntu-focal.krill.service"
     rpm_rpmlint_check_filters: 
-
-  - image: "debian:bullseye"
-    deb_extra_lintian_args: "--suppress-tags systemd-service-file-outside-lib"
-
-  # package for the Raspberry Pi 4b as an ARMv7 cross compiled variant of the Debian Bullseye upon which
-  # Raspbian 11 is based.
-  - pkg: "krill"
-    image: "debian:bullseye"
-    target: "armv7-unknown-linux-gnueabihf"
-    deb_extra_lintian_args: "--suppress-tags systemd-service-file-outside-lib"
-  - pkg: "krillup"
-    image: "debian:bullseye"
-    target: "armv7-unknown-linux-gnueabihf"
-    deb_extra_lintian_args: "--suppress-tags systemd-service-file-outside-lib"
-

--- a/pkg/rules/packages-to-test.yml
+++ b/pkg/rules/packages-to-test.yml
@@ -8,7 +8,6 @@ image:
   - "ubuntu:jammy" # ubuntu/22.04
   - "ubuntu:noble" # ubuntu/24.04
   - "ubuntu:resolute" # ubuntu/26.04
-  - "debian:bullseye" # debian/11
   - "debian:bookworm" # debian/12
   - "debian:trixie" # debian/13
   - "almalinux:8" # compatible with EOL centos:8
@@ -38,15 +37,6 @@ include:
 
   - image: "almalinux:9"
     rpm_systemd_service_unit_file: "pkg/common/krill-ubuntu-focal.krill.service"
-
-  # package for the Raspberry Pi 4b as an ARMv7 cross compiled variant of the Debian Bullseye upon which
-  # Raspbian 11 is based.
-  - pkg: "krill"
-    image: "debian:bullseye"
-    target: "armv7-unknown-linux-gnueabihf"
-  - pkg: "krillup"
-    image: "debian:bullseye"
-    target: "armv7-unknown-linux-gnueabihf"
 
 # Exclude upgrade testing on Ubuntu Resolute as no prior released versions exist to upgrade from.
 exclude:


### PR DESCRIPTION
This removes Debian Bullseye from packaging, as well as updates Ploutos to v10. 

This also means no more prebuilt ARM packages.

CI run: https://github.com/NLnetLabs/krill/actions/runs/34219338957